### PR TITLE
Fix an infinite loop in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,14 +194,14 @@ cav:
 	dijkstra/verif_dijkstra1.vo dijkstra/verif_dijkstra2.vo dijkstra/verif_dijkstra3.vo \
 	kruskal/verif_sort.v kruskal/verif_kruskal_edgelist.vo -kj7
 
-.depend depend: rename
+depend: rename
 	@echo 'coqdep ... >.depend'
 	@$(COQDEP) $(NORMAL_FLAG) $(NORMAL_FILES) > .depend
 	@$(COQDEP) $(CLIGHT_FLAG) $(CLIGHT_FILES) >> .depend
 
 clean:
-	@rm */*.vo */*.glob */.*.aux .depend
+	@rm -f */*.vo */*.glob */.*.aux .depend
 
 .DEFAULT_GOAL := all
 
-include .depend 
+-include .depend 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
         > COMPCERT_DIR=../VST/compcert  
 	  VST_DIR=../VST
 	1. `make clean`
+	1. `make depend`
 	1. `make -jn`, where `n` is the number of cores you want to dedicate
 
 1. Developing Inside CertiGraph (requires that you have clightgen)


### PR DESCRIPTION
# Background

* `Makefile` imports a file called `.depend`.
* `.depend` is generated by `Makefile`.
* To achieve this, `Makefile` contains a rule with `.depend` as a target.

# Problem

On some machines this causes `make` to incorrectly run the `.depend` rule several times in a row.

[This issue has been encountered by other projects](https://stackoverflow.com/a/66312163).

In particular, it seems to be caused by a race condition related to the timestamp for `.depend`.

# Fix

This PR provides a quick fix that simply removes `.depend` as a target.

It also addresses 2 other issues:
* `make clean` produces error messages if there's nothing to clean. This is a low-priority issue. This PR resolves this by introducing the `-f` flag.
* `make` cannot process `Makefile` unless `.depend` already exists. This issue blocks the build but has an easy fix. This PR resolves this by replacing `include .depend` with `-include .depend`. (The former causes `make` to exit if `.depend` does not exist, while the latter allows `make` to continue. See https://www.gnu.org/software/make/manual/html_node/Include.html)

# Impact

As it stands today, the build procedure is
```console
$ make clean
$ make
```

With this change, the build procedure becomes
```console
$ make clean
$ make depend
$ make
```

This PR updates `README.md` with these new instructions.
