### PR TITLE
Replace invalid no_backward_edge invariant for mutable GC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ syntax: glob
 .Makefile.coq.d
 .\#*
 .CoqMakefile.d
+.generated_files.postprocessed
 .lia.cache
 .nia.cache
 .vscode

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -2751,15 +2751,6 @@ Proof.
   rewrite lmc_vertex_address, lacv_vertex_address; [reflexivity | assumption..].
 Qed.
 
-Lemma lcv_vertex_address_new: forall g v to,
-    graph_has_gen g to ->
-    vertex_address (lgraph_copy_v g v to) (new_copied_v g to) =
-    vertex_address g (new_copied_v g to).
-Proof.
-  intros.
-  apply lcv_vertex_address;  [| red; simpl; split]; [assumption..| apply Nat.le_refl].
-Qed.
-
 Lemma lcv_vertex_address_old: forall g v to x,
     graph_has_gen g to -> graph_has_v g x ->
     vertex_address (lgraph_copy_v g v to) x = vertex_address g x.
@@ -2800,19 +2791,6 @@ Proof.
   intros. unfold rootpairs_compatible in *.
   rewrite <- upd_Znth_map, H, update_rootpairs_upd_Znth, <- upd_Znth_map.
   simpl. reflexivity.
-Qed.
-
-Lemma upd_rootpairs_compatible: forall g rootpairs roots z,
-    rootpairs_compatible g rootpairs roots ->
-    forall (v : VType) (HB : 0 <= z < Zlength roots),
-      rootpairs_compatible g
-      (update_rootpairs rootpairs
-            (upd_Znth z (map rp_val rootpairs) (vertex_address g v)))
-       (upd_Znth z roots (ExteriorVertex v)).
-Proof.
-  intros. hnf in H. rewrite <- H.
-  change (vertex_address g v) with (exterior2val g (ExteriorVertex v)).
-  rewrite upd_Znth_map. apply upd_rootpairs_compatible'. apply H.
 Qed.
 
 #[export] Instance share_inhabitant: Inhabitant share := emptyshare.
@@ -3978,14 +3956,6 @@ Definition nth_gen_size_spec (h: part_heap) (n: nat): Prop :=
 Definition ti_size_spec (h: part_heap): Prop :=
   Forall (nth_gen_size_spec h) (nat_inc_list (Z.to_nat MAX_SPACES)).
 
-(* old one *)
-(*
-Definition do_generation_condition g t_info (*roots*) from to: Prop :=
-  enough_space_to_have_g g t_info from to /\ graph_has_gen g from /\
-  graph_has_gen g to /\ copy_compatible g /\ no_dangling_dst g /\
-  0 < available_size t_info to /\ gen_unmarked g to.
- *)
-
 Definition do_generation_condition g h from to: Prop :=
   enough_space_enhanced g h from to /\ graph_has_gen g from /\
   graph_has_gen g to /\ copy_compatible g /\ no_dangling_dst g /\
@@ -4430,14 +4400,6 @@ Lemma graph_has_e_reset: forall g gen e,
 Proof.
   intros. unfold graph_has_e, egeneration. destruct e as [v idx]. simpl.
   rewrite graph_has_v_reset, get_edges_reset. intuition auto.
-Qed.
-
-Lemma gen2gen_no_edge_reset: forall g gen1 gen2 gen3,
-    gen2gen_no_edge g gen2 gen3 ->
-    gen2gen_no_edge (reset_graph gen1 g) gen2 gen3.
-Proof.
-  intros. unfold gen2gen_no_edge. intros. simpl. rewrite remove_ve_dst_unchanged.
-  apply H. rewrite graph_has_e_reset in H0. destruct H0. assumption.
 Qed.
 
 Lemma fr_O_dst_unchanged_root: forall from to r g g',
@@ -10069,74 +10031,6 @@ Proof.
   eapply rrhc_forall_rrsc; exact Hrrhc.
 Qed.
 
-Lemma fr_O_prefix_no_edge2gen_old_to:
-  forall from to p g g' bound,
-    graph_has_gen g to -> from <> to -> copy_compatible g -> no_dangling_dst g ->
-    forward_t_compatible p g ->
-    forward_relation from to O p g g' ->
-    (bound <= gen_v_num g to)%nat ->
-    (forall (vidx eidx: nat),
-        (vidx < bound)%nat ->
-        graph_has_e g (to, vidx, eidx) ->
-        vgeneration (dst g (to, vidx, eidx)) <> from) ->
-    forall (vidx eidx: nat),
-      (vidx < bound)%nat ->
-      graph_has_e g' (to, vidx, eidx) ->
-      vgeneration (dst g' (to, vidx, eidx)) <> from.
-Proof.
-  intros from to p g g' bound Hto Hneq Hcc Hndd Hftc Hfr
-         Hbound Hprefix vidx eidx Hvidx He.
-  destruct p as [z | out | v | e]; inversion Hfr; subst; simpl in *.
-  all: try solve [eapply Hprefix; eauto].
-  1: (assert (Hsrc: graph_has_v g (to, vidx)) by
-        (destruct He as [Hsrc_new _];
-         apply lcv_graph_has_v_inv in Hsrc_new;
-         [destruct Hsrc_new as [Hsrc_old | Hnew]; [exact Hsrc_old |]
-         | exact Hto];
-         unfold new_copied_v in Hnew; inversion Hnew; subst vidx;
-         unfold gen_v_num in Hbound; lia);
-      rewrite pcv_dst_old;
-      [ eapply Hprefix; [exact Hvidx |];
-        destruct He as [_ He]; split; simpl; [exact Hsrc |];
-        unfold get_edges, make_fields in He |- *;
-        rewrite (lcv_raw_fields g v to (to, vidx) Hto Hsrc); exact He
-      | unfold new_copied_v; intro Hbad; inversion Hbad; subst vidx;
-        unfold gen_v_num in Hbound; lia ]).
-  1: (destruct (E_EqDec e (to, vidx, eidx)) as [Heq | Hne];
-      [ hnf in Heq; subst e; unfold updateEdgeFunc; rewrite if_true by reflexivity;
-        destruct Hftc as [Hsrc_e Hin_e];
-        pose proof (Hndd _ Hsrc_e _ Hin_e) as Hdst;
-        specialize (Hcc _ Hdst H2) as [_ Hgen];
-        intro Hbad; apply Hgen; symmetry; exact Hbad
-      | unfold updateEdgeFunc; rewrite if_false by (intro Hbad; apply Hne; hnf; exact Hbad);
-        eapply Hprefix; [exact Hvidx |];
-        destruct He as [Hsrc_new Hin_new]; split; simpl;
-        [exact Hsrc_new | exact Hin_new] ]).
-  1: (destruct (E_EqDec e (to, vidx, eidx)) as [Heq | Hne];
-      [ hnf in Heq; subst e; unfold updateEdgeFunc; rewrite if_true by reflexivity;
-        unfold new_copied_v; simpl; intro Hbad; apply Hneq; symmetry; exact Hbad
-      | unfold updateEdgeFunc; rewrite if_false by (intro Hbad; apply Hne; hnf; exact Hbad);
-        rewrite pcv_dst_old;
-        [ eapply Hprefix; [exact Hvidx |];
-          destruct He as [Hsrc_new Hin_new];
-          change (graph_has_v (lgraph_copy_v g (dst g e) to) (to, vidx)) in Hsrc_new;
-          pose proof (lcv_graph_has_v_inv g (dst g e) to (to, vidx) Hto Hsrc_new)
-            as Hsrc_inv;
-          destruct Hsrc_inv as [Hsrc_old | Hnew];
-          [ split; simpl; [exact Hsrc_old |];
-            unfold get_edges, make_fields in Hin_new |- *;
-            change (In (to, vidx, eidx)
-                       (filter_proj field_proj_edge
-                          (make_fields (lgraph_copy_v g (dst g e) to) (to, vidx))))
-              in Hin_new;
-            rewrite (lcv_raw_fields g (dst g e) to (to, vidx) Hto Hsrc_old);
-            exact Hin_new
-          | unfold new_copied_v in Hnew; inversion Hnew; subst vidx;
-            unfold gen_v_num in Hbound; lia ]
-        | unfold new_copied_v; intro Hbad; inversion Hbad; subst vidx;
-          unfold gen_v_num in Hbound; lia ] ]).
-Qed.
-
 Lemma forward_remset_item_gen_v_num_to:
   forall from to g h rh rmst item g' h' rh' rmst',
     graph_has_gen g to ->
@@ -10470,40 +10364,6 @@ Proof.
            rewrite Hdst2_eq. exact Hdst.
 Qed.
 
-Lemma forward_remset_gh_recorded_old_edge_dst_to:
-  forall from to bound g h rh rmst g' h' rh' rmst' outlier v n,
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_compatible g outlier from rmst rh h ->
-    copied_to_compatible from to g ->
-    graph_has_e g (v, n) ->
-    vgeneration v <> from ->
-    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
-    (bound <= gen_v_num g to)%nat ->
-    vgeneration (dst g (v, n)) = from ->
-    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n)))
-       (nth_remset_space rh from) ->
-    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
-    graph_has_e g' (v, n) ->
-    vgeneration (dst g' (v, n)) = to.
-Proof.
-  intros from to bound g h rh rmst g' h' rh' rmst' outlier v n
-         Hneq Hto Hcc Hndd Hrnd Hremc Hct He Hsrc Hold Hbound Hdst Hin Hfrg Hefinal.
-  destruct Hremc as [Hrgoc [Hrrhc _]].
-  assert (Hrgc: remset_graph_compatible g rmst) by
-      (eapply remset_graph_outlier_compatible_weakened; exact Hrgoc).
-  assert (Hrrsc:
-            remset_and_remset_space_compatible g from rmst
-              (Znth (Z.of_nat from) rh)) by
-      (eapply rrhc_forall_rrsc; exact Hrrhc).
-  unfold forward_remset_gh in Hfrg.
-  rewrite nth_remset_space_Znth in Hin.
-  eapply forward_remset_item_fold_recorded_old_edge_dst_to; eauto.
-Qed.
-
 Lemma forward_remset_item_fold_old_edge_dst_not_from_pres:
   forall from to bound r g h rh rmst g' h' rh' rmst' v n,
     graph_has_gen g to ->
@@ -10620,110 +10480,6 @@ Proof.
       eauto.
 Qed.
 
-Lemma forward_remset_item_prefix_no_edge2gen_old_to:
-  forall from to g h rh rmst item g' h' rh' rmst' bound,
-    graph_has_gen g to -> from <> to -> copy_compatible g -> no_dangling_dst g ->
-    remset_graph_compatible g rmst ->
-    remset_item_compatible g from rmst item ->
-    (bound <= gen_v_num g to)%nat ->
-    (forall (vidx eidx: nat),
-        (vidx < bound)%nat ->
-        graph_has_e g (to, vidx, eidx) ->
-        vgeneration (dst g (to, vidx, eidx)) <> from) ->
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    forall (vidx eidx: nat),
-      (vidx < bound)%nat ->
-      graph_has_e g' (to, vidx, eidx) ->
-      vgeneration (dst g' (to, vidx, eidx)) <> from.
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' bound
-         Hto Hneq Hcc Hndd Hrc Hric Hbound Hprefix Hfri.
-  unfold forward_remset_item in Hfri.
-  destruct (negb (remset_item_in_gen item rmst g from)).
-  - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
-    eapply fr_O_prefix_no_edge2gen_old_to; eauto.
-    eapply remset_item2forward_t_ftc; eassumption.
-  - inversion Hfri; subst. exact Hprefix.
-Qed.
-
-Lemma forward_remset_item_fold_prefix_no_edge2gen_old_to:
-  forall from to g h rh rmst r g' h' rh' rmst' bound,
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_graph_compatible g rmst ->
-    remset_and_remset_space_compatible g from rmst r ->
-    (bound <= gen_v_num g to)%nat ->
-    (forall (vidx eidx: nat),
-        (vidx < bound)%nat ->
-        graph_has_e g (to, vidx, eidx) ->
-        vgeneration (dst g (to, vidx, eidx)) <> from) ->
-    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
-    forall (vidx eidx: nat),
-      (vidx < bound)%nat ->
-      graph_has_e g' (to, vidx, eidx) ->
-      vgeneration (dst g' (to, vidx, eidx)) <> from.
-Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' bound
-                       Hneq Hto Hcc Hndd Hrnd Hrc Hrrsc Hbound Hprefix Hfold.
-  - simpl in Hfold. inversion Hfold; subst. exact Hprefix.
-  - simpl in Hfold. hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
-    destruct Hrrsc as [Hrica Hricr].
-    destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    symmetry in Hfri2.
-    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
-    rewrite <- Hfri2 in Hfold.
-    destruct (forward_remset_item_step_bound_facts
-                from to bound g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hndd Hrnd Hrc Hrica Hricr Hbound Hfri2)
-      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrc2 [Hricr2 Hbound2]]]]]].
-    assert (Hprefix2: forall vidx eidx : nat,
-               (vidx < bound)%nat ->
-               graph_has_e g2 (to, vidx, eidx) ->
-               vgeneration (dst g2 (to, vidx, eidx)) <> from) by
-        exact (forward_remset_item_prefix_no_edge2gen_old_to
-                 from to g h rh rmst a g2 h2 rh2 rmst2 bound
-                 Hto Hneq Hcc Hndd Hrc Hrica Hbound Hprefix Hfri2).
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' bound); eauto.
-Qed.
-
-Lemma forward_remset_gh_prefix_no_edge2gen_old_to:
-  forall from to g h rh rmst g' h' rh' rmst' outlier bound,
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_compatible g outlier from rmst rh h ->
-    (bound <= gen_v_num g to)%nat ->
-    (forall (vidx eidx: nat),
-        (vidx < bound)%nat ->
-        graph_has_e g (to, vidx, eidx) ->
-        vgeneration (dst g (to, vidx, eidx)) <> from) ->
-    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
-    forall (vidx eidx: nat),
-      (vidx < bound)%nat ->
-      graph_has_e g' (to, vidx, eidx) ->
-      vgeneration (dst g' (to, vidx, eidx)) <> from.
-Proof.
-  intros from to g h rh rmst g' h' rh' rmst' outlier bound
-         Hneq Hto Hcc Hndd Hrnd Hremc Hbound Hprefix Hfrg.
-  destruct Hremc as [Hrgoc [Hrrhc _]].
-  assert (Hrc: remset_graph_compatible g rmst) by
-      (eapply remset_graph_outlier_compatible_weakened; eassumption).
-  unfold forward_remset_gh in Hfrg.
-  eapply forward_remset_item_fold_prefix_no_edge2gen_old_to; eauto.
-  eapply rrhc_forall_rrsc; exact Hrrhc.
-Qed.
-
 Lemma frr_prefix_no_edge2gen_old_to:
   forall from to roots roots' g g' bound,
     graph_has_gen g to ->
@@ -10807,144 +10563,6 @@ Proof.
                   Hto Hneq Hun Hscan another from Hneq_to
                   (Hother another Hanother Hneq_to)) as Hpres.
     exact Hpres.
-Qed.
-
-Lemma fr_O_gen2gen_no_edge2from_not_to:
-  forall from to p g g' gen1,
-    graph_has_gen g to -> from <> to -> copy_compatible g -> no_dangling_dst g ->
-    forward_t_compatible p g ->
-    forward_relation from to O p g g' ->
-    gen1 <> to ->
-    gen2gen_no_edge g gen1 from ->
-    gen2gen_no_edge g' gen1 from.
-Proof.
-  intros from to p g g' gen1 Hto Hneq Hcc Hndd Hftc Hfr Hgen1 Hno.
-  unfold gen2gen_no_edge in *. intros vidx eidx He.
-  destruct p as [z | out | v | e]; inversion Hfr; subst; simpl in *;
-    try solve [apply Hno; exact He].
-  1: (assert (Hsrc: graph_has_v g (gen1, vidx)) by
-        (destruct He as [Hsrc_new _];
-         apply lcv_graph_has_v_inv in Hsrc_new;
-         [destruct Hsrc_new as [Hsrc_old | Hnew]; [exact Hsrc_old |]
-         | exact Hto];
-         unfold new_copied_v in Hnew; inversion Hnew; contradiction);
-      rewrite pcv_dst_old;
-      [ apply Hno; destruct He as [_ Hin]; split; simpl; [exact Hsrc |];
-        unfold get_edges, make_fields in Hin |- *;
-        rewrite (lcv_raw_fields g v to (gen1, vidx) Hto Hsrc); exact Hin
-      | unfold new_copied_v; intro Hbad; inversion Hbad; contradiction ]).
-  1: (destruct (E_EqDec e (gen1, vidx, eidx)) as [Heq | Hne];
-      [ hnf in Heq; subst e; unfold updateEdgeFunc; rewrite if_true by reflexivity;
-        destruct Hftc as [Hsrc_e Hin_e];
-        pose proof (Hndd _ Hsrc_e _ Hin_e) as Hdst;
-        specialize (Hcc _ Hdst H2) as [_ Hgen];
-        intro Hbad; apply Hgen; symmetry; exact Hbad
-      | unfold updateEdgeFunc; rewrite if_false by (intro Hbad; apply Hne; hnf; exact Hbad);
-        apply Hno; destruct He as [Hsrc_new Hin_new]; split; simpl;
-        [exact Hsrc_new | exact Hin_new] ]).
-  1: (destruct (E_EqDec e (gen1, vidx, eidx)) as [Heq | Hne];
-      [ hnf in Heq; subst e; unfold updateEdgeFunc; rewrite if_true by reflexivity;
-        unfold new_copied_v; simpl; intro Hbad; apply Hneq; symmetry; exact Hbad
-      | unfold updateEdgeFunc; rewrite if_false by (intro Hbad; apply Hne; hnf; exact Hbad);
-        rewrite pcv_dst_old;
-        [ apply Hno; destruct He as [Hsrc_new Hin_new];
-          change (graph_has_v (lgraph_copy_v g (dst g e) to) (gen1, vidx)) in Hsrc_new;
-          pose proof (lcv_graph_has_v_inv g (dst g e) to (gen1, vidx) Hto Hsrc_new)
-            as Hsrc_inv;
-          destruct Hsrc_inv as [Hsrc_old | Hnew];
-          [ split; simpl; [exact Hsrc_old |];
-            unfold get_edges, make_fields in Hin_new |- *;
-            change (In (gen1, vidx, eidx)
-                       (filter_proj field_proj_edge
-                          (make_fields (lgraph_copy_v g (dst g e) to) (gen1, vidx))))
-              in Hin_new;
-            rewrite (lcv_raw_fields g (dst g e) to (gen1, vidx) Hto Hsrc_old);
-            exact Hin_new
-          | unfold new_copied_v in Hnew; inversion Hnew; contradiction ]
-        | unfold new_copied_v; intro Hbad; inversion Hbad; contradiction ] ]).
-Qed.
-
-Lemma forward_remset_item_gen2gen_no_edge2from_not_to:
-  forall from to g h rh rmst item g' h' rh' rmst' gen1,
-    graph_has_gen g to -> from <> to -> copy_compatible g -> no_dangling_dst g ->
-    remset_graph_compatible g rmst ->
-    remset_item_compatible g from rmst item ->
-    gen1 <> to ->
-    gen2gen_no_edge g gen1 from ->
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    gen2gen_no_edge g' gen1 from.
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' gen1
-         Hto Hneq Hcc Hndd Hrc Hric Hgen1 Hno Hfri.
-  unfold forward_remset_item in Hfri.
-  destruct (negb (remset_item_in_gen item rmst g from)).
-  - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
-    eapply fr_O_gen2gen_no_edge2from_not_to; eauto.
-    eapply remset_item2forward_t_ftc; eassumption.
-  - inversion Hfri; subst. exact Hno.
-Qed.
-
-Lemma forward_remset_item_fold_gen2gen_no_edge2from_not_to:
-  forall from to g h rh rmst r g' h' rh' rmst' gen1,
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_graph_compatible g rmst ->
-    remset_and_remset_space_compatible g from rmst r ->
-    gen1 <> to ->
-    gen2gen_no_edge g gen1 from ->
-    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
-    gen2gen_no_edge g' gen1 from.
-Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' gen1
-                       Hneq Hto Hcc Hndd Hrnd Hrc Hrrsc Hgen1 Hno Hfold.
-  - simpl in Hfold. inversion Hfold; subst. exact Hno.
-  - simpl in Hfold. hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
-    destruct Hrrsc as [Hrica Hricr].
-    destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    symmetry in Hfri2.
-    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
-    rewrite <- Hfri2 in Hfold.
-    destruct (forward_remset_item_step_bound_facts
-                from to O g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hndd Hrnd Hrc Hrica Hricr ltac:(lia) Hfri2)
-      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrc2 [Hricr2 _]]]]]].
-    assert (Hno2: gen2gen_no_edge g2 gen1 from) by
-        exact (forward_remset_item_gen2gen_no_edge2from_not_to
-                 from to g h rh rmst a g2 h2 rh2 rmst2 gen1
-                 Hto Hneq Hcc Hndd Hrc Hrica Hgen1 Hno Hfri2).
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' gen1); eauto.
-Qed.
-
-Lemma forward_remset_gh_gen2gen_no_edge2from_not_to:
-  forall from to g h rh rmst g' h' rh' rmst' outlier gen1,
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_compatible g outlier from rmst rh h ->
-    gen1 <> to ->
-    gen2gen_no_edge g gen1 from ->
-    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
-    gen2gen_no_edge g' gen1 from.
-Proof.
-  intros from to g h rh rmst g' h' rh' rmst' outlier gen1
-         Hneq Hto Hcc Hndd Hrnd Hremc Hgen1 Hno Hfrg.
-  destruct Hremc as [Hrgoc [Hrrhc _]].
-  assert (Hrc: remset_graph_compatible g rmst) by
-      (eapply remset_graph_outlier_compatible_weakened; eassumption).
-  unfold forward_remset_gh in Hfrg.
-  eapply forward_remset_item_fold_gen2gen_no_edge2from_not_to; eauto.
-  eapply rrhc_forall_rrsc; exact Hrrhc.
 Qed.
 
 Lemma do_generation_relation_no_dangling_dst_unrecorded:
@@ -11378,155 +10996,6 @@ Proof.
   - apply gen_unmarked_reset_diff. apply Hunmarked2. assumption.
 Qed.
 
-Lemma fr_O_gen2gen_no_edge_gt_to_source:
-  forall from to p g g' gen1 gen2,
-    graph_has_gen g to -> from <> to -> copy_compatible g -> no_dangling_dst g ->
-    forward_t_compatible p g -> forward_relation from to O p g g' ->
-    (forall dst_gen, (dst_gen < gen1)%nat -> gen2gen_no_edge g gen1 dst_gen) ->
-    gen2gen_no_edge g gen1 from ->
-    (to < gen1)%nat -> (gen2 < gen1)%nat ->
-    gen2gen_no_edge g' gen1 gen2.
-Proof.
-  intros from to p g g' gen1 gen2 Hto Hneq Hcc Hndd Hftc Hfr Hnbe_src Hnofrom
-         Hgtto Hgt.
-  unfold gen2gen_no_edge in *. intros vidx eidx He.
-  destruct p as [z | out | v | e]; inversion Hfr; subst; simpl in *;
-    try solve [eapply Hnbe_src; eauto].
-  1: (assert (Hsrc: graph_has_v g (gen1, vidx)) by
-        (destruct He as [Hsrc_new _];
-         apply lcv_graph_has_v_inv in Hsrc_new;
-         [destruct Hsrc_new as [Hsrc_old | Hnew]; [exact Hsrc_old |]
-         | exact Hto];
-         unfold new_copied_v in Hnew; inversion Hnew; lia);
-      rewrite pcv_dst_old;
-      [ eapply Hnbe_src; [exact Hgt |]; destruct He as [_ Hin]; split; simpl; [exact Hsrc |];
-        unfold get_edges, make_fields in Hin |- *;
-        rewrite (lcv_raw_fields g v to (gen1, vidx) Hto Hsrc); exact Hin
-      | unfold new_copied_v; intro Hbad; inversion Hbad; lia ]).
-  1: (destruct (E_EqDec e (gen1, vidx, eidx)) as [Heq | Hne];
-      [ hnf in Heq; subst e; unfold updateEdgeFunc; rewrite if_true by reflexivity;
-        exfalso; apply Hnofrom with (vidx := vidx) (eidx := eidx);
-        [exact Hftc | reflexivity]
-      | unfold updateEdgeFunc; rewrite if_false by (intro Hbad; apply Hne; hnf; exact Hbad);
-        eapply Hnbe_src; [exact Hgt |]; destruct He as [Hsrc_new Hin_new]; split; simpl;
-        [exact Hsrc_new | exact Hin_new] ]).
-  1: (destruct (E_EqDec e (gen1, vidx, eidx)) as [Heq | Hne];
-      [ hnf in Heq; subst e; unfold updateEdgeFunc; rewrite if_true by reflexivity;
-        exfalso; apply Hnofrom with (vidx := vidx) (eidx := eidx);
-        [exact Hftc | reflexivity]
-      | unfold updateEdgeFunc; rewrite if_false by (intro Hbad; apply Hne; hnf; exact Hbad);
-        rewrite pcv_dst_old;
-        [ eapply Hnbe_src; [exact Hgt |]; destruct He as [Hsrc_new Hin_new];
-          change (graph_has_v (lgraph_copy_v g (dst g e) to) (gen1, vidx)) in Hsrc_new;
-          pose proof (lcv_graph_has_v_inv g (dst g e) to (gen1, vidx) Hto Hsrc_new)
-            as Hsrc_inv;
-          destruct Hsrc_inv as [Hsrc_old | Hnew];
-          [ split; simpl; [exact Hsrc_old |];
-            unfold get_edges, make_fields in Hin_new |- *;
-            change (In (gen1, vidx, eidx)
-                       (filter_proj field_proj_edge
-                          (make_fields (lgraph_copy_v g (dst g e) to) (gen1, vidx))))
-              in Hin_new;
-            rewrite (lcv_raw_fields g (dst g e) to (gen1, vidx) Hto Hsrc_old);
-            exact Hin_new
-          | unfold new_copied_v in Hnew; inversion Hnew; lia ]
-        | unfold new_copied_v; intro Hbad; inversion Hbad; lia ] ]).
-Qed.
-
-Lemma forward_remset_item_gen2gen_no_edge_gt_to_source:
-  forall from to g h rh rmst item g' h' rh' rmst' gen1 gen2,
-    graph_has_gen g to -> from <> to -> copy_compatible g -> no_dangling_dst g ->
-    remset_graph_compatible g rmst ->
-    remset_item_compatible g from rmst item ->
-    (forall dst_gen, (dst_gen < gen1)%nat -> gen2gen_no_edge g gen1 dst_gen) ->
-    gen2gen_no_edge g gen1 from ->
-    (to < gen1)%nat -> (gen2 < gen1)%nat ->
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    gen2gen_no_edge g' gen1 gen2.
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' gen1 gen2
-         Hto Hneq Hcc Hndd Hrc Hric Hnbe_src Hnofrom Hgtto Hgt Hfri.
-  unfold forward_remset_item in Hfri.
-  destruct (negb (remset_item_in_gen item rmst g from)).
-  - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
-    eapply fr_O_gen2gen_no_edge_gt_to_source; eauto.
-    eapply remset_item2forward_t_ftc; eassumption.
-  - inversion Hfri; subst.
-    exact (Hnbe_src gen2 Hgt).
-Qed.
-
-Lemma forward_remset_item_fold_gen2gen_no_edge_gt_to_source:
-  forall from to g h rh rmst r g' h' rh' rmst' gen1 gen2,
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_graph_compatible g rmst ->
-    remset_and_remset_space_compatible g from rmst r ->
-    (forall dst_gen, (dst_gen < gen1)%nat -> gen2gen_no_edge g gen1 dst_gen) ->
-    gen2gen_no_edge g gen1 from ->
-    (to < gen1)%nat -> (gen2 < gen1)%nat ->
-    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
-    gen2gen_no_edge g' gen1 gen2.
-Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' gen1 gen2
-                       Hneq Hto Hcc Hndd Hrnd Hrc Hrrsc Hnbe_src Hnofrom Hgtto Hgt Hfold.
-  - simpl in Hfold. inversion Hfold; subst. exact (Hnbe_src gen2 Hgt).
-  - simpl in Hfold. hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
-    destruct Hrrsc as [Hrica Hricr].
-    destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    symmetry in Hfri2.
-    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
-    rewrite <- Hfri2 in Hfold.
-    destruct (forward_remset_item_step_bound_facts
-                from to O g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hndd Hrnd Hrc Hrica Hricr ltac:(lia) Hfri2)
-      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrc2 [Hricr2 _]]]]]].
-    assert (Hnbe_src2: forall dst_gen : nat,
-               (dst_gen < gen1)%nat -> gen2gen_no_edge g2 gen1 dst_gen). {
-      intros dst_gen Hdst.
-      exact (forward_remset_item_gen2gen_no_edge_gt_to_source
-               from to g h rh rmst a g2 h2 rh2 rmst2 gen1 dst_gen
-               Hto Hneq Hcc Hndd Hrc Hrica Hnbe_src Hnofrom Hgtto Hdst Hfri2).
-    }
-    assert (Hnofrom2: gen2gen_no_edge g2 gen1 from) by
-        exact (forward_remset_item_gen2gen_no_edge2from_not_to
-                 from to g h rh rmst a g2 h2 rh2 rmst2 gen1
-                 Hto Hneq Hcc Hndd Hrc Hrica ltac:(lia) Hnofrom Hfri2).
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' gen1 gen2); eauto.
-Qed.
-
-Lemma forward_remset_gh_gen2gen_no_edge_gt_to_source:
-  forall from to g h rh rmst g' h' rh' rmst' outlier gen1 gen2,
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_compatible g outlier from rmst rh h ->
-    (forall dst_gen, (dst_gen < gen1)%nat -> gen2gen_no_edge g gen1 dst_gen) ->
-    gen2gen_no_edge g gen1 from ->
-    (to < gen1)%nat -> (gen2 < gen1)%nat ->
-    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
-    gen2gen_no_edge g' gen1 gen2.
-Proof.
-  intros from to g h rh rmst g' h' rh' rmst' outlier gen1 gen2
-         Hneq Hto Hcc Hndd Hrnd Hremc Hnbe_src Hnofrom Hgtto Hgt Hfrg.
-  destruct Hremc as [Hrgoc [Hrrhc _]].
-  assert (Hrc: remset_graph_compatible g rmst) by
-      (eapply remset_graph_outlier_compatible_weakened; eassumption).
-  unfold forward_remset_gh in Hfrg.
-  eapply forward_remset_item_fold_gen2gen_no_edge_gt_to_source; eauto.
-  eapply rrhc_forall_rrsc; exact Hrrhc.
-Qed.
-
 Lemma do_generation_relation_gcc:
   forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier,
     graph_has_gen g (S i) ->
@@ -11889,21 +11358,6 @@ Record thread_info: Type :=
     ti_frames: list frame;
     ti_nalloc: Ptrofs.int
   }.
-
-(* Definition reset_nth_heap_thread_info (n: nat) (ti: thread_info) : thread_info := *)
-(*   Build_thread_info (ti_heap_p ti) (reset_nth_heap n (ti_heap ti)) *)
-(*                     (ti_args ti) (arg_size ti) (ti_frames ti) (ti_nalloc ti). *)
-
-Lemma upd_tf_arg_Zlength: forall (t: thread_info) (index: Z) (v: val),
-    0 <= index < MAX_ARGS -> Zlength (upd_Znth index (ti_args t) v) = MAX_ARGS.
-Proof.
-  intros. rewrite upd_Znth_Zlength; [apply arg_size | rewrite arg_size; assumption].
-Qed.
-
-Definition update_thread_info_arg (t: thread_info) (index: Z)
-           (v: val) (H: 0 <= index < MAX_ARGS): thread_info :=
-  Build_thread_info (ti_heap_p t) (ti_heap t) (upd_Znth index (ti_args t) v)
-                    (upd_tf_arg_Zlength t index v H) (ti_frames t) (ti_nalloc t).
 
 Lemma add_new_space_rhhc: forall hp sp i (Hs: 0 <= i < MAX_SPACES),
     available_space sp = total_space sp ->

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -9063,53 +9063,33 @@ Qed.
 
 Lemma forward_remset_item_fold_roots_graph_compatible_pres:
   forall from to g h rh rmst r g' h' rh' rmst' roots,
-    from <> to ->
     graph_has_gen g to ->
-    copy_compatible g ->
-    remset_nodup rmst ->
-    remset_graph_compatible g rmst ->
-    remset_and_remset_space_compatible g from rmst r ->
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     roots_graph_compatible roots g ->
     roots_graph_compatible roots g'.
 Proof.
   intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' roots Hneq Hto Hcc Hrnd Hrc Hrrsc Hfri Hrgc;
-    simpl in Hfri.
-  - now inversion Hfri.
-  - hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc. destruct Hrrsc as [Hrica Hricr].
-    destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    pose proof Hfri2 as Hfri2'. unfold forward_remset_item in Hfri2'. simpl in Hfri2'.
-    rewrite Hfri2' in Hfri. symmetry in Hfri2.
+  induction r; intros g h rh rmst g' h' rh' rmst' roots Hto Hfold Hrgc; simpl in Hfold.
+  - now inversion Hfold.
+  - destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    pose proof Hfri as Hfri'. unfold forward_remset_item in Hfri'. simpl in Hfri'.
+    rewrite Hfri' in Hfold. symmetry in Hfri.
     eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' roots); eauto.
-    + eapply forward_remset_item_ghg with (g := g); eassumption.
-    + eapply fri_copy_compatible; eauto.
-    + eapply fri_remset_nodup; eassumption.
-    + eapply fri_remset_graph_compatible; eauto.
-    + hnf. rewrite Forall_forall in Hricr |- *. intros x Hin. specialize (Hricr _ Hin).
-      eapply fri_remset_item_compatible with (rmst := rmst) (item := a); eassumption.
-    + eapply (forward_remset_item_roots_graph_compatible_pres
-                from to g h rh rmst a g2 h2 rh2 rmst2 roots); eauto.
+    + rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri to).
+      exact Hto.
+    + eapply forward_remset_item_roots_graph_compatible_pres; eauto.
 Qed.
 
 Lemma forward_remset_gh_roots_graph_compatible:
-  forall from to g h rh rmst g' h' rh' rmst' roots outlier,
-    from <> to ->
+  forall from to g h rh rmst g' h' rh' rmst' roots,
     graph_has_gen g to ->
-    copy_compatible g ->
-    remset_nodup rmst ->
-    remset_compatible g outlier from rmst rh h ->
     (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
     roots_graph_compatible roots g ->
     roots_graph_compatible roots g'.
 Proof.
-  intros from to g h rh rmst g' h' rh' rmst' roots outlier Hneq Hto Hcc Hrnd Hremc Hfrg Hrgc.
-  destruct Hremc as [Hrgoc [Hrrhc _]].
-  assert (Hrc: remset_graph_compatible g rmst) by
-      (eapply remset_graph_outlier_compatible_weakened; eassumption).
+  intros from to g h rh rmst g' h' rh' rmst' roots Hto Hfrg Hrgc.
   unfold forward_remset_gh in Hfrg.
   eapply forward_remset_item_fold_roots_graph_compatible_pres; eauto.
-  eapply rrhc_forall_rrsc; exact Hrrhc.
 Qed.
 
 Lemma forward_remset_item_gen_unmarked_pres:
@@ -9366,6 +9346,37 @@ Proof.
     exact Hin.
 Qed.
 
+Lemma forward_remset_item_fold_space_property:
+  forall (Q: remset_space -> remset_heap -> Prop)
+         from to r g h rh rmst g' h' rh' rmst',
+    0 <= Z.of_nat to < Zlength rh ->
+    Q r rh ->
+    (forall item rest g h rh rmst g2 h2 rh2 rmst2,
+        0 <= Z.of_nat to < Zlength rh ->
+        Q (item :: rest) rh ->
+        (g2, h2, rh2, rmst2) =
+          forward_remset_item from to (g, h, rh, rmst) item ->
+        Q rest rh2) ->
+    (g', h', rh', rmst') =
+      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    Q nil rh'.
+Proof.
+  intros Q from to r.
+  induction r as [|item rest IH];
+    intros g h rh rmst g' h' rh' rmst' Hrange HQ HQstep Hfold.
+  - simpl in Hfold. inversion Hfold; subst. exact HQ.
+  - Opaque forward_remset_item.
+    simpl in Hfold.
+    Transparent forward_remset_item.
+    destruct (forward_remset_item from to (g, h, rh, rmst) item)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    assert (Hrange2: 0 <= Z.of_nat to < Zlength rh2) by
+        (pose proof (fri_rh_Zlength_same from to g h rh rmst item
+                       g2 h2 rh2 rmst2 Hfri); lia).
+    eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst'); eauto.
+Qed.
+
 Lemma remset_item2forward_t_not_edge:
   forall from g rmst item v n,
     remset_item_compatible g from rmst item ->
@@ -9452,25 +9463,11 @@ Lemma forward_remset_item_fold_preserves_remset_entry:
       fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     In old (nth_remset_space rh' gen).
 Proof.
-  intros from to r. induction r as [|item rest IH];
-    intros g h rh rmst g' h' rh' rmst' gen old Hrange Hin Hfold.
-  - simpl in Hfold. inversion Hfold; subst. exact Hin.
-  - simpl in Hfold.
-    destruct (forward_remset_item from to (g, h, rh, rmst) item)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    symmetry in Hfri.
-    fold (forward_remset_item from to (g, h, rh, rmst) item) in Hfold.
-    rewrite <- Hfri in Hfold.
-    assert (Hrange2: 0 <= Z.of_nat to < Zlength rh2) by
-        (pose proof (fri_rh_Zlength_same
-                       from to g h rh rmst item g2 h2 rh2 rmst2 Hfri);
-         lia).
-    eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst' gen old).
-    + exact Hrange2.
-    + eapply (forward_remset_item_preserves_remset_entry
-                from to g h rh rmst item g2 h2 rh2 rmst2 gen old);
-        [exact Hrange | exact Hin | exact Hfri].
-    + exact Hfold.
+  intros from to r g h rh rmst g' h' rh' rmst' gen old Hrange Hin Hfold.
+  eapply (forward_remset_item_fold_space_property
+            (fun _ rh => In old (nth_remset_space rh gen))); eauto.
+  intros item rest g0 h0 rh0 rmst0 g2 h2 rh2 rmst2 Hrange0 Hin0 Hfri.
+  eapply forward_remset_item_preserves_remset_entry; eauto.
 Qed.
 
 Lemma forward_remset_gh_preserves_remset_entry:
@@ -11047,7 +11044,7 @@ Proof.
                outlier Hneq Hto Hcc Hndd Hrnd Hremc Hfrg).
   assert (Hrgc_rem: roots_graph_compatible roots g_rem) by
       exact (forward_remset_gh_roots_graph_compatible i (S i) g h rh rmst g_rem h_rem rh'
-               rmst' roots outlier Hneq Hto Hcc Hrnd Hremc Hfrg Hrgc).
+               rmst' roots Hto Hfrg Hrgc).
   assert (Hun_rem: gen_unmarked g_rem (S i)) by
       exact (forward_remset_gh_gen_unmarked i (S i) g h rh rmst
                g_rem h_rem rh' rmst' (S i) Hto Hneq Hfrg Hun_to).
@@ -11229,7 +11226,6 @@ Proof.
       eapply (forward_remset_item_fold_roots_graph_compatible_pres
                 i (S i) g h rh rmst (Znth (Z.of_nat i) rh)
                 g_rem h_rem rh' rmst' roots); eauto.
-      eapply rrhc_forall_rrsc. exact Hrrhc.
     }
     assert (Hun_rem: gen_unmarked g_rem (S i)) by
         exact (forward_remset_gh_gen_unmarked i (S i) g h rh rmst

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -11147,8 +11147,8 @@ Proof.
   subst g'. apply firstn_gen_clear_reset. assumption.
 Qed.
 
-Lemma do_generation_relation_no_unrecorded_backward_edge_reset:
-  forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier,
+Lemma do_generation_relation_no_unrecorded_backward_edge_reset_core:
+  forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i,
     graph_has_gen g (S i) ->
     graph_unmarked g ->
     copy_compatible g ->
@@ -11157,7 +11157,8 @@ Lemma do_generation_relation_no_unrecorded_backward_edge_reset:
     firstn_gen_clear g i ->
     roots_graph_compatible roots g ->
     remset_nodup rmst ->
-    remset_compatible g outlier i rmst rh h ->
+    remset_graph_compatible g rmst ->
+    remset_and_remset_heap_compatible g i rmst rh ->
     firstn_gen_clear g' (S i) ->
     no_dangling_dst g' ->
     0 <= Z.of_nat (S i) < Zlength rh ->
@@ -11165,9 +11166,9 @@ Lemma do_generation_relation_no_unrecorded_backward_edge_reset:
       g_rem h_rem rh' rmst' g' h' ->
     no_unrecorded_backward_edge g' (reset_nth_remset_heap i rh').
 Proof.
-  intros g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier
-         Hto Hun Hcc Hndd Hunrec Hfirst Hroots Hrnd Hremc Hfirst' Hndd'
-         Hrange_to Hrel.
+  intros g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i
+         Hto Hun Hcc Hndd Hunrec Hfirst Hroots Hrnd Hrgc Hrrhc
+         Hfirst' Hndd' Hrange_to Hrel.
   destruct Hrel as [[g1 [g2 [Hfrg [Hfrr [Hscan Hreset]]]]] _].
   subst g'.
   unfold no_unrecorded_backward_edge.
@@ -11216,13 +11217,20 @@ Proof.
     assert (Hcc_rem: copy_compatible g_rem) by
         exact (forward_remset_gh_copy_compatible i (S i) g h rh rmst
                  g_rem h_rem rh' rmst' Hneq Hto Hcc Hfrg).
-    assert (Hndd_rem: no_dangling_dst g_rem) by
-        exact (forward_remset_gh_no_dangling_dst i (S i) g h rh rmst
-                 g_rem h_rem rh' rmst' outlier Hneq Hto Hcc Hndd Hrnd Hremc Hfrg).
-    assert (Hroots_rem: roots_graph_compatible roots g_rem) by
-        exact (forward_remset_gh_roots_graph_compatible
-                 i (S i) g h rh rmst g_rem h_rem rh' rmst' roots outlier
-                 Hneq Hto Hcc Hrnd Hremc Hfrg Hroots).
+    assert (Hndd_rem: no_dangling_dst g_rem). {
+      unfold forward_remset_gh in Hfrg.
+      eapply (fri_no_dangling_dst_fold
+                i (S i) g h rh rmst (Znth (Z.of_nat i) rh)
+                g_rem h_rem rh' rmst'); eauto.
+      eapply rrhc_forall_rrsc. exact Hrrhc.
+    }
+    assert (Hroots_rem: roots_graph_compatible roots g_rem). {
+      unfold forward_remset_gh in Hfrg.
+      eapply (forward_remset_item_fold_roots_graph_compatible_pres
+                i (S i) g h rh rmst (Znth (Z.of_nat i) rh)
+                g_rem h_rem rh' rmst' roots); eauto.
+      eapply rrhc_forall_rrsc. exact Hrrhc.
+    }
     assert (Hun_rem: gen_unmarked g_rem (S i)) by
         exact (forward_remset_gh_gen_unmarked i (S i) g h rh rmst
                  g_rem h_rem rh' rmst' (S i) Hto Hneq Hfrg Hun_to).
@@ -11309,25 +11317,29 @@ Proof.
             (replace (fst e, snd e) with e by (destruct e; reflexivity);
              exact Hdst_from).
         assert (Hdst_rem_to_pair:
-                  vgeneration (dst g_rem (fst e, snd e)) = S i) by
-            (eapply (forward_remset_gh_recorded_old_edge_dst_to
-                       i (S i) (gen_v_num g (S i)) g h rh rmst
-                       g_rem h_rem rh' rmst' outlier (fst e) (snd e));
-             [exact Hneq
-             | exact Hto
-             | exact Hcc
-             | exact Hndd
-             | exact Hrnd
-             | exact Hremc
-             | exact Hct
-             | exact He_g_pair
-             | unfold egeneration in Hsrc_gt_to; lia
-             | left; unfold egeneration in Hsrc_gt_to; lia
-             | lia
-             | exact Hdst_from_pair
-             | exact Hin_old
-             | exact Hfrg
-             | exact He_rem_pair]).
+                  vgeneration (dst g_rem (fst e, snd e)) = S i). {
+          unfold forward_remset_gh in Hfrg.
+          rewrite nth_remset_space_Znth in Hin_old.
+          eapply (forward_remset_item_fold_recorded_old_edge_dst_to
+                    i (S i) (gen_v_num g (S i)) (Znth (Z.of_nat i) rh)
+                    g h rh rmst g_rem h_rem rh' rmst' (fst e) (snd e));
+            [exact Hneq
+            | exact Hto
+            | exact Hcc
+            | exact Hndd
+            | exact Hrnd
+            | exact Hrgc
+            | eapply rrhc_forall_rrsc; exact Hrrhc
+            | exact Hct
+            | exact He_g_pair
+            | unfold egeneration in Hsrc_gt_to; lia
+            | left; unfold egeneration in Hsrc_gt_to; lia
+            | lia
+            | exact Hdst_from_pair
+            | exact Hin_old
+            | exact Hfrg
+            | exact He_rem_pair].
+        }
         replace (fst e, snd e) with e in Hdst_rem_to_pair by
             (destruct e; reflexivity).
         exact Hdst_rem_to_pair.
@@ -11370,6 +11382,32 @@ Proof.
       rewrite <- Hdst_rem_scan.
       rewrite Hdst_rem_g.
       eapply forward_remset_gh_preserves_remset_entry; eauto.
+Qed.
+
+Lemma do_generation_relation_no_unrecorded_backward_edge_reset:
+  forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier,
+    graph_has_gen g (S i) ->
+    graph_unmarked g ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    no_unrecorded_backward_edge g rh ->
+    firstn_gen_clear g i ->
+    roots_graph_compatible roots g ->
+    remset_nodup rmst ->
+    remset_compatible g outlier i rmst rh h ->
+    firstn_gen_clear g' (S i) ->
+    no_dangling_dst g' ->
+    0 <= Z.of_nat (S i) < Zlength rh ->
+    do_generation_relation i (S i) roots roots' g h rh rmst
+      g_rem h_rem rh' rmst' g' h' ->
+    no_unrecorded_backward_edge g' (reset_nth_remset_heap i rh').
+Proof.
+  intros g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier
+         Hto Hun Hcc Hndd Hunrec Hfirst Hroots Hrnd Hremc Hfirst' Hndd'
+         Hrange_to Hrel.
+  destruct Hremc as [Hrgoc [Hrrhc _]].
+  eapply do_generation_relation_no_unrecorded_backward_edge_reset_core; eauto.
+  eapply remset_graph_outlier_compatible_weakened; exact Hrgoc.
 Qed.
 
 Lemma do_generation_relation_graph_unmarked:

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -5082,25 +5082,6 @@ Proof.
         unfold gen_v_num in Hbound. lia.
 Qed.
 
-Lemma fr_O_old_edge_dst_not_from_pres:
-  forall from to p g g' v n bound,
-    graph_has_gen g to ->
-    from <> to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    forward_relation from to O p g g' ->
-    graph_has_e g (v, n) ->
-    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
-    (bound <= gen_v_num g to)%nat ->
-    vgeneration (dst g (v, n)) <> from ->
-    vgeneration (dst g' (v, n)) <> from.
-Proof.
-  intros from to p g g' v n bound Hto _ _ _ Hfr He Hold Hbound Hdst.
-  rewrite (fr_O_old_edge_dst_eq_pres
-             from to p g g' v n bound Hto Hfr He Hold Hbound Hdst).
-  exact Hdst.
-Qed.
-
 Definition forward_t_compatible (p: forward_t) (g: LGraph) :=
   match p with
   | ForwardVertex v => graph_has_v g v
@@ -10208,6 +10189,41 @@ Proof.
   eapply forward_remset_item_fold_gen_v_num_to; eassumption.
 Qed.
 
+Lemma forward_remset_item_step_bound_facts:
+  forall from to bound g h rh rmst item r g2 h2 rh2 rmst2,
+    from <> to ->
+    graph_has_gen g to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    remset_nodup rmst ->
+    remset_graph_compatible g rmst ->
+    remset_item_compatible g from rmst item ->
+    remset_and_remset_space_compatible g from rmst r ->
+    (bound <= gen_v_num g to)%nat ->
+    (g2, h2, rh2, rmst2) = forward_remset_item from to (g, h, rh, rmst) item ->
+    graph_has_gen g2 to /\
+    copy_compatible g2 /\
+    no_dangling_dst g2 /\
+    remset_nodup rmst2 /\
+    remset_graph_compatible g2 rmst2 /\
+    remset_and_remset_space_compatible g2 from rmst2 r /\
+    (bound <= gen_v_num g2 to)%nat.
+Proof.
+  intros from to bound g h rh rmst item r g2 h2 rh2 rmst2
+         Hneq Hto Hcc Hndd Hrnd Hrgc Hric Hrrsc Hbound Hfri.
+  destruct (forward_remset_item_step_facts
+              from to g h rh rmst item r g2 h2 rh2 rmst2
+              Hneq Hto Hcc Hrnd Hrgc Hric Hrrsc Hfri)
+    as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
+  refine (conj Hto2 (conj Hcc2 (conj _ (conj Hrnd2
+            (conj Hrgc2 (conj Hrrsc2 _)))))).
+  - exact (fri_no_dangling_dst from to g h rh rmst item g2 h2 rh2 rmst2
+             Hto Hcc Hrgc Hric Hndd Hfri).
+  - pose proof (forward_remset_item_gen_v_num_to
+                  from to g h rh rmst item g2 h2 rh2 rmst2 Hto Hfri).
+    lia.
+Qed.
+
 Lemma forward_remset_item_clears_interior_edge:
   forall from to g h rh rmst v n g' h' rh' rmst',
     graph_has_gen g to ->
@@ -10289,27 +10305,6 @@ Proof.
     inversion Hfri; subst; clear Hfri.
     eapply fr_O_old_edge_dst_eq_pres; eauto.
   - inversion Hfri; subst. reflexivity.
-Qed.
-
-Lemma forward_remset_item_old_edge_dst_not_from_pres:
-  forall from to g h rh rmst item g' h' rh' rmst' v n bound,
-    graph_has_gen g to ->
-    from <> to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    graph_has_e g (v, n) ->
-    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
-    (bound <= gen_v_num g to)%nat ->
-    vgeneration (dst g (v, n)) <> from ->
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    vgeneration (dst g' (v, n)) <> from.
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' v n bound
-         Hto _ _ _ He Hold Hbound Hdst Hfri.
-  rewrite (forward_remset_item_old_edge_dst_eq_pres
-             from to g h rh rmst item g' h' rh' rmst' v n bound
-             Hto He Hold Hbound Hdst Hfri).
-  exact Hdst.
 Qed.
 
 Lemma forward_remset_item_fold_old_edge_graph_has_e_inv:
@@ -10419,21 +10414,13 @@ Proof.
     symmetry in Hfri.
     fold (forward_remset_item from to (g, h, rh, rmst) item) in Hfold.
     rewrite <- Hfri in Hfold.
-    destruct (forward_remset_item_step_facts
-                from to g h rh rmst item rest g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hrnd Hrgc Hrica Hricr Hfri)
-      as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
-    assert (Hndd2: no_dangling_dst g2) by
-        exact (fri_no_dangling_dst from to g h rh rmst item g2 h2 rh2 rmst2
-                 Hto Hcc Hrgc Hrica Hndd Hfri).
+    destruct (forward_remset_item_step_bound_facts
+                from to bound g h rh rmst item rest g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hndd Hrnd Hrgc Hrica Hricr Hbound Hfri)
+      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrgc2 [Hrrsc2 Hbound2]]]]]].
     assert (Hct2: copied_to_compatible from to g2) by
         exact (forward_remset_item_copied_to_compatible
                  from to g h rh rmst item g2 h2 rh2 rmst2 Hneq Hto Hct Hfri).
-    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
-      pose proof (forward_remset_item_gen_v_num_to
-                    from to g h rh rmst item g2 h2 rh2 rmst2 Hto Hfri).
-      lia.
-    }
     assert (He2: graph_has_e g2 (v, n)) by
         (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
                    from to bound rest g2 h2 rh2 rmst2 g' h' rh' rmst' v n);
@@ -10519,13 +10506,7 @@ Qed.
 
 Lemma forward_remset_item_fold_old_edge_dst_not_from_pres:
   forall from to bound r g h rh rmst g' h' rh' rmst' v n,
-    from <> to ->
     graph_has_gen g to ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    remset_nodup rmst ->
-    remset_graph_compatible g rmst ->
-    remset_and_remset_space_compatible g from rmst r ->
     (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
     (bound <= gen_v_num g to)%nat ->
     graph_has_e g (v, n) ->
@@ -10534,38 +10515,12 @@ Lemma forward_remset_item_fold_old_edge_dst_not_from_pres:
     graph_has_e g' (v, n) ->
     vgeneration (dst g' (v, n)) <> from.
 Proof.
-  intros from to bound r. induction r;
-    intros g h rh rmst g' h' rh' rmst' v n
-           Hneq Hto Hcc Hndd Hrnd Hrgc Hrrsc Hold Hbound He Hdst Hfold Hefinal.
-  - simpl in Hfold. inversion Hfold; subst. exact Hdst.
-  - simpl in Hfold. hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
-    destruct Hrrsc as [Hrica Hricr].
-    destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    symmetry in Hfri.
-    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
-    rewrite <- Hfri in Hfold.
-    destruct (forward_remset_item_step_facts
-                from to g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hrnd Hrgc Hrica Hricr Hfri)
-      as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
-    assert (Hndd2: no_dangling_dst g2) by
-        exact (fri_no_dangling_dst from to g h rh rmst a g2 h2 rh2 rmst2
-                 Hto Hcc Hrgc Hrica Hndd Hfri).
-    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
-      pose proof (forward_remset_item_gen_v_num_to from to g h rh rmst a g2 h2 rh2 rmst2
-                    Hto Hfri).
-      lia.
-    }
-    assert (He2: graph_has_e g2 (v, n)) by
-        (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
-                   from to bound r g2 h2 rh2 rmst2 g' h' rh' rmst' v n);
-         eauto).
-    assert (Hdst2: vgeneration (dst g2 (v, n)) <> from) by
-        (eapply (forward_remset_item_old_edge_dst_not_from_pres
-                   from to g h rh rmst a g2 h2 rh2 rmst2 v n bound);
-         eauto).
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' v n); eauto.
+  intros from to bound r g h rh rmst g' h' rh' rmst' v n
+         Hto Hold Hbound He Hdst Hfold Hefinal.
+  rewrite (forward_remset_item_fold_old_edge_dst_eq_pres
+             from to bound r g h rh rmst g' h' rh' rmst' v n
+             Hto Hold Hbound He Hdst Hfold Hefinal).
+  exact Hdst.
 Qed.
 
 Lemma forward_remset_item_fold_clears_recorded_old_edge:
@@ -10596,18 +10551,10 @@ Proof.
     symmetry in Hfri.
     fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
     rewrite <- Hfri in Hfold.
-    destruct (forward_remset_item_step_facts
-                from to g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hrnd Hrgc Hrica Hricr Hfri)
-      as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
-    assert (Hndd2: no_dangling_dst g2) by
-        exact (fri_no_dangling_dst from to g h rh rmst a g2 h2 rh2 rmst2
-                 Hto Hcc Hrgc Hrica Hndd Hfri).
-    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
-      pose proof (forward_remset_item_gen_v_num_to from to g h rh rmst a g2 h2 rh2 rmst2
-                    Hto Hfri).
-      lia.
-    }
+    destruct (forward_remset_item_step_bound_facts
+                from to bound g h rh rmst a r g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hndd Hrnd Hrgc Hrica Hricr Hbound Hfri)
+      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrgc2 [Hrrsc2 Hbound2]]]]]].
     destruct Hin as [Hhead | Htail].
     + subst a.
       assert (He2: graph_has_e g2 (v, n)) by
@@ -10734,13 +10681,10 @@ Proof.
     symmetry in Hfri2.
     fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
     rewrite <- Hfri2 in Hfold.
-    destruct (forward_remset_item_step_facts
-                from to g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hrnd Hrc Hrica Hricr Hfri2)
-      as [Hto2 [Hcc2 [Hrnd2 [Hrc2 Hricr2]]]].
-    assert (Hndd2: no_dangling_dst g2) by
-        exact (fri_no_dangling_dst from to g h rh rmst a g2 h2 rh2 rmst2
-                 Hto Hcc Hrc Hrica Hndd Hfri2).
+    destruct (forward_remset_item_step_bound_facts
+                from to bound g h rh rmst a r g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hndd Hrnd Hrc Hrica Hricr Hbound Hfri2)
+      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrc2 [Hricr2 Hbound2]]]]]].
     assert (Hprefix2: forall vidx eidx : nat,
                (vidx < bound)%nat ->
                graph_has_e g2 (to, vidx, eidx) ->
@@ -10748,11 +10692,6 @@ Proof.
         exact (forward_remset_item_prefix_no_edge2gen_old_to
                  from to g h rh rmst a g2 h2 rh2 rmst2 bound
                  Hto Hneq Hcc Hndd Hrc Hrica Hbound Hprefix Hfri2).
-    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
-      pose proof (forward_remset_item_gen_v_num_to from to g h rh rmst a g2 h2 rh2 rmst2
-                    Hto Hfri2).
-      lia.
-    }
     eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' bound); eauto.
 Qed.
 
@@ -10974,13 +10913,10 @@ Proof.
     symmetry in Hfri2.
     fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
     rewrite <- Hfri2 in Hfold.
-    destruct (forward_remset_item_step_facts
-                from to g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hrnd Hrc Hrica Hricr Hfri2)
-      as [Hto2 [Hcc2 [Hrnd2 [Hrc2 Hricr2]]]].
-    assert (Hndd2: no_dangling_dst g2) by
-        exact (fri_no_dangling_dst from to g h rh rmst a g2 h2 rh2 rmst2
-                 Hto Hcc Hrc Hrica Hndd Hfri2).
+    destruct (forward_remset_item_step_bound_facts
+                from to O g h rh rmst a r g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hndd Hrnd Hrc Hrica Hricr ltac:(lia) Hfri2)
+      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrc2 [Hricr2 _]]]]]].
     assert (Hno2: gen2gen_no_edge g2 gen1 from) by
         exact (forward_remset_item_gen2gen_no_edge2from_not_to
                  from to g h rh rmst a g2 h2 rh2 rmst2 gen1
@@ -11549,13 +11485,10 @@ Proof.
     symmetry in Hfri2.
     fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
     rewrite <- Hfri2 in Hfold.
-    destruct (forward_remset_item_step_facts
-                from to g h rh rmst a r g2 h2 rh2 rmst2
-                Hneq Hto Hcc Hrnd Hrc Hrica Hricr Hfri2)
-      as [Hto2 [Hcc2 [Hrnd2 [Hrc2 Hricr2]]]].
-    assert (Hndd2: no_dangling_dst g2) by
-        exact (fri_no_dangling_dst from to g h rh rmst a g2 h2 rh2 rmst2
-                 Hto Hcc Hrc Hrica Hndd Hfri2).
+    destruct (forward_remset_item_step_bound_facts
+                from to O g h rh rmst a r g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hndd Hrnd Hrc Hrica Hricr ltac:(lia) Hfri2)
+      as [Hto2 [Hcc2 [Hndd2 [Hrnd2 [Hrc2 [Hricr2 _]]]]]].
     assert (Hnbe_src2: forall dst_gen : nat,
                (dst_gen < gen1)%nat -> gen2gen_no_edge g2 gen1 dst_gen). {
       intros dst_gen Hdst.

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -4935,6 +4935,172 @@ Proof.
   - unfold new_copied_v. simpl. auto.
 Qed.
 
+Lemma graph_has_e_Znth:
+  forall g v n,
+    graph_has_e g (v, n) ->
+    (0 <= Z.of_nat n < Zlength (raw_fields (vlabel g v)))%Z /\
+    Znth (Z.of_nat n) (make_fields g v) = FieldEdge (v, n).
+Proof.
+  intros g v n [_ Hin].
+  rewrite get_edges_In_iff in Hin.
+  apply In_Znth in Hin. destruct Hin as [j [Hj Hfield]].
+  assert (Hj_raw: (0 <= j < Zlength (raw_fields (vlabel g v)))%Z) by
+      (rewrite <- make_fields_eq_length; exact Hj).
+  pose proof (make_fields_Znth_edge g v j (v, n) Hj_raw Hfield) as Heq.
+  inversion Heq; subst.
+  split; [lia |].
+  replace (Z.of_nat (Z.to_nat j)) with j by lia.
+  exact Hfield.
+Qed.
+
+Lemma fr_O_dst_changed_field_to:
+  forall from to v n g g',
+    no_dangling_dst g ->
+    copied_to_compatible from to g ->
+    graph_has_e g (v, n) ->
+    vgeneration (dst g (v, n)) = from ->
+    forward_relation from to O
+      (interior2forward (InteriorVertexPos v (Z.of_nat n)) g) g g' ->
+    vgeneration (dst g' (v, n)) = to.
+Proof.
+  intros from to v n g g' Hndd Hct He Hdst Hfr.
+  pose proof (graph_has_e_Znth g v n He) as [_ Hfield].
+  simpl in Hfr. rewrite Hfield in Hfr. simpl in Hfr.
+  inversion Hfr; subst; try contradiction.
+  - simpl. unfold updateEdgeFunc. rewrite if_true by reflexivity.
+    eapply Hct; eauto.
+    destruct He as [Hsrc Hfield_in]. eapply Hndd; eauto.
+  - simpl. unfold updateEdgeFunc. rewrite if_true by reflexivity.
+    unfold new_copied_v. reflexivity.
+Qed.
+
+Lemma graph_has_v_not_new_copied:
+  forall g to v,
+    graph_has_v g v ->
+    v <> new_copied_v g to.
+Proof.
+  intros g to [gen idx] [_ Hidx] Hbad.
+  unfold new_copied_v in Hbad. inversion Hbad; subst.
+  unfold gen_has_index, gen_v_num in Hidx. simpl in Hidx. lia.
+Qed.
+
+Lemma fr_O_dst_eq_unless_forward_edge:
+  forall from to p g g' e,
+    graph_has_gen g to ->
+    graph_has_v g (fst e) ->
+    forward_relation from to O p g g' ->
+    (forall e0, p = ForwardEdge e0 -> e0 <> e) ->
+    dst g' e = dst g e.
+Proof.
+  intros from to p g g' e Hto Hsrc Hfr Hnot.
+  destruct p as [z | out | v | e0]; inversion Hfr; subst; simpl in *;
+    try reflexivity.
+  - rewrite pcv_dst_old; [reflexivity |].
+    eapply graph_has_v_not_new_copied; eauto.
+  - apply lgd_dst_old. apply Hnot. reflexivity.
+  - simpl. unfold updateEdgeFunc.
+    rewrite if_false by
+        (intro Hbad; apply (Hnot e0 eq_refl); hnf; exact Hbad).
+    rewrite pcv_dst_old; [reflexivity |].
+    eapply graph_has_v_not_new_copied; eauto.
+Qed.
+
+Lemma fr_O_old_edge_graph_has_e_inv:
+  forall from to p g g' v n bound,
+    graph_has_gen g to ->
+    forward_relation from to O p g g' ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    graph_has_e g' (v, n) ->
+    graph_has_e g (v, n).
+Proof.
+  intros from to p g g' v n bound Hto Hfr Hold Hbound He'.
+  assert (Hv: graph_has_v g v). {
+    destruct Hold as [Hnot_to | Hidx].
+    - destruct He' as [Hv' _].
+      pose proof (fr_O_graph_has_v_inv from to p g g' Hto Hfr v Hv') as Hinv.
+      destruct Hinv as [Hv | Hnew]; [exact Hv |].
+      exfalso. subst v. unfold new_copied_v in Hnot_to. simpl in Hnot_to.
+      contradiction.
+    - destruct Hidx as [Hgen Hidx].
+      destruct v as [vgen vidx]. simpl in *. subst vgen.
+      split; simpl; [exact Hto |].
+      unfold gen_has_index, gen_v_num in *. simpl in *. lia.
+  }
+  pose proof (graph_has_e_Znth g' v n He') as [Hrange' Hfield'].
+  assert (Hraw: raw_fields (vlabel g v) = raw_fields (vlabel g' v)) by
+      (eapply fr_raw_fields; eauto).
+  split; [exact Hv |].
+  rewrite get_edges_In_iff.
+  assert (Hfield: Znth (Z.of_nat n) (make_fields g v) = FieldEdge (v, n)). {
+    unfold make_fields. rewrite Hraw. exact Hfield'.
+  }
+  rewrite <- Hfield.
+  apply Znth_In.
+  rewrite make_fields_eq_length.
+  change (0 <= Z.of_nat n < Zlength (raw_fields (vlabel g v)))%Z.
+  rewrite Hraw. exact Hrange'.
+Qed.
+
+Lemma fr_O_old_edge_dst_eq_pres:
+  forall from to p g g' v n bound,
+    graph_has_gen g to ->
+    forward_relation from to O p g g' ->
+    graph_has_e g (v, n) ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    vgeneration (dst g (v, n)) <> from ->
+    dst g' (v, n) = dst g (v, n).
+Proof.
+  intros from to p g g' v n bound Hto Hfr He Hold Hbound Hdst.
+  destruct p as [z | out | v0 | e]; inversion Hfr; subst; simpl in *;
+    try reflexivity.
+  - rewrite pcv_dst_old; [reflexivity |].
+    unfold new_copied_v. destruct Hold as [Hnot_to | [Hgen Hidx]]; intro Hbad.
+    + apply Hnot_to.
+      replace (vgeneration v) with (vgeneration (fst (v, n))) by reflexivity.
+      rewrite Hbad. reflexivity.
+    + assert (vindex v = number_of_vertices (nth_gen g to)) as Hvidx.
+      { replace (vindex v) with (vindex (fst (v, n))) by reflexivity.
+        rewrite Hbad. reflexivity. }
+      unfold gen_v_num in Hbound. lia.
+  - destruct (E_EqDec e (v, n)) as [Heq | Hne].
+    + hnf in Heq. subst e. contradiction.
+    + apply lgd_dst_old. intro Hbad. apply Hne. hnf. exact Hbad.
+  - destruct (E_EqDec e (v, n)) as [Heq | Hne].
+    + hnf in Heq. subst e. contradiction.
+    + simpl. unfold updateEdgeFunc.
+      rewrite if_false by (intro Hbad; apply Hne; hnf; exact Hbad).
+      rewrite pcv_dst_old; [reflexivity |].
+      unfold new_copied_v. destruct Hold as [Hnot_to | [Hgen Hidx]]; intro Hbad.
+      * apply Hnot_to.
+        replace (vgeneration v) with (vgeneration (fst (v, n))) by reflexivity.
+        rewrite Hbad. reflexivity.
+      * assert (vindex v = number_of_vertices (nth_gen g to)) as Hvidx.
+        { replace (vindex v) with (vindex (fst (v, n))) by reflexivity.
+          rewrite Hbad. reflexivity. }
+        unfold gen_v_num in Hbound. lia.
+Qed.
+
+Lemma fr_O_old_edge_dst_not_from_pres:
+  forall from to p g g' v n bound,
+    graph_has_gen g to ->
+    from <> to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    forward_relation from to O p g g' ->
+    graph_has_e g (v, n) ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    vgeneration (dst g (v, n)) <> from ->
+    vgeneration (dst g' (v, n)) <> from.
+Proof.
+  intros from to p g g' v n bound Hto _ _ _ Hfr He Hold Hbound Hdst.
+  rewrite (fr_O_old_edge_dst_eq_pres
+             from to p g g' v n bound Hto Hfr He Hold Hbound Hdst).
+  exact Hdst.
+Qed.
+
 Definition forward_t_compatible (p: forward_t) (g: LGraph) :=
   match p with
   | ForwardVertex v => graph_has_v g v
@@ -5270,9 +5436,6 @@ Proof.
   list_solve.
 Qed.
 
-Definition no_backward_edge (g: LGraph): Prop :=
-  forall gen1 gen2, gen1 > gen2 -> gen2gen_no_edge g gen1 gen2.
-
 Definition firstn_gen_clear (g: LGraph) (n: nat): Prop :=
   forall i, i < n -> graph_gen_clear g i.
 
@@ -5339,17 +5502,6 @@ Proof.
     apply Hexcept; auto.
 Qed.
 
-Lemma fgc_nbe_no_edge2gen: forall g n,
-    firstn_gen_clear g n -> no_backward_edge g -> no_edge2gen g n.
-Proof.
-  intros. red in H, H0 |-* . intros. red. intros. destruct H2. simpl in *.
-  destruct (lt_eq_lt_dec another n) as [[?|?]|?]. 2: contradiction.
-  - specialize (H _ l). red in H. destruct H2. simpl in *.
-    red in H4. rewrite H in H4. lia.
-  - assert (another > n) by lia. specialize (H0 _ _ H4). apply H0.
-    split; simpl; assumption.
-Qed.
-
 Definition add_new_gen (gi: graph_info) (gen_i: generation_info): graph_info :=
   Build_graph_info (g_gen gi +:: gen_i) (app_not_nil (g_gen gi) gen_i).
 
@@ -5363,8 +5515,7 @@ Definition new_gen_relation (gen: nat) (g1 g2: LGraph): Prop :=
                                       g2 = lgraph_add_new_gen g1 gen_i.
 
 Definition garbage_collect_condition (g: LGraph) (h : part_heap) : Prop :=
-  graph_unmarked g /\ no_backward_edge g /\ no_dangling_dst g
-   /\ ti_size_spec h.
+  graph_unmarked g /\ no_dangling_dst g /\ ti_size_spec h.
 
 Local Open Scope Z_scope.
 
@@ -5622,15 +5773,6 @@ Lemma ang_get_edges: forall g gi v,
     get_edges g v = get_edges (lgraph_add_new_gen g gi) v.
 Proof. intros. unfold get_edges, make_fields. simpl. reflexivity. Qed.
 
-Lemma no_backward_edge_add: forall g gi,
-    number_of_vertices gi = O -> no_backward_edge g ->
-    no_backward_edge (lgraph_add_new_gen g gi).
-Proof.
-  intros. unfold no_backward_edge, gen2gen_no_edge in *. intros. simpl.
-  destruct H2. simpl in *. rewrite <- ang_get_edges in H3.
-  apply ang_graph_has_v_inv in H2; auto. apply H0; auto. split; simpl; auto.
-Qed.
-
 Lemma no_dangling_dst_add: forall g gi,
     number_of_vertices gi = O -> no_dangling_dst g ->
     no_dangling_dst (lgraph_add_new_gen g gi).
@@ -5646,9 +5788,8 @@ Lemma gcc_add: forall g h gi sp i (Hs: 0 <= i < MAX_SPACES),
     garbage_collect_condition (lgraph_add_new_gen g gi)
                               (add_new_space h sp i Hs).
 Proof.
-  intros. destruct H1 as [? [? [? ?]]]. split; [|split; [|split]].
+  intros. destruct H1 as [? [? ?]]. split; [|split].
   - apply graph_unmarked_add; assumption.
-  - apply no_backward_edge_add; assumption.
   - apply no_dangling_dst_add; assumption.
   - apply ti_size_spec_add; assumption.
 Qed.
@@ -5661,7 +5802,7 @@ Lemma gc_cond_implies_do_gen_cons: forall g h i,
     do_generation_condition g h i (S i).
 Proof.
   intros g h i Hstch HghS Hghc Hgcc.
-  destruct Hgcc as [Hunmarked [Hnbe [Hndd Hsize]]].
+  destruct Hgcc as [Hunmarked [Hndd Hsize]].
   assert (Hghi: graph_has_gen g i) by (unfold graph_has_gen in *; lia).
   assert (Hheap: safe_to_copy_gen_heap h i (S i)). {
     unfold safe_to_copy_to_except_heap in Hstch.
@@ -6776,6 +6917,51 @@ Fixpoint reset_nth_remset_heap (n: nat) (rh: remset_heap) : remset_heap :=
             | rs :: rest => rs :: reset_nth_remset_heap n' rest
             end
   end.
+
+Definition no_unrecorded_backward_edge (g: LGraph) (rh: remset_heap): Prop :=
+  forall e,
+    graph_has_e g e ->
+    (egeneration e > vgeneration (dst g e))%nat ->
+    In (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e))))
+       (nth_remset_space rh (vgeneration (dst g e))).
+
+Lemma firstn_gen_clear_edge_source_gt:
+  forall g from e,
+    firstn_gen_clear g from ->
+    graph_has_e g e ->
+    egeneration e <> from ->
+    vgeneration (dst g e) = from ->
+    (egeneration e > from)%nat.
+Proof.
+  intros g from [[gen idx] eidx] Hfirst [Hsrc _] Hneq Hdst.
+  unfold egeneration in *. simpl in *.
+  destruct (lt_eq_lt_dec gen from) as [[Hlt | Heq] | Hgt].
+  - unfold firstn_gen_clear, graph_gen_clear in Hfirst.
+    specialize (Hfirst gen Hlt).
+    destruct Hsrc as [_ Hidx].
+    unfold gen_has_index in Hidx. simpl in Hidx.
+    rewrite Hfirst in Hidx. lia.
+  - contradiction.
+  - exact Hgt.
+Qed.
+
+Lemma no_unrecorded_backward_edge_current_remset:
+  forall g rh from e,
+    firstn_gen_clear g from ->
+    no_unrecorded_backward_edge g rh ->
+    graph_has_e g e ->
+    egeneration e <> from ->
+    vgeneration (dst g e) = from ->
+    In (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e))))
+       (nth_remset_space rh from).
+Proof.
+  intros g rh from e Hfirst Hunrec He Hsrc Hdst.
+  specialize (Hunrec e He).
+  assert (Hback: (egeneration e > vgeneration (dst g e))%nat) by
+      (rewrite Hdst; eapply firstn_gen_clear_edge_source_gt; eauto).
+  specialize (Hunrec Hback).
+  now rewrite Hdst in Hunrec.
+Qed.
 
 Lemma reset_nth_remset_heap_length: forall n rh,
     length (reset_nth_remset_heap n rh) = length rh.
@@ -9159,6 +9345,209 @@ Proof.
   destruct (Nat.eq_dec to to); simpl; tauto.
 Qed.
 
+Lemma forward_remset_item_preserves_remset_entry:
+  forall from to g h rh rmst item g' h' rh' rmst' gen old,
+    0 <= Z.of_nat to < Zlength rh ->
+    In old (nth_remset_space rh gen) ->
+    (g', h', rh', rmst') =
+      forward_remset_item from to (g, h, rh, rmst) item ->
+    In old (nth_remset_space rh' gen).
+Proof.
+  intros from to g h rh rmst item g' h' rh' rmst' gen old
+         Hrange Hin Hfri.
+  unfold forward_remset_item in Hfri.
+  destruct (negb (remset_item_in_gen item rmst g from)).
+  - destruct (forward_graph_and_heap
+                from to 0 (remset_item2forward_t item rmst g) g h)
+      as [new_g new_h].
+    inversion Hfri; subst; clear Hfri.
+    apply nth_remset_space_upd_remset_heap_old; assumption.
+  - inversion Hfri; subst; clear Hfri.
+    exact Hin.
+Qed.
+
+Lemma remset_item2forward_t_not_edge:
+  forall from g rmst item v n,
+    remset_item_compatible g from rmst item ->
+    item <> RemSetInterior (InteriorVertexPos v (Z.of_nat n)) ->
+    remset_item2forward_t item rmst g <> ForwardEdge (v, n).
+Proof.
+  intros from g rmst item v n Hric Hneq Hedge.
+  destruct item as [addr | [v0 pos]]; simpl in *.
+  - destruct (find_remset_ext addr rmst) as [rext |]; simpl in Hedge;
+      [destruct rext |]; simpl in Hedge; discriminate.
+  - destruct Hric as [_ [Hrange _]].
+    destruct (Znth pos (make_fields g v0)) as [z | p | e] eqn:Hfield;
+      inversion Hedge; subst e.
+    pose proof (make_fields_Znth_edge g v0 pos (v, n) Hrange Hfield)
+      as Heq.
+    inversion Heq; subst v0. apply Hneq.
+    replace pos with (Z.of_nat n) by lia. reflexivity.
+Qed.
+
+Lemma forward_remset_item_nonrecorded_edge_dst_eq:
+  forall from to g h rh rmst item g' h' rh' rmst' v n,
+    graph_has_gen g to ->
+    remset_item_compatible g from rmst item ->
+    graph_has_e g (v, n) ->
+    item <> RemSetInterior (InteriorVertexPos v (Z.of_nat n)) ->
+    (g', h', rh', rmst') =
+      forward_remset_item from to (g, h, rh, rmst) item ->
+    dst g' (v, n) = dst g (v, n).
+Proof.
+  intros from to g h rh rmst item g' h' rh' rmst' v n
+         Hto Hric He Hneq Hfri.
+  unfold forward_remset_item in Hfri.
+  destruct (negb (remset_item_in_gen item rmst g from)).
+  - destruct (forward_graph_and_heap
+                from to 0 (remset_item2forward_t item rmst g) g h)
+      as [new_g new_h] eqn:Hfgh.
+    pose proof fr_forward_graph_and_heap
+         from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
+    rewrite Hfgh in Hfr. simpl in Hfr.
+    inversion Hfri; subst; clear Hfri.
+    eapply fr_O_dst_eq_unless_forward_edge; eauto.
+    + exact (proj1 He).
+    + intros e0 Hp He0.
+      apply (remset_item2forward_t_not_edge from g rmst item v n Hric Hneq).
+      subst e0. exact Hp.
+  - inversion Hfri; subst. reflexivity.
+Qed.
+
+Lemma forward_remset_item_recorded_edge_dst_to:
+  forall from to g h rh rmst g' h' rh' rmst' v n,
+    no_dangling_dst g ->
+    copied_to_compatible from to g ->
+    graph_has_e g (v, n) ->
+    vgeneration (dst g (v, n)) = from ->
+    vgeneration v <> from ->
+    (g', h', rh', rmst') =
+      forward_remset_item from to (g, h, rh, rmst)
+        (RemSetInterior (InteriorVertexPos v (Z.of_nat n))) ->
+    vgeneration (dst g' (v, n)) = to.
+Proof.
+  intros from to g h rh rmst g' h' rh' rmst' v n
+         Hndd Hct He Hdst Hsrc Hfri.
+  unfold forward_remset_item in Hfri. simpl in Hfri.
+  replace (vgeneration v =? from)%nat with false in Hfri by
+      (symmetry; apply Nat.eqb_neq; exact Hsrc).
+  simpl in Hfri.
+  destruct (forward_graph_and_heap
+              from to 0
+              (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h)
+    as [new_g new_h] eqn:Hfgh.
+  pose proof fr_forward_graph_and_heap
+       from to 0
+       (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h as Hfr.
+  rewrite Hfgh in Hfr. simpl in Hfr.
+  inversion Hfri; subst; clear Hfri.
+  eapply fr_O_dst_changed_field_to; eauto.
+Qed.
+
+Lemma forward_remset_item_fold_preserves_remset_entry:
+  forall from to r g h rh rmst g' h' rh' rmst' gen old,
+    0 <= Z.of_nat to < Zlength rh ->
+    In old (nth_remset_space rh gen) ->
+    (g', h', rh', rmst') =
+      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    In old (nth_remset_space rh' gen).
+Proof.
+  intros from to r. induction r as [|item rest IH];
+    intros g h rh rmst g' h' rh' rmst' gen old Hrange Hin Hfold.
+  - simpl in Hfold. inversion Hfold; subst. exact Hin.
+  - simpl in Hfold.
+    destruct (forward_remset_item from to (g, h, rh, rmst) item)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    fold (forward_remset_item from to (g, h, rh, rmst) item) in Hfold.
+    rewrite <- Hfri in Hfold.
+    assert (Hrange2: 0 <= Z.of_nat to < Zlength rh2) by
+        (pose proof (fri_rh_Zlength_same
+                       from to g h rh rmst item g2 h2 rh2 rmst2 Hfri);
+         lia).
+    eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst' gen old).
+    + exact Hrange2.
+    + eapply (forward_remset_item_preserves_remset_entry
+                from to g h rh rmst item g2 h2 rh2 rmst2 gen old);
+        [exact Hrange | exact Hin | exact Hfri].
+    + exact Hfold.
+Qed.
+
+Lemma forward_remset_gh_preserves_remset_entry:
+  forall from to g h rh rmst g' h' rh' rmst' gen old,
+    0 <= Z.of_nat to < Zlength rh ->
+    In old (nth_remset_space rh gen) ->
+    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
+    In old (nth_remset_space rh' gen).
+Proof.
+  intros from to g h rh rmst g' h' rh' rmst' gen old Hrange Hin Hfrg.
+  unfold forward_remset_gh in Hfrg.
+  rewrite <- nth_remset_space_Znth in Hfrg.
+  eapply forward_remset_item_fold_preserves_remset_entry; eauto.
+Qed.
+
+Lemma forward_remset_item_fold_records_nonfrom_interior:
+  forall from to r g h rh rmst g' h' rh' rmst' v n,
+    0 <= Z.of_nat to < Zlength rh ->
+    vgeneration v <> from ->
+    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n))) r ->
+    (g', h', rh', rmst') =
+      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n)))
+       (nth_remset_space rh' to).
+Proof.
+  intros from to r. induction r as [|item rest IH];
+    intros g h rh rmst g' h' rh' rmst' v n Hrange Hgen Hin Hfold.
+  - contradiction.
+  - simpl in Hfold.
+    destruct (forward_remset_item from to (g, h, rh, rmst) item)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    fold (forward_remset_item from to (g, h, rh, rmst) item) in Hfold.
+    rewrite <- Hfri in Hfold.
+    assert (Hrange2: 0 <= Z.of_nat to < Zlength rh2) by
+        (pose proof (fri_rh_Zlength_same
+                       from to g h rh rmst item g2 h2 rh2 rmst2 Hfri);
+         lia).
+    destruct Hin as [Hhead | Htail].
+    + subst item.
+      assert (Hin2:
+                In (RemSetInterior (InteriorVertexPos v (Z.of_nat n)))
+                   (nth_remset_space rh2 to)). {
+        unfold forward_remset_item in Hfri.
+        simpl in Hfri.
+        replace (vgeneration v =? from)%nat with false in Hfri by
+            (symmetry; apply Nat.eqb_neq; exact Hgen).
+        simpl in Hfri.
+        destruct (forward_graph_and_heap
+                    from to 0
+                    (field2forward (Znth (Z.of_nat n) (make_fields g v)))
+                    g h) as [new_g new_h] eqn:Hfgh.
+        simpl in Hfri.
+        inversion Hfri; subst; clear Hfri.
+        apply nth_remset_space_upd_remset_heap_new. exact Hrange.
+      }
+      eapply forward_remset_item_fold_preserves_remset_entry; eauto.
+    + eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst' v n); eauto.
+Qed.
+
+Lemma forward_remset_gh_records_nonfrom_interior:
+  forall from to g h rh rmst g' h' rh' rmst' v n,
+    0 <= Z.of_nat to < Zlength rh ->
+    vgeneration v <> from ->
+    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n)))
+       (nth_remset_space rh from) ->
+    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
+    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n)))
+       (nth_remset_space rh' to).
+Proof.
+  intros from to g h rh rmst g' h' rh' rmst' v n
+         Hrange Hgen Hin Hfrg.
+  unfold forward_remset_gh in Hfrg.
+  rewrite <- nth_remset_space_Znth in Hfrg.
+  eapply forward_remset_item_fold_records_nonfrom_interior; eauto.
+Qed.
+
 Lemma upd_remset_addr_ext_space_compatible:
   forall from to g addr rmst rh,
     0 <= Z.of_nat to < Zlength rh ->
@@ -9822,6 +10211,471 @@ Proof.
   eapply forward_remset_item_fold_gen_v_num_to; eassumption.
 Qed.
 
+Lemma forward_remset_item_clears_interior_edge:
+  forall from to g h rh rmst v n g' h' rh' rmst',
+    graph_has_gen g to ->
+    from <> to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    remset_graph_compatible g rmst ->
+    remset_item_compatible g from rmst
+      (RemSetInterior (InteriorVertexPos v (Z.of_nat n))) ->
+    vgeneration v <> from ->
+    (g', h', rh', rmst') =
+      forward_remset_item from to (g, h, rh, rmst)
+        (RemSetInterior (InteriorVertexPos v (Z.of_nat n))) ->
+    graph_has_e g' (v, n) ->
+    vgeneration (dst g' (v, n)) <> from.
+Proof.
+  intros from to g h rh rmst v n g' h' rh' rmst'
+         Hto Hneq Hcc Hndd Hrgc Hric Hsrc Hfri He.
+  unfold forward_remset_item in Hfri. simpl in Hfri.
+  destruct (Nat.eqb (vgeneration v) from) eqn:Hsrc_eq.
+  - apply Nat.eqb_eq in Hsrc_eq. contradiction.
+  - simpl in Hfri.
+  destruct (forward_graph_and_heap from to 0
+              (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h)
+    as [newg newh] eqn:Hfgh.
+  pose proof fr_forward_graph_and_heap
+       from to 0 (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h as Hfr.
+  rewrite Hfgh in Hfr. simpl in Hfr.
+  inversion Hfri; subst; clear Hfri.
+  pose proof (graph_has_e_Znth newg v n He) as [_ Hfield].
+  eapply (fr_O_dst_changed_field from to v n g newg); eauto.
+  simpl in Hric. destruct Hric as [Hv [Hrange Hmark]].
+  split; [exact Hv | split; [exact Hrange |]].
+  specialize (Hmark Hsrc). tauto.
+Qed.
+
+Lemma forward_remset_item_old_edge_graph_has_e_inv:
+  forall from to g h rh rmst item g' h' rh' rmst' v n bound,
+    graph_has_gen g to ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
+    graph_has_e g' (v, n) ->
+    graph_has_e g (v, n).
+Proof.
+  intros from to g h rh rmst item g' h' rh' rmst' v n bound
+         Hto Hold Hbound Hfri He.
+  unfold forward_remset_item in Hfri.
+  destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hitem.
+  - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
+      as [newg newh] eqn:Hfgh.
+    pose proof fr_forward_graph_and_heap
+         from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
+    rewrite Hfgh in Hfr. simpl in Hfr.
+    inversion Hfri; subst; clear Hfri.
+    eapply fr_O_old_edge_graph_has_e_inv; eauto.
+  - inversion Hfri; subst. exact He.
+Qed.
+
+Lemma forward_remset_item_old_edge_dst_eq_pres:
+  forall from to g h rh rmst item g' h' rh' rmst' v n bound,
+    graph_has_gen g to ->
+    graph_has_e g (v, n) ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    vgeneration (dst g (v, n)) <> from ->
+    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
+    dst g' (v, n) = dst g (v, n).
+Proof.
+  intros from to g h rh rmst item g' h' rh' rmst' v n bound
+         Hto He Hold Hbound Hdst Hfri.
+  unfold forward_remset_item in Hfri.
+  destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hitem.
+  - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
+      as [newg newh] eqn:Hfgh.
+    pose proof fr_forward_graph_and_heap
+         from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
+    rewrite Hfgh in Hfr. simpl in Hfr.
+    inversion Hfri; subst; clear Hfri.
+    eapply fr_O_old_edge_dst_eq_pres; eauto.
+  - inversion Hfri; subst. reflexivity.
+Qed.
+
+Lemma forward_remset_item_old_edge_dst_not_from_pres:
+  forall from to g h rh rmst item g' h' rh' rmst' v n bound,
+    graph_has_gen g to ->
+    from <> to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    graph_has_e g (v, n) ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    vgeneration (dst g (v, n)) <> from ->
+    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
+    vgeneration (dst g' (v, n)) <> from.
+Proof.
+  intros from to g h rh rmst item g' h' rh' rmst' v n bound
+         Hto _ _ _ He Hold Hbound Hdst Hfri.
+  rewrite (forward_remset_item_old_edge_dst_eq_pres
+             from to g h rh rmst item g' h' rh' rmst' v n bound
+             Hto He Hold Hbound Hdst Hfri).
+  exact Hdst.
+Qed.
+
+Lemma forward_remset_item_fold_old_edge_graph_has_e_inv:
+  forall from to bound r g h rh rmst g' h' rh' rmst' v n,
+    graph_has_gen g to ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    graph_has_e g' (v, n) ->
+    graph_has_e g (v, n).
+Proof.
+  intros from to bound r. induction r;
+    intros g h rh rmst g' h' rh' rmst' v n Hto Hold Hbound Hfold He.
+  - simpl in Hfold. inversion Hfold; subst. exact He.
+  - simpl in Hfold.
+    destruct (forward_remset_item from to (g, h, rh, rmst) a)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
+    rewrite <- Hfri in Hfold.
+    assert (Hto2: graph_has_gen g2 to) by
+        (rewrite <- (forward_remset_item_ghg from to g h rh rmst a g2 h2 rh2 rmst2
+                       Hto Hfri to); exact Hto).
+    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
+      pose proof (forward_remset_item_gen_v_num_to from to g h rh rmst a g2 h2 rh2 rmst2
+                    Hto Hfri).
+      lia.
+    }
+    pose proof (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' v n
+                  Hto2 Hold Hbound2 Hfold He) as He2.
+    eapply forward_remset_item_old_edge_graph_has_e_inv; eauto.
+Qed.
+
+Lemma forward_remset_item_fold_old_edge_dst_eq_pres:
+  forall from to bound r g h rh rmst g' h' rh' rmst' v n,
+    graph_has_gen g to ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    graph_has_e g (v, n) ->
+    vgeneration (dst g (v, n)) <> from ->
+    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    graph_has_e g' (v, n) ->
+    dst g' (v, n) = dst g (v, n).
+Proof.
+  intros from to bound r. induction r;
+    intros g h rh rmst g' h' rh' rmst' v n
+           Hto Hold Hbound He Hdst Hfold Hefinal.
+  - simpl in Hfold. inversion Hfold; subst. reflexivity.
+  - simpl in Hfold.
+    destruct (forward_remset_item from to (g, h, rh, rmst) a)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
+    rewrite <- Hfri in Hfold.
+    assert (Hto2: graph_has_gen g2 to) by
+        (rewrite <- (forward_remset_item_ghg from to g h rh rmst a
+                       g2 h2 rh2 rmst2 Hto Hfri to);
+         exact Hto).
+    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
+      pose proof (forward_remset_item_gen_v_num_to
+                    from to g h rh rmst a g2 h2 rh2 rmst2 Hto Hfri).
+      lia.
+    }
+    assert (He2: graph_has_e g2 (v, n)) by
+        (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
+                   from to bound r g2 h2 rh2 rmst2 g' h' rh' rmst' v n);
+         eauto).
+    assert (Hdst_step: dst g2 (v, n) = dst g (v, n)) by
+        (eapply (forward_remset_item_old_edge_dst_eq_pres
+                   from to g h rh rmst a g2 h2 rh2 rmst2 v n bound);
+         eauto).
+    rewrite (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' v n
+               Hto2 Hold Hbound2 He2 ltac:(rewrite Hdst_step; exact Hdst)
+               Hfold Hefinal).
+    exact Hdst_step.
+Qed.
+
+Lemma forward_remset_item_fold_recorded_old_edge_dst_to:
+  forall from to bound r g h rh rmst g' h' rh' rmst' v n,
+    from <> to ->
+    graph_has_gen g to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    remset_nodup rmst ->
+    remset_graph_compatible g rmst ->
+    remset_and_remset_space_compatible g from rmst r ->
+    copied_to_compatible from to g ->
+    graph_has_e g (v, n) ->
+    vgeneration v <> from ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    vgeneration (dst g (v, n)) = from ->
+    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n))) r ->
+    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    graph_has_e g' (v, n) ->
+    vgeneration (dst g' (v, n)) = to.
+Proof.
+  intros from to bound r. induction r as [|item rest IH];
+    intros g h rh rmst g' h' rh' rmst' v n
+           Hneq Hto Hcc Hndd Hrnd Hrgc Hrrsc Hct He Hsrc Hold Hbound Hdst
+           Hin Hfold Hefinal.
+  - contradiction.
+  - simpl in Hfold. hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
+    destruct Hrrsc as [Hrica Hricr].
+    destruct (forward_remset_item from to (g, h, rh, rmst) item)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    fold (forward_remset_item from to (g, h, rh, rmst) item) in Hfold.
+    rewrite <- Hfri in Hfold.
+    destruct (forward_remset_item_step_facts
+                from to g h rh rmst item rest g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hrnd Hrgc Hrica Hricr Hfri)
+      as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
+    assert (Hndd2: no_dangling_dst g2) by
+        exact (fri_no_dangling_dst from to g h rh rmst item g2 h2 rh2 rmst2
+                 Hto Hcc Hrgc Hrica Hndd Hfri).
+    assert (Hct2: copied_to_compatible from to g2) by
+        exact (forward_remset_item_copied_to_compatible
+                 from to g h rh rmst item g2 h2 rh2 rmst2 Hneq Hto Hct Hfri).
+    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
+      pose proof (forward_remset_item_gen_v_num_to
+                    from to g h rh rmst item g2 h2 rh2 rmst2 Hto Hfri).
+      lia.
+    }
+    assert (He2: graph_has_e g2 (v, n)) by
+        (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
+                   from to bound rest g2 h2 rh2 rmst2 g' h' rh' rmst' v n);
+         eauto).
+    destruct item as [addr | [v0 pos]].
+    + destruct Hin as [Hhead | Htail]; [inversion Hhead |].
+      assert (Hdst2_eq: dst g2 (v, n) = dst g (v, n)) by
+          (eapply forward_remset_item_nonrecorded_edge_dst_eq;
+           [exact Hto | exact Hrica | exact He | discriminate | exact Hfri]).
+      eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst' v n); eauto.
+      rewrite Hdst2_eq. exact Hdst.
+    + destruct (V_EqDec v0 v) as [Hv | Hv].
+      * hnf in Hv. subst v0.
+        destruct (Z.eq_dec pos (Z.of_nat n)) as [Hp | Hp].
+        -- subst pos.
+           assert (Hdst2_to: vgeneration (dst g2 (v, n)) = to) by
+               (eapply (forward_remset_item_recorded_edge_dst_to
+                          from to g h rh rmst g2 h2 rh2 rmst2 v n);
+                [exact Hndd | exact Hct | exact He | exact Hdst | exact Hsrc | exact Hfri]).
+           assert (Hfinal_eq: dst g' (v, n) = dst g2 (v, n)) by
+               (eapply (forward_remset_item_fold_old_edge_dst_eq_pres
+                          from to bound rest g2 h2 rh2 rmst2
+                          g' h' rh' rmst' v n); eauto;
+                rewrite Hdst2_to; lia).
+           rewrite Hfinal_eq. exact Hdst2_to.
+        -- destruct Hin as [Hhead | Htail].
+           ++ inversion Hhead; subst. contradiction.
+           ++ assert (Hnot_item:
+                        RemSetInterior (InteriorVertexPos v pos) <>
+                        RemSetInterior (InteriorVertexPos v (Z.of_nat n))) by
+                  (intro Hbad; inversion Hbad; contradiction).
+              assert (Hdst2_eq: dst g2 (v, n) = dst g (v, n)) by
+                  (eapply forward_remset_item_nonrecorded_edge_dst_eq;
+                   [exact Hto | exact Hrica | exact He | exact Hnot_item | exact Hfri]).
+              eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst' v n); eauto.
+              rewrite Hdst2_eq. exact Hdst.
+      * destruct Hin as [Hhead | Htail].
+        -- inversion Hhead; subst. exfalso. apply Hv. hnf. reflexivity.
+        -- assert (Hnot_item:
+                     RemSetInterior (InteriorVertexPos v0 pos) <>
+                     RemSetInterior (InteriorVertexPos v (Z.of_nat n))) by
+               (intro Hbad; inversion Hbad; subst; apply Hv; hnf; reflexivity).
+           assert (Hdst2_eq: dst g2 (v, n) = dst g (v, n)) by
+               (eapply forward_remset_item_nonrecorded_edge_dst_eq;
+                [exact Hto | exact Hrica | exact He | exact Hnot_item | exact Hfri]).
+           eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst' v n); eauto.
+           rewrite Hdst2_eq. exact Hdst.
+Qed.
+
+Lemma forward_remset_gh_recorded_old_edge_dst_to:
+  forall from to bound g h rh rmst g' h' rh' rmst' outlier v n,
+    from <> to ->
+    graph_has_gen g to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    remset_nodup rmst ->
+    remset_compatible g outlier from rmst rh h ->
+    copied_to_compatible from to g ->
+    graph_has_e g (v, n) ->
+    vgeneration v <> from ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    vgeneration (dst g (v, n)) = from ->
+    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n)))
+       (nth_remset_space rh from) ->
+    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
+    graph_has_e g' (v, n) ->
+    vgeneration (dst g' (v, n)) = to.
+Proof.
+  intros from to bound g h rh rmst g' h' rh' rmst' outlier v n
+         Hneq Hto Hcc Hndd Hrnd Hremc Hct He Hsrc Hold Hbound Hdst Hin Hfrg Hefinal.
+  destruct Hremc as [Hrgoc [Hrrhc _]].
+  assert (Hrgc: remset_graph_compatible g rmst) by
+      (eapply remset_graph_outlier_compatible_weakened; exact Hrgoc).
+  assert (Hrrsc:
+            remset_and_remset_space_compatible g from rmst
+              (Znth (Z.of_nat from) rh)) by
+      (eapply rrhc_forall_rrsc; exact Hrrhc).
+  unfold forward_remset_gh in Hfrg.
+  rewrite nth_remset_space_Znth in Hin.
+  eapply forward_remset_item_fold_recorded_old_edge_dst_to; eauto.
+Qed.
+
+Lemma forward_remset_item_fold_old_edge_dst_not_from_pres:
+  forall from to bound r g h rh rmst g' h' rh' rmst' v n,
+    from <> to ->
+    graph_has_gen g to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    remset_nodup rmst ->
+    remset_graph_compatible g rmst ->
+    remset_and_remset_space_compatible g from rmst r ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    graph_has_e g (v, n) ->
+    vgeneration (dst g (v, n)) <> from ->
+    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    graph_has_e g' (v, n) ->
+    vgeneration (dst g' (v, n)) <> from.
+Proof.
+  intros from to bound r. induction r;
+    intros g h rh rmst g' h' rh' rmst' v n
+           Hneq Hto Hcc Hndd Hrnd Hrgc Hrrsc Hold Hbound He Hdst Hfold Hefinal.
+  - simpl in Hfold. inversion Hfold; subst. exact Hdst.
+  - simpl in Hfold. hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
+    destruct Hrrsc as [Hrica Hricr].
+    destruct (forward_remset_item from to (g, h, rh, rmst) a)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
+    rewrite <- Hfri in Hfold.
+    destruct (forward_remset_item_step_facts
+                from to g h rh rmst a r g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hrnd Hrgc Hrica Hricr Hfri)
+      as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
+    assert (Hndd2: no_dangling_dst g2) by
+        exact (fri_no_dangling_dst from to g h rh rmst a g2 h2 rh2 rmst2
+                 Hto Hcc Hrgc Hrica Hndd Hfri).
+    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
+      pose proof (forward_remset_item_gen_v_num_to from to g h rh rmst a g2 h2 rh2 rmst2
+                    Hto Hfri).
+      lia.
+    }
+    assert (He2: graph_has_e g2 (v, n)) by
+        (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
+                   from to bound r g2 h2 rh2 rmst2 g' h' rh' rmst' v n);
+         eauto).
+    assert (Hdst2: vgeneration (dst g2 (v, n)) <> from) by
+        (eapply (forward_remset_item_old_edge_dst_not_from_pres
+                   from to g h rh rmst a g2 h2 rh2 rmst2 v n bound);
+         eauto).
+    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' v n); eauto.
+Qed.
+
+Lemma forward_remset_item_fold_clears_recorded_old_edge:
+  forall from to bound r g h rh rmst g' h' rh' rmst' v n,
+    from <> to ->
+    graph_has_gen g to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    remset_nodup rmst ->
+    remset_graph_compatible g rmst ->
+    remset_and_remset_space_compatible g from rmst r ->
+    vgeneration v <> from ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    In (RemSetInterior (InteriorVertexPos v (Z.of_nat n))) r ->
+    (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    graph_has_e g' (v, n) ->
+    vgeneration (dst g' (v, n)) <> from.
+Proof.
+  intros from to bound r. induction r;
+    intros g h rh rmst g' h' rh' rmst' v n
+           Hneq Hto Hcc Hndd Hrnd Hrgc Hrrsc Hsrc Hold Hbound Hin Hfold Hefinal.
+  - contradiction.
+  - simpl in Hfold. simpl in Hin. hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
+    destruct Hrrsc as [Hrica Hricr].
+    destruct (forward_remset_item from to (g, h, rh, rmst) a)
+      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
+    symmetry in Hfri.
+    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
+    rewrite <- Hfri in Hfold.
+    destruct (forward_remset_item_step_facts
+                from to g h rh rmst a r g2 h2 rh2 rmst2
+                Hneq Hto Hcc Hrnd Hrgc Hrica Hricr Hfri)
+      as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
+    assert (Hndd2: no_dangling_dst g2) by
+        exact (fri_no_dangling_dst from to g h rh rmst a g2 h2 rh2 rmst2
+                 Hto Hcc Hrgc Hrica Hndd Hfri).
+    assert (Hbound2: (bound <= gen_v_num g2 to)%nat). {
+      pose proof (forward_remset_item_gen_v_num_to from to g h rh rmst a g2 h2 rh2 rmst2
+                    Hto Hfri).
+      lia.
+    }
+    destruct Hin as [Hhead | Htail].
+    + subst a.
+      assert (He2: graph_has_e g2 (v, n)) by
+          (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
+                     from to bound r g2 h2 rh2 rmst2 g' h' rh' rmst' v n);
+           eauto).
+      assert (Hclear2: vgeneration (dst g2 (v, n)) <> from) by
+          (eapply (forward_remset_item_clears_interior_edge
+                     from to g h rh rmst v n g2 h2 rh2 rmst2);
+           eauto).
+      eapply (forward_remset_item_fold_old_edge_dst_not_from_pres
+                from to bound r g2 h2 rh2 rmst2 g' h' rh' rmst' v n);
+        eauto.
+    + eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' v n); eauto.
+Qed.
+
+Lemma forward_remset_gh_old_edge_dst_not_from:
+  forall from to bound g h rh rmst g' h' rh' rmst' outlier v n,
+    from <> to ->
+    graph_has_gen g to ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    firstn_gen_clear g from ->
+    no_unrecorded_backward_edge g rh ->
+    remset_nodup rmst ->
+    remset_compatible g outlier from rmst rh h ->
+    vgeneration v <> from ->
+    (vgeneration v <> to \/ (vgeneration v = to /\ (vindex v < bound)%nat)) ->
+    (bound <= gen_v_num g to)%nat ->
+    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
+    graph_has_e g' (v, n) ->
+    vgeneration (dst g' (v, n)) <> from.
+Proof.
+  intros from to bound g h rh rmst g' h' rh' rmst' outlier v n
+         Hneq Hto Hcc Hndd Hfirst Hunrec Hrnd Hremc Hsrc Hold Hbound Hfrg Hefinal.
+  destruct Hremc as [Hrgoc [Hrrhc _]].
+  assert (Hrgc: remset_graph_compatible g rmst) by
+      (eapply remset_graph_outlier_compatible_weakened; eassumption).
+  assert (Hrrsc: remset_and_remset_space_compatible g from rmst (Znth (Z.of_nat from) rh)) by
+      (eapply rrhc_forall_rrsc; exact Hrrhc).
+  unfold forward_remset_gh in Hfrg.
+  assert (He_initial: graph_has_e g (v, n)) by
+      (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
+                 from to bound (Znth (Z.of_nat from) rh)
+                 g h rh rmst g' h' rh' rmst' v n);
+       eauto).
+  destruct (Nat.eq_dec (vgeneration (dst g (v, n))) from) as [Hdst_from | Hdst_not].
+  - assert (Hin: In (RemSetInterior (InteriorVertexPos v (Z.of_nat n)))
+                  (Znth (Z.of_nat from) rh)). {
+      rewrite <- nth_remset_space_Znth.
+      assert (Hegen: egeneration (v, n) <> from) by
+          (unfold egeneration; simpl; exact Hsrc).
+      exact (no_unrecorded_backward_edge_current_remset
+               g rh from (v, n) Hfirst Hunrec He_initial Hegen Hdst_from).
+    }
+    eapply (forward_remset_item_fold_clears_recorded_old_edge
+              from to bound (Znth (Z.of_nat from) rh)
+              g h rh rmst g' h' rh' rmst' v n);
+      eauto.
+  - eapply (forward_remset_item_fold_old_edge_dst_not_from_pres
+              from to bound (Znth (Z.of_nat from) rh)
+              g h rh rmst g' h' rh' rmst' v n);
+      eauto.
+Qed.
+
 Lemma forward_remset_item_prefix_no_edge2gen_old_to:
   forall from to g h rh rmst item g' h' rh' rmst' bound,
     graph_has_gen g to -> from <> to -> copy_compatible g -> no_dangling_dst g ->
@@ -10160,13 +11014,13 @@ Proof.
   eapply rrhc_forall_rrsc; exact Hrrhc.
 Qed.
 
-Lemma do_generation_relation_no_dangling_dst:
+Lemma do_generation_relation_no_dangling_dst_unrecorded:
   forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier,
     graph_has_gen g (S i) ->
     graph_unmarked g ->
     copy_compatible g ->
     no_dangling_dst g ->
-    no_backward_edge g ->
+    no_unrecorded_backward_edge g rh ->
     firstn_gen_clear g i ->
     roots_graph_compatible roots g ->
     remset_nodup rmst ->
@@ -10176,21 +11030,12 @@ Lemma do_generation_relation_no_dangling_dst:
     no_dangling_dst g'.
 Proof.
   intros g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier
-         Hto Hungraph Hcc Hndd Hnbe Hfirst Hrgc Hrnd Hremc Hrel.
+         Hto Hungraph Hcc Hndd Hunrec Hfirst Hrgc Hrnd Hremc Hrel.
   destruct Hrel as [[g1 [g2 [Hfrg [Hfrr [Hscan Hreset]]]]] _].
   assert (Hneq: i <> S i) by lia.
   assert (Hneq': S i <> i) by lia.
   assert (Hun_to: gen_unmarked g (S i)) by
       (rewrite graph_gen_unmarked_iff in Hungraph; apply Hungraph).
-  assert (Hnoedge_g: no_edge2gen g i) by (eapply fgc_nbe_no_edge2gen; eauto).
-  assert (Hprefix_g: forall vidx eidx : nat,
-             (vidx < gen_v_num g (S i))%nat ->
-             graph_has_e g (S i, vidx, eidx) ->
-             vgeneration (dst g (S i, vidx, eidx)) <> i). {
-    intros vidx eidx _ He.
-    unfold no_edge2gen in Hnoedge_g. specialize (Hnoedge_g (S i) Hneq').
-    unfold gen2gen_no_edge in Hnoedge_g. apply Hnoedge_g. exact He.
-  }
   assert (Hto_rem: graph_has_gen g_rem (S i)) by
       (rewrite <- (forward_remset_gh_graph_has_gen i (S i) g h rh rmst
                      g_rem h_rem rh' rmst' Hto Hfrg (S i)); exact Hto).
@@ -10211,17 +11056,27 @@ Proof.
   assert (Hprefix_rem: forall vidx eidx : nat,
              (vidx < gen_v_num g (S i))%nat ->
              graph_has_e g_rem (S i, vidx, eidx) ->
-             vgeneration (dst g_rem (S i, vidx, eidx)) <> i) by
-      exact (forward_remset_gh_prefix_no_edge2gen_old_to
-               i (S i) g h rh rmst g_rem h_rem rh' rmst' outlier
-               (gen_v_num g (S i)) Hneq Hto Hcc Hndd Hrnd Hremc
-               (le_n _) Hprefix_g Hfrg).
+             vgeneration (dst g_rem (S i, vidx, eidx)) <> i). {
+    intros vidx eidx Hvidx He.
+    refine (forward_remset_gh_old_edge_dst_not_from
+              i (S i) (gen_v_num g (S i)) g h rh rmst
+              g_rem h_rem rh' rmst' outlier (S i, vidx) eidx
+              Hneq Hto Hcc Hndd Hfirst Hunrec Hrnd Hremc _ _ _ Hfrg He).
+    { simpl. lia. }
+    { right. split; simpl; [reflexivity | exact Hvidx]. }
+    { lia. }
+  }
   assert (Hother_rem: forall another : nat,
              another <> i -> another <> S i -> gen2gen_no_edge g_rem another i). {
     intros another Hanother Hnot_to.
-    exact (forward_remset_gh_gen2gen_no_edge2from_not_to
-             i (S i) g h rh rmst g_rem h_rem rh' rmst' outlier another
-             Hneq Hto Hcc Hndd Hrnd Hremc Hnot_to (Hnoedge_g another Hanother) Hfrg).
+    unfold gen2gen_no_edge. intros vidx eidx He.
+    refine (forward_remset_gh_old_edge_dst_not_from
+              i (S i) (gen_v_num g (S i)) g h rh rmst
+              g_rem h_rem rh' rmst' outlier (another, vidx) eidx
+              Hneq Hto Hcc Hndd Hfirst Hunrec Hrnd Hremc _ _ _ Hfrg He).
+    { simpl. exact Hanother. }
+    { left. simpl. exact Hnot_to. }
+    { lia. }
   }
   assert (Hto1: graph_has_gen g1 (S i)) by
       (rewrite <- (frr_graph_has_gen i (S i) roots g_rem roots' g1 Hto_rem Hfrr (S i));
@@ -10290,6 +11145,231 @@ Proof.
       eauto; try lia.
   }
   subst g'. apply firstn_gen_clear_reset. assumption.
+Qed.
+
+Lemma do_generation_relation_no_unrecorded_backward_edge_reset:
+  forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier,
+    graph_has_gen g (S i) ->
+    graph_unmarked g ->
+    copy_compatible g ->
+    no_dangling_dst g ->
+    no_unrecorded_backward_edge g rh ->
+    firstn_gen_clear g i ->
+    roots_graph_compatible roots g ->
+    remset_nodup rmst ->
+    remset_compatible g outlier i rmst rh h ->
+    firstn_gen_clear g' (S i) ->
+    no_dangling_dst g' ->
+    0 <= Z.of_nat (S i) < Zlength rh ->
+    do_generation_relation i (S i) roots roots' g h rh rmst
+      g_rem h_rem rh' rmst' g' h' ->
+    no_unrecorded_backward_edge g' (reset_nth_remset_heap i rh').
+Proof.
+  intros g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier
+         Hto Hun Hcc Hndd Hunrec Hfirst Hroots Hrnd Hremc Hfirst' Hndd'
+         Hrange_to Hrel.
+  destruct Hrel as [[g1 [g2 [Hfrg [Hfrr [Hscan Hreset]]]]] _].
+  subst g'.
+  unfold no_unrecorded_backward_edge.
+  intros e He Hback.
+  rewrite graph_has_e_reset in He.
+  destruct He as [He_scan Hsrc_not_from].
+  simpl in Hback |- *.
+  rewrite remove_ve_dst_unchanged in Hback |- *.
+  destruct (lt_dec (vgeneration (dst g2 e)) (S i)) as [Hdst_lt | Hdst_ge].
+  - exfalso.
+    assert (Hdst_has:
+              graph_has_v (reset_graph i g2)
+                (dst (reset_graph i g2) e)). {
+      destruct e as [src idx].
+      destruct He_scan as [Hsrc Hfield].
+      eapply Hndd'.
+      - rewrite graph_has_v_reset.
+        split; [exact Hsrc |].
+        intro Hbad.
+        apply Hsrc_not_from.
+        unfold egeneration.
+        now rewrite Hbad.
+      - rewrite get_edges_reset. exact Hfield.
+    }
+    unfold firstn_gen_clear, graph_gen_clear in Hfirst'.
+    change (dst (reset_graph i g2) e) with
+      (dst (remove_nth_gen_ve g2 i) e) in Hdst_has.
+    rewrite remove_ve_dst_unchanged in Hdst_has.
+    destruct (dst g2 e) as [dgen didx].
+    simpl in *.
+    destruct Hdst_has as [_ Hdst_idx].
+    unfold gen_has_index in Hdst_idx. simpl in Hdst_idx.
+    specialize (Hfirst' dgen Hdst_lt).
+    rewrite Hfirst' in Hdst_idx. lia.
+  - rewrite reset_nth_remset_heap_diff by lia.
+    assert (Hsrc_gt_to: (S i < egeneration e)%nat) by lia.
+    assert (Hneq: i <> S i) by lia.
+    assert (Hneq': S i <> i) by lia.
+    assert (Hun_to: gen_unmarked g (S i)) by
+        (rewrite graph_gen_unmarked_iff in Hun; apply Hun).
+    assert (Hct: copied_to_compatible i (S i) g) by
+        (apply graph_unmarked_copied_to_compatible; exact Hun).
+    assert (Hto_rem: graph_has_gen g_rem (S i)) by
+        (rewrite <- (forward_remset_gh_graph_has_gen i (S i) g h rh rmst
+                       g_rem h_rem rh' rmst' Hto Hfrg (S i)); exact Hto).
+    assert (Hcc_rem: copy_compatible g_rem) by
+        exact (forward_remset_gh_copy_compatible i (S i) g h rh rmst
+                 g_rem h_rem rh' rmst' Hneq Hto Hcc Hfrg).
+    assert (Hndd_rem: no_dangling_dst g_rem) by
+        exact (forward_remset_gh_no_dangling_dst i (S i) g h rh rmst
+                 g_rem h_rem rh' rmst' outlier Hneq Hto Hcc Hndd Hrnd Hremc Hfrg).
+    assert (Hroots_rem: roots_graph_compatible roots g_rem) by
+        exact (forward_remset_gh_roots_graph_compatible
+                 i (S i) g h rh rmst g_rem h_rem rh' rmst' roots outlier
+                 Hneq Hto Hcc Hrnd Hremc Hfrg Hroots).
+    assert (Hun_rem: gen_unmarked g_rem (S i)) by
+        exact (forward_remset_gh_gen_unmarked i (S i) g h rh rmst
+                 g_rem h_rem rh' rmst' (S i) Hto Hneq Hfrg Hun_to).
+    assert (Hto1: graph_has_gen g1 (S i)) by
+        (rewrite <- (frr_graph_has_gen i (S i) roots g_rem roots' g1
+                       Hto_rem Hfrr (S i)); exact Hto_rem).
+    assert (Hun1: gen_unmarked g1 (S i)) by
+        exact (frr_gen_unmarked i (S i) roots g_rem roots' g1
+                 Hto_rem Hfrr (S i) Hneq' Hun_rem).
+    destruct Hscan as [nscan [Hsvwl Hscan_bound]].
+    assert (Hsrc1: graph_has_v g1 (fst e)). {
+      pose proof (svwl_graph_has_v_inv
+                    i (S i) (seq (gen_v_num g (S i)) nscan)
+                    g1 g2 Hto1 Hsvwl (fst e) (proj1 He_scan)) as Hinv.
+      destruct Hinv as [Hsrc1 | [Hgen_new _]]; [exact Hsrc1 |].
+      unfold egeneration in Hsrc_gt_to.
+      rewrite Hgen_new in Hsrc_gt_to. lia.
+    }
+    assert (Hdst1_scan: dst g1 e = dst g2 e). {
+      eapply svwl_dst_unchanged; eauto.
+      intros Hsrc_to _.
+      unfold egeneration in Hsrc_gt_to.
+      rewrite Hsrc_to in Hsrc_gt_to. lia.
+    }
+    assert (He1: graph_has_e g1 e). {
+      destruct He_scan as [_ Hfield_scan].
+      split; [exact Hsrc1 |].
+      unfold get_edges, make_fields in Hfield_scan |- *.
+      rewrite (svwl_raw_fields
+                 i (S i) (seq (gen_v_num g (S i)) nscan)
+                 g1 g2 Hto1 Hsvwl (fst e) Hsrc1).
+      exact Hfield_scan.
+    }
+    assert (Hsrc_rem: graph_has_v g_rem (fst e)). {
+      pose proof (frr_graph_has_v_inv i (S i) roots g_rem roots' g1
+                    Hto_rem Hfrr (fst e) Hsrc1) as Hinv.
+      destruct Hinv as [Hsrc_rem | [Hgen_new _]]; [exact Hsrc_rem |].
+      unfold egeneration in Hsrc_gt_to.
+      rewrite Hgen_new in Hsrc_gt_to. lia.
+    }
+    assert (Hdst_rem_1: dst g_rem e = dst g1 e) by
+        (eapply frr_dst_unchanged; eauto).
+    assert (He_rem: graph_has_e g_rem e). {
+      destruct He1 as [_ Hfield1].
+      split; [exact Hsrc_rem |].
+      unfold get_edges, make_fields in Hfield1 |- *.
+      rewrite (frr_raw_fields i (S i) roots g_rem roots' g1
+                 Hto_rem Hfrr (fst e) Hsrc_rem).
+      exact Hfield1.
+    }
+    assert (He_g: graph_has_e g e). {
+      unfold forward_remset_gh in Hfrg.
+      assert (He_rem_pair: graph_has_e g_rem (fst e, snd e)) by
+          (replace (fst e, snd e) with e by (destruct e; reflexivity);
+           exact He_rem).
+      assert (He_g_pair: graph_has_e g (fst e, snd e)) by
+          (eapply (forward_remset_item_fold_old_edge_graph_has_e_inv
+                     i (S i) (gen_v_num g (S i)) (Znth (Z.of_nat i) rh)
+                     g h rh rmst g_rem h_rem rh' rmst' (fst e) (snd e));
+           [exact Hto
+           | left; unfold egeneration in Hsrc_gt_to; lia
+           | lia
+           | exact Hfrg
+           | exact He_rem_pair]).
+      replace (fst e, snd e) with e in He_g_pair by (destruct e; reflexivity).
+      exact He_g_pair.
+    }
+    assert (Hdst_rem_scan: dst g_rem e = dst g2 e) by congruence.
+    assert (Hsrc_not_i: egeneration e <> i) by lia.
+    destruct (Nat.eq_dec (vgeneration (dst g e)) i) as [Hdst_from | Hdst_not_from].
+    + assert (Hin_old:
+                In (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e))))
+                   (nth_remset_space rh i)) by
+          (eapply no_unrecorded_backward_edge_current_remset; eauto).
+      assert (Hdst_rem_to: vgeneration (dst g_rem e) = S i). {
+        assert (He_g_pair: graph_has_e g (fst e, snd e)) by
+            (replace (fst e, snd e) with e by (destruct e; reflexivity);
+             exact He_g).
+        assert (He_rem_pair: graph_has_e g_rem (fst e, snd e)) by
+            (replace (fst e, snd e) with e by (destruct e; reflexivity);
+             exact He_rem).
+        assert (Hdst_from_pair:
+                  vgeneration (dst g (fst e, snd e)) = i) by
+            (replace (fst e, snd e) with e by (destruct e; reflexivity);
+             exact Hdst_from).
+        assert (Hdst_rem_to_pair:
+                  vgeneration (dst g_rem (fst e, snd e)) = S i) by
+            (eapply (forward_remset_gh_recorded_old_edge_dst_to
+                       i (S i) (gen_v_num g (S i)) g h rh rmst
+                       g_rem h_rem rh' rmst' outlier (fst e) (snd e));
+             [exact Hneq
+             | exact Hto
+             | exact Hcc
+             | exact Hndd
+             | exact Hrnd
+             | exact Hremc
+             | exact Hct
+             | exact He_g_pair
+             | unfold egeneration in Hsrc_gt_to; lia
+             | left; unfold egeneration in Hsrc_gt_to; lia
+             | lia
+             | exact Hdst_from_pair
+             | exact Hin_old
+             | exact Hfrg
+             | exact He_rem_pair]).
+        replace (fst e, snd e) with e in Hdst_rem_to_pair by
+            (destruct e; reflexivity).
+        exact Hdst_rem_to_pair.
+      }
+      rewrite <- Hdst_rem_scan.
+      rewrite Hdst_rem_to.
+      eapply forward_remset_gh_records_nonfrom_interior; eauto.
+    + assert (Hdst_rem_g: dst g_rem e = dst g e). {
+        unfold forward_remset_gh in Hfrg.
+        assert (He_g_pair: graph_has_e g (fst e, snd e)) by
+            (replace (fst e, snd e) with e by (destruct e; reflexivity);
+             exact He_g).
+        assert (He_rem_pair: graph_has_e g_rem (fst e, snd e)) by
+            (replace (fst e, snd e) with e by (destruct e; reflexivity);
+             exact He_rem).
+        assert (Hdst_not_pair:
+                  vgeneration (dst g (fst e, snd e)) <> i) by
+            (replace (fst e, snd e) with e by (destruct e; reflexivity);
+             exact Hdst_not_from).
+        assert (Hdst_rem_g_pair:
+                  dst g_rem (fst e, snd e) = dst g (fst e, snd e)) by
+            (eapply (forward_remset_item_fold_old_edge_dst_eq_pres
+                       i (S i) (gen_v_num g (S i)) (Znth (Z.of_nat i) rh)
+                       g h rh rmst g_rem h_rem rh' rmst' (fst e) (snd e));
+             [exact Hto
+             | left; unfold egeneration in Hsrc_gt_to; lia
+             | lia
+             | exact He_g_pair
+             | exact Hdst_not_pair
+             | exact Hfrg
+             | exact He_rem_pair]).
+        replace (fst e, snd e) with e in Hdst_rem_g_pair by
+            (destruct e; reflexivity).
+        exact Hdst_rem_g_pair.
+      }
+      assert (Hback_g: (egeneration e > vgeneration (dst g e))%nat). {
+        rewrite <- Hdst_rem_g.
+        rewrite Hdst_rem_scan. exact Hback.
+      }
+      rewrite <- Hdst_rem_scan.
+      rewrite Hdst_rem_g.
+      eapply forward_remset_gh_preserves_remset_entry; eauto.
 Qed.
 
 Lemma do_generation_relation_graph_unmarked:
@@ -10480,86 +11560,13 @@ Proof.
   eapply rrhc_forall_rrsc; exact Hrrhc.
 Qed.
 
-Lemma do_generation_relation_no_backward_edge:
-  forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier,
-    graph_has_gen g (S i) ->
-    graph_unmarked g ->
-    copy_compatible g ->
-    no_dangling_dst g ->
-    no_backward_edge g ->
-    firstn_gen_clear g i ->
-    roots_graph_compatible roots g ->
-    remset_nodup rmst ->
-    remset_compatible g outlier i rmst rh h ->
-    do_generation_relation i (S i) roots roots' g h rh rmst
-      g_rem h_rem rh' rmst' g' h' ->
-    no_backward_edge g'.
-Proof.
-  intros g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier
-         Hto Hungraph Hcc Hndd Hnbe Hfirst Hrgc Hrnd Hremc Hrel.
-  assert (Hndd_final: no_dangling_dst g') by
-      (eapply do_generation_relation_no_dangling_dst; eauto).
-  assert (Hfirst_final: firstn_gen_clear g' (S i)) by
-      (eapply do_generation_relation_firstn_gen_clear; eauto).
-  unfold no_backward_edge. intros gen1 gen2 Hgt.
-  destruct (le_lt_dec gen1 (S i)) as [Hle | Hgtto].
-  - unfold gen2gen_no_edge. intros vidx eidx He Hbad.
-    destruct He as [Hsrc Hin].
-    pose proof (Hndd_final _ Hsrc _ Hin) as Hdst.
-    destruct (dst g' (gen1, vidx, eidx)) as [dgen didx] eqn:Hdstv.
-    simpl in Hbad. subst dgen. simpl in Hdst.
-    assert (Hgen2_lt: (gen2 < S i)%nat) by lia.
-    unfold firstn_gen_clear in Hfirst_final.
-    specialize (Hfirst_final _ Hgen2_lt).
-    unfold graph_gen_clear in Hfirst_final.
-    destruct Hdst as [_ Hidx].
-    unfold gen_has_index in Hidx. simpl in Hidx.
-    rewrite Hfirst_final in Hidx. lia.
-  - destruct Hrel as [[g1 [g2 [Hfrg [Hfrr [Hscan Hreset]]]]] _].
-    subst g'. apply gen2gen_no_edge_reset.
-    assert (Hneq: i <> S i) by lia.
-    assert (Hneq': S i <> i) by lia.
-    assert (Hun_to: gen_unmarked g (S i)) by
-        (rewrite graph_gen_unmarked_iff in Hungraph; apply Hungraph).
-    assert (Hto_rem: graph_has_gen g_rem (S i)) by
-        (rewrite <- (forward_remset_gh_graph_has_gen i (S i) g h rh rmst
-                       g_rem h_rem rh' rmst' Hto Hfrg (S i)); exact Hto).
-    assert (Hun_rem: gen_unmarked g_rem (S i)) by
-        exact (forward_remset_gh_gen_unmarked i (S i) g h rh rmst
-                 g_rem h_rem rh' rmst' (S i) Hto Hneq Hfrg Hun_to).
-    assert (Hto1: graph_has_gen g1 (S i)) by
-        (rewrite <- (frr_graph_has_gen i (S i) roots g_rem roots' g1 Hto_rem Hfrr (S i));
-         exact Hto_rem).
-    assert (Hun1: gen_unmarked g1 (S i)) by
-        exact (frr_gen_unmarked i (S i) roots g_rem roots' g1
-                 Hto_rem Hfrr (S i) Hneq' Hun_rem).
-    assert (Hrem_src: forall dst_gen : nat,
-               (dst_gen < gen1)%nat -> gen2gen_no_edge g_rem gen1 dst_gen). {
-      intros dst_gen Hdst.
-      exact (forward_remset_gh_gen2gen_no_edge_gt_to_source
-               i (S i) g h rh rmst g_rem h_rem rh' rmst' outlier gen1 dst_gen
-               Hneq Hto Hcc Hndd Hrnd Hremc
-               (fun dst_gen0 Hdst0 => Hnbe gen1 dst_gen0 Hdst0)
-               (Hnbe gen1 i ltac:(lia)) Hgtto Hdst Hfrg).
-    }
-    assert (Hfrr_src: forall dst_gen : nat,
-               (dst_gen < gen1)%nat -> gen2gen_no_edge g1 gen1 dst_gen). {
-      intros dst_gen Hdst.
-      exact (frr_gen2gen_no_edge i (S i) roots g_rem roots' g1
-               Hto_rem Hfrr gen1 dst_gen ltac:(lia) (Hrem_src dst_gen Hdst)).
-    }
-    destruct Hscan as [n [Hscan _]].
-    eapply (svwl_gen2gen_no_edge i (S i) (seq (number_of_vertices (nth_gen g (S i))) n) g1 g2);
-      eauto; try lia.
-Qed.
-
 Lemma do_generation_relation_gcc:
   forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier,
     graph_has_gen g (S i) ->
     graph_unmarked g ->
     copy_compatible g ->
     no_dangling_dst g ->
-    no_backward_edge g ->
+    no_unrecorded_backward_edge g rh ->
     firstn_gen_clear g i ->
     roots_graph_compatible roots g ->
     remset_nodup rmst ->
@@ -10571,11 +11578,10 @@ Lemma do_generation_relation_gcc:
     garbage_collect_condition g' h'.
 Proof.
   intros g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i outlier
-         Hto Hun Hcc Hndd Hnbe Hfirst Hrgc Hrnd Hremc Hwhr Hsize Hrel.
-  split; [|split; [|split]].
+         Hto Hun Hcc Hndd Hunrec Hfirst Hrgc Hrnd Hremc Hwhr Hsize Hrel.
+  split; [|split].
   - eapply do_generation_relation_graph_unmarked; eauto.
-  - eapply do_generation_relation_no_backward_edge; eauto.
-  - eapply do_generation_relation_no_dangling_dst; eauto.
+  - eapply do_generation_relation_no_dangling_dst_unrecorded; eauto.
   - eapply weak_heap_relation_size_spec; eauto.
 Qed.
 
@@ -10591,6 +11597,30 @@ Definition new_gen_heap_relation
       used_space sp = 0 /\
       g' = lgraph_add_new_gen g gi /\
       h' = add_new_space h sp i Hs.
+
+Lemma new_gen_heap_no_unrecorded_backward_edge_pres:
+  forall g1 h1 g2 h2 rh gen,
+    no_unrecorded_backward_edge g1 rh ->
+    new_gen_heap_relation gen g1 h1 g2 h2 ->
+    no_unrecorded_backward_edge g2 rh.
+Proof.
+  intros g1 h1 g2 h2 rh gen Hunrec Hrel.
+  unfold new_gen_heap_relation in Hrel.
+  destruct (graph_has_gen_dec g1 gen).
+  - destruct Hrel as [Hg2 _]. subst g2. exact Hunrec.
+  - destruct Hrel as [gi [sp [i [Hs [Hgen [Hempty [Htotal [Havail [Hused [Hg2 _]]]]]]]]]].
+    subst g2.
+    unfold no_unrecorded_backward_edge in *.
+    intros e He Hback.
+    apply Hunrec; [|exact Hback].
+    destruct e as [v idx].
+    destruct He as [Hv Hin].
+    split.
+    + eapply (ang_graph_has_v_inv g1 gi v); eauto.
+    + unfold get_edges, make_fields in Hin |- *.
+      simpl in Hin |- *.
+      exact Hin.
+Qed.
 
 Inductive garbage_collect_loop
   : list nat -> roots_t -> LGraph -> part_heap -> remset_heap -> remset ->

--- a/CertiGC/forward_lemmas.v
+++ b/CertiGC/forward_lemmas.v
@@ -103,14 +103,6 @@ Proof.
   rewrite roots_iff_exterior_compatible, Forall_forall in H0. now apply H0.
 Qed.
 
-Lemma weak_derives_strong: forall (P Q: mpred),
-    P |-- Q -> P |-- (weak_derives P Q && emp) * P.
-Proof.
-  intros. cancel. apply andp_right. 2: cancel.
-  assert (HS: emp |-- TT) by entailer; sep_apply HS; clear HS.
-  apply derives_weak. assumption.
-Qed.
-
 Lemma sapi_ptr_val: forall p m n,
     isptr p -> Int.min_signed <= n <= Int.max_signed ->
     (force_val

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -5427,37 +5427,6 @@ Proof.
       exact Hin.
 Qed.
 
-Lemma forward_remset_item_fold_space_property:
-  forall (Q: remset_space -> remset_heap -> Prop)
-         from to r g h rh rmst g' h' rh' rmst',
-    0 <= Z.of_nat to < Zlength rh ->
-    Q r rh ->
-    (forall item rest g h rh rmst g2 h2 rh2 rmst2,
-        0 <= Z.of_nat to < Zlength rh ->
-        Q (item :: rest) rh ->
-        (g2, h2, rh2, rmst2) =
-          forward_remset_item from to (g, h, rh, rmst) item ->
-        Q rest rh2) ->
-    (g', h', rh', rmst') =
-      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
-    Q nil rh'.
-Proof.
-  intros Q from to r.
-  induction r as [|item rest IH];
-    intros g h rh rmst g' h' rh' rmst' Hrange HQ HQstep Hfold.
-  - simpl in Hfold. inversion Hfold; subst. exact HQ.
-  - Opaque forward_remset_item.
-    simpl in Hfold.
-    Transparent forward_remset_item.
-    destruct (forward_remset_item from to (g, h, rh, rmst) item)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    symmetry in Hfri.
-    assert (Hrange2: 0 <= Z.of_nat to < Zlength rh2) by
-        (pose proof (fri_rh_Zlength_same from to g h rh rmst item
-                       g2 h2 rh2 rmst2 Hfri); lia).
-    eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst'); eauto.
-Qed.
-
 Lemma forward_remset_item_fold_pending_or_recorded:
   forall from to base r g h rh rmst g' h' rh' rmst',
     0 <= Z.of_nat to < Zlength rh ->
@@ -5476,57 +5445,6 @@ Proof.
                  base v from r (nth_remset_space rh to))); eauto.
   intros item rest g0 h0 rh0 rmst0 g2 h2 rh2 rmst2 Hrange0 Hpending0 Hfri.
   eapply forward_remset_item_pending_or_recorded; eauto.
-Qed.
-
-Lemma forward_remset_item_preserves_remset_entry:
-  forall from to g h rh rmst item g' h' rh' rmst' gen old,
-    0 <= Z.of_nat to < Zlength rh ->
-    In old (nth_remset_space rh gen) ->
-    (g', h', rh', rmst') =
-      forward_remset_item from to (g, h, rh, rmst) item ->
-    In old (nth_remset_space rh' gen).
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' gen old
-         Hrange Hin Hfri.
-  Opaque forward_graph_and_heap.
-  unfold forward_remset_item in Hfri.
-  Transparent forward_graph_and_heap.
-  destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hdo.
-  - destruct (forward_graph_and_heap
-                from to 0 (remset_item2forward_t item rmst g) g h)
-      as [new_g new_h] eqn:Hfgh.
-    inversion Hfri; subst; clear Hfri.
-    apply nth_remset_space_upd_remset_heap_old; assumption.
-  - inversion Hfri; subst; clear Hfri.
-    exact Hin.
-Qed.
-
-Lemma forward_remset_item_fold_preserves_remset_entry:
-  forall from to r g h rh rmst g' h' rh' rmst' gen old,
-    0 <= Z.of_nat to < Zlength rh ->
-    In old (nth_remset_space rh gen) ->
-    (g', h', rh', rmst') =
-      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
-    In old (nth_remset_space rh' gen).
-Proof.
-  intros from to r g h rh rmst g' h' rh' rmst' gen old Hrange Hin Hfold.
-  eapply (forward_remset_item_fold_space_property
-            (fun _ rh => In old (nth_remset_space rh gen))); eauto.
-  intros item rest g0 h0 rh0 rmst0 g2 h2 rh2 rmst2 Hrange0 Hin0 Hfri.
-  eapply forward_remset_item_preserves_remset_entry; eauto.
-Qed.
-
-Lemma forward_remset_gh_preserves_remset_entry:
-  forall from to g h rh rmst g' h' rh' rmst' gen old,
-    0 <= Z.of_nat to < Zlength rh ->
-    In old (nth_remset_space rh gen) ->
-    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
-    In old (nth_remset_space rh' gen).
-Proof.
-  intros from to g h rh rmst g' h' rh' rmst' gen old Hrange Hin Hfrg.
-  unfold forward_remset_gh in Hfrg.
-  rewrite <- nth_remset_space_Znth in Hfrg.
-  eapply forward_remset_item_fold_preserves_remset_entry; eauto.
 Qed.
 
 Lemma forward_remset_gh_old_edges_to_from_recorded:
@@ -6359,7 +6277,7 @@ Proof.
        eapply (forward_remset_item_fold_roots_graph_compatible_pres
                  from to g h rh rmst (Znth (Z.of_nat from) rh)
                  g_rem h_rem rh' rmst' roots);
-       eauto; eapply rrhc_forall_rrsc; exact Hrrhc).
+       eauto).
   assert (Hndd_rem: no_dangling_dst g_rem) by
       (unfold forward_remset_gh in Hfrg;
        eapply (fri_no_dangling_dst_fold
@@ -6440,7 +6358,7 @@ Proof.
        eapply (forward_remset_item_fold_roots_graph_compatible_pres
                  from to g h rh rmst (Znth (Z.of_nat from) rh)
                  g_rem h_rem rh' rmst' roots);
-       eauto; eapply rrhc_forall_rrsc; exact Hrrhc).
+       eauto).
   assert (Hndd_rem: no_dangling_dst g_rem) by
       (unfold forward_remset_gh in Hfrg;
        eapply (fri_no_dangling_dst_fold
@@ -8920,19 +8838,6 @@ Proof.
   - intros. eapply forward_remset_gh_sound; eauto.
 Qed.
 
-Lemma forward_remset_gh_roots_graph_compatible_simple:
-  forall from to g h rh rmst g' h' rh' rmst' roots,
-    graph_has_gen g to ->
-    roots_graph_compatible roots g ->
-    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
-    roots_graph_compatible roots g'.
-Proof.
-  intros from to g h rh rmst g' h' rh' rmst' roots Hto Hrgc Hfrg.
-  eapply (forward_remset_gh_P_holds (fun g0 => roots_graph_compatible roots g0)); eauto.
-  intros g1 g2 p Hroots Hto1 Hfr.
-  eapply fr_roots_graph_compatible; eauto.
-Qed.
-
 Lemma forward_remset_item_copied_vertex_prop:
   forall from to g h rh rmst item g' h' rh' rmst',
     from <> to ->
@@ -9062,9 +8967,9 @@ Proof.
                      g_rem h_rem rh' rmst'); eauto.
            eapply rrhc_forall_rrsc; exact Hrrhc.
         -- split.
-           ++ exact (forward_remset_gh_roots_graph_compatible_simple
+           ++ exact (forward_remset_gh_roots_graph_compatible
                        from to g h rh rmst g_rem h_rem rh' rmst' roots
-                       Hto Hroots Hfrg).
+                       Hto Hfrg Hroots).
            ++ exact (forward_remset_gh_gen_unmarked
                        from to g h rh rmst g_rem h_rem rh' rmst' to
                        Hto Hneq Hfrg Hun_to).
@@ -9225,9 +9130,9 @@ Proof.
   destruct Hrel as [[g1 [g2 [Hfrg [Hfrr [Hscan Hreset]]]]] _].
   subst g'.
   assert (Hrgc_rem: roots_graph_compatible roots g_rem) by
-      exact (forward_remset_gh_roots_graph_compatible_simple
+      exact (forward_remset_gh_roots_graph_compatible
                from to g h rh rmst g_rem h_rem rh' rmst' roots
-               Hto Hrgc Hfrg).
+               Hto Hfrg Hrgc).
   assert (Hto_rem: graph_has_gen g_rem to) by
       (rewrite <- (forward_remset_gh_graph_has_gen
                      from to g h rh rmst g_rem h_rem rh' rmst' Hto Hfrg to);

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -5358,27 +5358,14 @@ Proof.
   intros g rh from v Hsound Hfirst Hunrec Hgenv e Hevalid Hsrcgen Hdst.
   destruct Hsound as [Hvv [Hev _]].
   assert (Hge: graph_has_e g e) by (apply (proj1 (Hev e)); exact Hevalid).
-  destruct Hge as [Hsrc_has Hfield].
-  assert (Hsrc_gt: (from < vgeneration (fst e))%nat). {
-    destruct (lt_eq_lt_dec (vgeneration (fst e)) from) as [[Hlt | Heq] | Hgt].
-    - unfold firstn_gen_clear, graph_gen_clear in Hfirst.
-      specialize (Hfirst (vgeneration (fst e)) Hlt).
-      destruct (fst e) as [gen idx]. simpl in *.
-      destruct Hsrc_has as [_ Hidx].
-      unfold gen_has_index in Hidx. simpl in Hidx.
-      rewrite Hfirst in Hidx. lia.
-    - contradiction.
-    - exact Hgt.
-  }
-  specialize (Hunrec e (conj Hsrc_has Hfield)).
-  assert (Hback: (egeneration e > vgeneration (dst g e))%nat). {
-    rewrite Hdst, Hgenv.
-    unfold egeneration. exact Hsrc_gt.
-  }
-  specialize (Hunrec Hback).
-  rewrite Hdst, Hgenv in Hunrec.
+  assert (Hin:
+            In (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e))))
+               (nth_remset_space rh from)) by
+      (eapply no_unrecorded_backward_edge_current_remset;
+       [exact Hfirst | exact Hunrec | exact Hge |
+        unfold egeneration in *; exact Hsrcgen | now rewrite Hdst]).
   exists (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e)))).
-  split; [exact Hunrec |].
+  split; [exact Hin |].
   simpl. split; reflexivity.
 Qed.
 
@@ -9598,7 +9585,6 @@ Qed.
 
 Lemma do_generation_relation_no_unrecorded_backward_edge_reset_state:
   forall from roots roots' g h rh rmst g_rem h_rem rh' rmst' g' h',
-    sound_gc_graph g ->
     graph_has_gen g (S from) ->
     graph_unmarked g ->
     roots_graph_compatible roots g ->
@@ -9614,194 +9600,11 @@ Lemma do_generation_relation_no_unrecorded_backward_edge_reset_state:
     no_unrecorded_backward_edge g' (reset_nth_remset_heap from rh').
 Proof.
   intros from roots roots' g h rh rmst g_rem h_rem rh' rmst' g' h'
-         Hsound Hto Hun Hroots Hndd Hfirst Hunrec Hstate Hcover Hfirst' Hndd' Hrel.
-  destruct Hrel as [[g1 [g_scan [Hfrg [Hfrr [Hscan Hreset]]]]] Hheap].
-  subst g'.
-  unfold no_unrecorded_backward_edge.
-  intros e He Hback.
-  rewrite graph_has_e_reset in He.
-  destruct He as [He_scan Hsrc_ne].
-  simpl in Hback |- *.
-  rewrite remove_ve_dst_unchanged in Hback |- *.
-  destruct (lt_dec (vgeneration (dst g_scan e)) (S from)) as [Hdst_lt | Hdst_ge].
-  - exfalso.
-    assert (Hdst_has:
-              graph_has_v (reset_graph from g_scan)
-                (dst (reset_graph from g_scan) e)). {
-      destruct e as [src idx].
-      destruct He_scan as [Hsrc Hfield].
-      eapply Hndd'.
-      - rewrite graph_has_v_reset.
-        split; [exact Hsrc |].
-        intro Hbad.
-        apply Hsrc_ne.
-        unfold egeneration.
-        now rewrite Hbad.
-      - rewrite get_edges_reset.
-        exact Hfield.
-    }
-    unfold firstn_gen_clear, graph_gen_clear in Hfirst'.
-    simpl in Hdst_has.
-    rewrite remove_ve_dst_unchanged in Hdst_has.
-    destruct (dst g_scan e) as [dgen didx].
-    simpl in *.
-    destruct Hdst_has as [_ Hdst_idx].
-    unfold gen_has_index in Hdst_idx.
-    simpl in Hdst_idx.
-    specialize (Hfirst' dgen Hdst_lt).
-    rewrite Hfirst' in Hdst_idx.
-    lia.
-  - rewrite reset_nth_remset_heap_diff by lia.
-    pose proof Hstate as Hstate0.
-    destruct Hstate as [[Hrnd [Hrgc Hrrhc]] Hremgen].
-    assert (Hrange_to: 0 <= Z.of_nat (S from) < Zlength rh) by
-        (eapply remset_heap_covers_graph_range; eauto).
-    assert (Hcc: copy_compatible g) by
-        (apply graph_unmarked_copy_compatible; exact Hun).
-    assert (Hun_from: gen_unmarked g from) by
-        (rewrite graph_gen_unmarked_iff in Hun; apply Hun).
-    assert (Hun_to: gen_unmarked g (S from)) by
-        (rewrite graph_gen_unmarked_iff in Hun; apply Hun).
-    destruct (forward_remset_gh_remset_semi_iso_closed
-                from (S from) g h rh rmst g_rem h_rem rh' rmst'
-                ltac:(lia) Hsound Hto Hcc Hrnd Hrgc Hrrhc Hndd Hun_from
-                Hfirst Hunrec Hfrg) as [l [Hsemi Hclosed]].
-    destruct (forward_remset_gh_basic_facts
-                from (S from) roots g h rh rmst g_rem h_rem rh' rmst'
-                ltac:(lia) Hsound Hto Hcc Hun_to Hroots Hndd Hstate0 Hfrg)
-      as [Hsound_rem [Hto_rem [Hcc_rem [Hndd_rem [Hroots_rem Hun_to_rem]]]]].
-    destruct (frr_basic_facts
-                from (S from) roots roots' g_rem g1
-                ltac:(lia) Hto_rem Hcc_rem Hndd_rem Hroots_rem Hun_to_rem Hfrr)
-      as [Hto1 [Hcc1 [Hndd1 [Hroots1 Hun_to1]]]].
-    destruct Hscan as [n [Hsvwl Hn]].
-    assert (Hsrc_gt_to: (S from < egeneration e)%nat) by lia.
-    assert (Hsrc_scan: graph_has_v g_scan (fst e)) by exact (proj1 He_scan).
-    assert (Hsrc_g1: graph_has_v g1 (fst e)). {
-      pose proof (svwl_graph_has_v_inv
-                    from (S from)
-                    (seq (number_of_vertices (nth_gen g (S from))) n)
-                    g1 g_scan Hto1 Hsvwl (fst e) Hsrc_scan) as Hinv.
-      destruct Hinv as [Hold | [Hgen_new _]]; [exact Hold |].
-      unfold egeneration in Hsrc_gt_to.
-      rewrite Hgen_new in Hsrc_gt_to.
-      lia.
-    }
-    assert (Hdst_g1_scan: dst g1 e = dst g_scan e). {
-      eapply svwl_dst_unchanged; eauto.
-      intros Hsrc_to _.
-      unfold egeneration in Hsrc_gt_to.
-      rewrite Hsrc_to in Hsrc_gt_to.
-      lia.
-    }
-    assert (He_g1: graph_has_e g1 e). {
-      destruct He_scan as [_ Hfield_scan].
-      split; [exact Hsrc_g1 |].
-      unfold get_edges, make_fields in Hfield_scan |- *.
-      erewrite svwl_raw_fields; eauto.
-    }
-    assert (Hsrc_rem: graph_has_v g_rem (fst e)). {
-      pose proof (frr_graph_has_v_inv from (S from) roots g_rem roots' g1
-                    Hto_rem Hfrr (fst e) Hsrc_g1) as Hinv.
-      destruct Hinv as [Hold | [Hgen_new _]]; [exact Hold |].
-      unfold egeneration in Hsrc_gt_to.
-      rewrite Hgen_new in Hsrc_gt_to.
-      lia.
-    }
-    assert (Hdst_rem_g1: dst g_rem e = dst g1 e) by
-        (eapply frr_dst_unchanged; eauto).
-    assert (He_rem: graph_has_e g_rem e). {
-      destruct He_g1 as [_ Hfield_g1].
-      split; [exact Hsrc_rem |].
-      unfold get_edges, make_fields in Hfield_g1 |- *.
-      erewrite frr_raw_fields; eauto.
-    }
-    assert (Hsrc_valid_rem: vvalid g_rem (fst e)) by
-        (destruct Hsound_rem as [Hvv _]; apply (proj2 (Hvv _)); exact Hsrc_rem).
-    assert (Hsrc_valid_g: vvalid g (fst e)). {
-      eapply remset_semi_iso_current_non_to_valid_base; eauto.
-      unfold egeneration in Hsrc_gt_to.
-      lia.
-    }
-    assert (He_g: graph_has_e g e). {
-      destruct Hsemi as [_ Hspec].
-      destruct (split l) as [from_l to_l] eqn:Hsplit.
-      destruct Hspec as [[_ Hfrom] [_ [Hlabel _]]].
-      assert (Hnot_in: ~ In (fst e) from_l). {
-        intro Hin.
-        rewrite <- Hfrom in Hin.
-        destruct Hin as [_ [_ Hgen_from]].
-        unfold egeneration in Hsrc_gt_to.
-        rewrite Hgen_from in Hsrc_gt_to.
-        lia.
-      }
-      assert (Hlabel_src: vlabel g (fst e) = vlabel g_rem (fst e)) by
-          (apply Hlabel; assumption).
-      destruct He_rem as [_ Hfield_rem].
-      split.
-      - destruct Hsound as [Hvv _].
-        apply (proj1 (Hvv _)); exact Hsrc_valid_g.
-      - unfold get_edges, make_fields in Hfield_rem |- *.
-        rewrite Hlabel_src.
-        exact Hfield_rem.
-    }
-    assert (Hdst_rem_scan: dst g_rem e = dst g_scan e) by congruence.
-    assert (Hsrc_not_from: vgeneration (fst e) <> from) by
-        (unfold egeneration in Hsrc_gt_to; lia).
-    pose proof Hsemi as Hsemi0.
-    destruct Hsemi0 as [_ Hspec0].
-    destruct (split l) as [from_l to_l] eqn:Hsplit0.
-    destruct Hspec0 as [[_ Hfrom] [[_ [Hto_valid Hto_gen]] [_ [_ Hedge_map]]]].
-    assert (Hevalid_g: evalid g e) by
-        (destruct Hsound as [_ [Hev _]]; apply (proj2 (Hev _)); exact He_g).
-    assert (Hdst_valid_g: vvalid g (dst g e)). {
-      destruct Hsound as [Hvv _].
-      apply (proj2 (Hvv _)).
-      destruct He_g as [Hsrc_g Hfield_g].
-      eapply Hndd; eauto.
-    }
-    assert (Hdst_map: dst g_rem e = list_bi_map l (dst g e)) by
-        (apply Hedge_map; assumption).
-    destruct (in_dec equiv_dec (dst g e) from_l) as [Hdst_in_from | Hdst_not_from].
-    + assert (Hdst_g_from: vgeneration (dst g e) = from). {
-        rewrite <- Hfrom in Hdst_in_from.
-        tauto.
-      }
-      assert (Hdst_scan_to: vgeneration (dst g_scan e) = S from). {
-        assert (Hin_fst: In (dst g e) (map fst l)) by
-            (rewrite map_fst_split, Hsplit0; exact Hdst_in_from).
-        rewrite In_map_fst_iff in Hin_fst.
-        destruct Hin_fst as [dst_to Hpair].
-        pose proof (remset_semi_iso_DoubleNoDup
-                      g g_rem from (S from) l ltac:(lia) Hsemi) as Hdd.
-        destruct (DoubleNoDup_list_bi_map _ _ _ Hdd Hpair) as [Hmap _].
-        rewrite <- Hdst_rem_scan, Hdst_map, Hmap.
-        assert (Hin_to: In dst_to to_l). {
-          apply In_map_snd in Hpair.
-          now rewrite map_snd_split, Hsplit0 in Hpair.
-        }
-        exact (Hto_gen _ Hin_to).
-      }
-      rewrite Hdst_scan_to.
-      eapply (forward_remset_gh_old_edges_to_from_recorded
-                from (S from) g g h rh rmst
-                g_rem h_rem rh' rmst'); eauto.
-    + assert (Hdst_not_to: ~ In (dst g e) to_l). {
-        intro Hin_to.
-        rewrite Hto_valid in Hin_to.
-        tauto.
-      }
-      assert (Hnot_either: ~ InEither (dst g e) l). {
-        unfold InEither.
-        rewrite Hsplit0, in_app_iff.
-        tauto.
-      }
-      rewrite list_bi_map_not_In in Hdst_map by exact Hnot_either.
-      assert (Hdst_g_scan: dst g e = dst g_scan e) by congruence.
-      rewrite <- Hdst_g_scan.
-      eapply forward_remset_gh_preserves_remset_entry; eauto.
-      apply Hunrec; [exact He_g |].
-      now rewrite Hdst_g_scan.
+         Hto Hun Hroots Hndd Hfirst Hunrec Hstate Hcover Hfirst' Hndd' Hrel.
+  destruct Hstate as [[Hrnd [Hrgc Hrrhc]] _].
+  eapply do_generation_relation_no_unrecorded_backward_edge_reset_core; eauto.
+  - apply graph_unmarked_copy_compatible. exact Hun.
+  - eapply remset_heap_covers_graph_range; eauto.
 Qed.
 
 Lemma vvalid_reachable_sub_cons:

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -5023,13 +5023,6 @@ Lemma dsr_sound: forall (g1 g2 : LGraph) from to to_index,
     do_scan_relation from to to_index g1 g2 -> sound_gc_graph g2.
 Proof. intros. eapply dsr_P_holds; eauto. apply fr_O_sound. Qed.
 
-Definition no_unrecorded_backward_edge (g: LGraph) (rh: remset_heap): Prop :=
-  forall e,
-    graph_has_e g e ->
-    (egeneration e > vgeneration (dst g e))%nat ->
-    In (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e))))
-       (nth_remset_space rh (vgeneration (dst g e))).
-
 Definition remset_ext_effective_root (rext: remset_ext): option VType :=
   match rext with
   | RemSetVertex v _ => Some v

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -406,9 +406,6 @@ Definition old_nonfrom_edges_mapped
     src g2 e = src g1 e /\
     dst g2 e = list_bi_map l (dst g1 e).
 
-Definition old_nonfrom_vertices_valid (g1 g2: LGraph) (from: nat): Prop :=
-  forall v, vvalid g1 v -> vgeneration v <> from -> vvalid g2 v.
-
 Definition old_vertices_valid (g1 g2: LGraph): Prop :=
   forall v, vvalid g1 v -> vvalid g2 v.
 
@@ -425,7 +422,6 @@ Definition unmarked_from_edges_unchanged
 Definition remset_partial_graph
            (g1 g2: LGraph) (l: list (VType * VType)) (from: nat): Prop :=
   old_vertices_valid g1 g2 /\
-  old_nonfrom_vertices_valid g1 g2 from /\
   old_nonfrom_edges_mapped g1 g2 l from /\
   unmarked_from_edges_unchanged g1 g2 from.
 
@@ -477,7 +473,6 @@ Definition remset_partial_graph_pending
            (g1 g2: LGraph) (l: list (VType * VType))
            (from: nat) (pending: remset_space): Prop :=
   old_vertices_valid g1 g2 /\
-  old_nonfrom_vertices_valid g1 g2 from /\
   old_nonfrom_edges_mapped_pending g1 g2 l from pending /\
   unmarked_from_edges_unchanged g1 g2 from.
 
@@ -494,7 +489,7 @@ Definition gc_graph_remset_quasi_iso (g1: LGraph) (roots1: roots_t)
     let (from_l, to_l) := split l in
     from_gen_quasi_spec g1 roots1 from_l from /\ to_gen_spec g1 g2 to_l to /\
     (forall v, vvalid g1 v -> ~ In v from_l -> vlabel g1 v = vlabel g2 v) /\
-    old_nonfrom_vertices_valid g1 g2 from /\
+    old_vertices_valid g1 g2 /\
     old_nonfrom_edges_mapped g1 g2 l from.
 
 Definition gen_has_index_dec (g: LGraph) (gen idx: nat):
@@ -1447,7 +1442,7 @@ Proof.
   destruct (split l) as [from_l to_l] eqn:Hsplit.
   destruct Hspec as [[_ Hfrom] [[_ [_ Hto_gen]] [_ Hpartial]]].
   unfold remset_partial_graph_pending in Hpartial.
-  destruct Hpartial as [_ [_ [Hedges _]]].
+  destruct Hpartial as [_ [Hedges _]].
   specialize (Hedges e Hevalid Hsrcgen).
   destruct Hedges as [Hpending | Hmapped].
   - destruct Hpending as [_ [_ [_ [Hdst_eq _]]]].
@@ -1494,7 +1489,7 @@ Lemma old_nonfrom_edge_mapped_lcv:
     sound_gc_graph g ->
     no_dangling_dst base ->
     graph_has_gen g to ->
-    old_nonfrom_vertices_valid base g from ->
+    old_vertices_valid base g ->
     evalid base e ->
     vgeneration (fst e) <> from ->
     evalid g e ->
@@ -1508,7 +1503,7 @@ Lemma old_nonfrom_edge_mapped_lcv:
       list_bi_map ((v, new_copied_v g to) :: l) (dst base e).
 Proof.
   intros base g from to l v e Hneq Hsound_base Hsound_g Hndd Hto
-         Hvertices Hevalid Hsrcgen He_g Hsrc_g Hdst_g Hdst_not_v Hgenv.
+         Holdvalid Hevalid Hsrcgen He_g Hsrc_g Hdst_g Hdst_not_v Hgenv.
   destruct Hsound_base as [Hvv_base [Hev_base [_ _]]].
   destruct Hsound_g as [Hvv_g [_ [_ _]]].
   assert (Hge: graph_has_e base e) by
@@ -1526,14 +1521,14 @@ Proof.
   }
   assert (Hsrc_not_new: fst e <> new_copied_v g to). {
     intro Hbad. apply Hnew_not_valid. rewrite <- Hbad.
-    apply Hvertices; assumption.
+    apply Holdvalid; assumption.
   }
   assert (Hdst_not_new: dst base e <> new_copied_v g to). {
     intro Hbad.
     destruct (Nat.eq_dec (vgeneration (dst base e)) from) as [Hdst_from | Hdst_not_from].
     - rewrite Hbad in Hdst_from. simpl in Hdst_from. lia.
     - apply Hnew_not_valid. rewrite <- Hbad.
-      apply Hvertices; assumption.
+      apply Holdvalid; assumption.
   }
   split.
   - simpl. rewrite pcv_evalid_iff. now left.
@@ -1551,7 +1546,7 @@ Lemma old_nonfrom_edges_mapped_lcv:
     sound_gc_graph g ->
     no_dangling_dst base ->
     graph_has_gen g to ->
-    old_nonfrom_vertices_valid base g from ->
+    old_vertices_valid base g ->
     old_nonfrom_edges_mapped base g l from ->
     no_unmarked_old_nonfrom_dst base g from ->
     raw_mark (vlabel g v) = false ->
@@ -1560,7 +1555,7 @@ Lemma old_nonfrom_edges_mapped_lcv:
       ((v, new_copied_v g to) :: l) from.
 Proof.
   intros base g from to l v Hneq Hsound_base Hsound_g Hndd Hto
-         Hvertices Hedges Hclosed Hmark Hgenv.
+         Holdvalid Hedges Hclosed Hmark Hgenv.
   unfold old_nonfrom_edges_mapped in *.
   intros e Hevalid Hsrcgen.
   specialize (Hedges e Hevalid Hsrcgen).
@@ -1579,7 +1574,7 @@ Lemma old_nonfrom_edges_mapped_pending_lcv:
     sound_gc_graph g ->
     no_dangling_dst base ->
     graph_has_gen g to ->
-    old_nonfrom_vertices_valid base g from ->
+    old_vertices_valid base g ->
     old_nonfrom_edges_mapped_pending base g l from pending ->
     old_nonfrom_edges_to_are_pending base v from pending ->
     vgeneration v = from ->
@@ -1588,7 +1583,7 @@ Lemma old_nonfrom_edges_mapped_pending_lcv:
       ((v, new_copied_v g to) :: l) from pending.
 Proof.
   intros base g from to l pending v Hneq Hsound_base Hsound_g Hndd Hto
-         Hvertices Hedges Hpending Hgenv Hmap_v.
+         Holdvalid Hedges Hpending Hgenv Hmap_v.
   unfold old_nonfrom_edges_mapped_pending in *.
   intros e Hevalid Hsrcgen.
   specialize (Hedges e Hevalid Hsrcgen).
@@ -1610,7 +1605,7 @@ Proof.
     }
     assert (Hsrc_not_new: fst e <> new_copied_v g to). {
       intro Hbad. apply Hnew_not_valid. rewrite <- Hbad.
-      apply Hvertices; assumption.
+      apply Holdvalid; assumption.
     }
     split.
     + simpl. rewrite pcv_evalid_iff. now left.
@@ -1637,7 +1632,7 @@ Proof.
       }
       assert (Hsrc_not_new: fst e <> new_copied_v g to). {
         intro Hbad. apply Hnew_not_valid. rewrite <- Hbad.
-        apply Hvertices; assumption.
+        apply Holdvalid; assumption.
       }
       split.
       * simpl. rewrite pcv_evalid_iff. now left.
@@ -1649,17 +1644,6 @@ Proof.
            ++ rewrite Hdst_v. exact Hgenv.
     + right.
       eapply old_nonfrom_edge_mapped_lcv; eauto.
-Qed.
-
-Lemma old_nonfrom_vertices_valid_lcv:
-  forall base g from to v,
-    old_nonfrom_vertices_valid base g from ->
-    old_nonfrom_vertices_valid base (lgraph_copy_v g v to) from.
-Proof.
-  unfold old_nonfrom_vertices_valid.
-  intros base g from to v Hvertices x Hvalid Hgen.
-  simpl. rewrite pcv_vvalid_iff. left.
-  apply Hvertices; assumption.
 Qed.
 
 Lemma old_vertices_valid_lcv:
@@ -1698,12 +1682,10 @@ Proof.
            split.
            ++ unfold old_vertices_valid. auto.
            ++ split.
-              ** unfold old_nonfrom_vertices_valid. auto.
-              ** split.
-                 --- unfold old_nonfrom_edges_mapped. simpl.
-                     intros e Hevalid _. split; [exact Hevalid | split; reflexivity].
-                 --- unfold unmarked_from_edges_unchanged.
-                     intros e Hevalid _ _. split; [exact Hevalid | split; reflexivity].
+              ** unfold old_nonfrom_edges_mapped. simpl.
+                 intros e Hevalid _. split; [exact Hevalid | split; reflexivity].
+              ** unfold unmarked_from_edges_unchanged.
+                 intros e Hevalid _ _. split; [exact Hevalid | split; reflexivity].
 Qed.
 
 Lemma old_nonfrom_edges_mapped_pending_nil:
@@ -1830,8 +1812,8 @@ Lemma remset_partial_graph_pending_lift_edges:
 Proof.
   unfold remset_partial_graph_pending.
   intros g1 g2 l from pending1 pending2 Hlift
-         [Hold [Hvertices [Hedges Hunmarked]]].
-  split; [exact Hold |]. split; [exact Hvertices |].
+         [Hold [Hedges Hunmarked]].
+  split; [exact Hold |].
   split; [|exact Hunmarked].
   now apply Hlift.
 Qed.
@@ -1842,8 +1824,8 @@ Lemma remset_partial_graph_pending_nil:
     remset_partial_graph g1 g2 l from.
 Proof.
   unfold remset_partial_graph_pending, remset_partial_graph.
-  intros g1 g2 l from [Hold [Hvertices [Hedges Hunmarked]]].
-  split; [exact Hold |]. split; [exact Hvertices |].
+  intros g1 g2 l from [Hold [Hedges Hunmarked]].
+  split; [exact Hold |].
   split; [|exact Hunmarked].
   now apply old_nonfrom_edges_mapped_pending_nil.
 Qed.
@@ -1854,8 +1836,8 @@ Lemma remset_partial_graph_pending_intro:
     remset_partial_graph_pending g1 g2 l from pending.
 Proof.
   unfold remset_partial_graph_pending, remset_partial_graph.
-  intros g1 g2 l from pending [Hold [Hvertices [Hedges Hunmarked]]].
-  split; [exact Hold |]. split; [exact Hvertices |].
+  intros g1 g2 l from pending [Hold [Hedges Hunmarked]].
+  split; [exact Hold |].
   split; [|exact Hunmarked].
   now apply old_nonfrom_edges_mapped_pending_intro.
 Qed.
@@ -2283,14 +2265,12 @@ Proof.
   intros base g from to l v Hneq Hsound_base Hsound_g Hndd Hto
          Hpartial Hclosed Hmark Hgen.
   unfold remset_partial_graph in *.
-  destruct Hpartial as [Holdvalid [Hvertices [Hedges Hunmarked]]].
+  destruct Hpartial as [Holdvalid [Hedges Hunmarked]].
   split.
   - now apply old_vertices_valid_lcv.
   - split.
-    + now apply old_nonfrom_vertices_valid_lcv.
-    + split.
-      * eapply old_nonfrom_edges_mapped_lcv; eauto.
-      * eapply unmarked_from_edges_unchanged_lcv; eauto.
+    + eapply old_nonfrom_edges_mapped_lcv; eauto.
+    + eapply unmarked_from_edges_unchanged_lcv; eauto.
 Qed.
 
 Lemma old_vertices_valid_lgd:
@@ -2301,16 +2281,6 @@ Proof.
   unfold old_vertices_valid.
   intros base g e v Hold x Hx.
   apply Hold. exact Hx.
-Qed.
-
-Lemma old_nonfrom_vertices_valid_lgd:
-  forall base g from e v,
-    old_nonfrom_vertices_valid base g from ->
-    old_nonfrom_vertices_valid base (labeledgraph_gen_dst g e v) from.
-Proof.
-  unfold old_nonfrom_vertices_valid.
-  intros base g from e v Hold x Hx Hgen.
-  apply Hold; assumption.
 Qed.
 
 Lemma old_nonfrom_edges_mapped_lgd:
@@ -2423,14 +2393,12 @@ Lemma remset_partial_graph_lgd:
 Proof.
   intros base g l from e v Hsound Hnot_base Hpartial.
   unfold remset_partial_graph in *.
-  destruct Hpartial as [Holdvalid [Hvertices [Hedges Hunmarked]]].
+  destruct Hpartial as [Holdvalid [Hedges Hunmarked]].
   split.
   - now apply old_vertices_valid_lgd.
   - split.
-    + now apply old_nonfrom_vertices_valid_lgd.
-    + split.
-      * eapply old_nonfrom_edges_mapped_lgd; eauto.
-      * eapply unmarked_from_edges_unchanged_lgd; eauto.
+    + eapply old_nonfrom_edges_mapped_lgd; eauto.
+    + eapply unmarked_from_edges_unchanged_lgd; eauto.
 Qed.
 
 Lemma remset_partial_graph_pending_lgd_mapped:
@@ -2448,14 +2416,12 @@ Proof.
   intros base g l from item pending e v Hevalid_base Hevalid_g Hsrc_g Hsrcgen
          Hitem Hv Hpartial.
   unfold remset_partial_graph_pending in *.
-  destruct Hpartial as [Holdvalid [Hvertices [Hedges Hunmarked]]].
+  destruct Hpartial as [Holdvalid [Hedges Hunmarked]].
   split.
   - now apply old_vertices_valid_lgd.
   - split.
-    + now apply old_nonfrom_vertices_valid_lgd.
-    + split.
-      * eapply old_nonfrom_edges_mapped_pending_lgd_mapped; eauto.
-      * eapply unmarked_from_edges_unchanged_lgd_nonfrom; eauto.
+    + eapply old_nonfrom_edges_mapped_pending_lgd_mapped; eauto.
+    + eapply unmarked_from_edges_unchanged_lgd_nonfrom; eauto.
 Qed.
 
 Lemma lcv_remset_semi_iso_parts:
@@ -2664,7 +2630,7 @@ Proof.
             ((v, new_copied_v g to) :: l)).
   eapply lcv_remset_semi_iso_parts; eauto.
   - intros base0 g0 l0 Hpartial. exact (proj1 Hpartial).
-  - intros base0 g0 l0 Hpartial. exact (proj2 (proj2 (proj2 Hpartial))).
+  - intros base0 g0 l0 Hpartial. exact (proj2 (proj2 Hpartial)).
 Qed.
 
 Lemma remset_partial_graph_pending_lcv:
@@ -2684,14 +2650,12 @@ Proof.
   intros base g from to l pending v Hneq Hsound_base Hsound_g Hndd Hto
          Hpartial Hpending Hgen Hmap_v.
   unfold remset_partial_graph_pending in *.
-  destruct Hpartial as [Holdvalid [Hnonfrom_vertices [Hedges Hunmarked]]].
+  destruct Hpartial as [Holdvalid [Hedges Hunmarked]].
   split.
   - now apply old_vertices_valid_lcv.
   - split.
-    + now apply old_nonfrom_vertices_valid_lcv.
-    + split.
-      * eapply old_nonfrom_edges_mapped_pending_lcv; eauto.
-      * eapply unmarked_from_edges_unchanged_lcv; eauto.
+    + eapply old_nonfrom_edges_mapped_pending_lcv; eauto.
+    + eapply unmarked_from_edges_unchanged_lcv; eauto.
 Qed.
 
 Lemma lcv_pending_remset_semi_iso:
@@ -2748,7 +2712,7 @@ Proof.
             ((v, new_copied_v g to) :: l)).
   eapply lcv_remset_semi_iso_parts; eauto.
   - intros base0 g0 l0 Hpartial. exact (proj1 Hpartial).
-  - intros base0 g0 l0 Hpartial. exact (proj2 (proj2 (proj2 Hpartial))).
+  - intros base0 g0 l0 Hpartial. exact (proj2 (proj2 Hpartial)).
 Qed.
 
 Lemma lgd_remset_semi_iso:
@@ -2773,7 +2737,7 @@ Proof.
   destruct Hfrom as [Hfrom_nd Hfrom].
   destruct Hto_spec as [Hto_nd [Hto_valid Hto_gen]].
   unfold remset_partial_graph in Hpartial.
-  destruct Hpartial as [Holdvalid [Hnonfrom_vertices [Hnonfrom_edges Hunmarked]]].
+  destruct Hpartial as [Holdvalid [Hnonfrom_edges Hunmarked]].
   destruct Hsound_base as [Hvv_base [Hev_base [Hsrc_base _]]].
   destruct Hsound_g as [Hvv_g [Hev_g [Hsrc_g _]]].
   assert (Hf: from_l = map fst l) by
@@ -2852,7 +2816,6 @@ Proof.
            apply make_fields_Znth_edge in Hfield; auto.
            subst e. exact Hnot_base.
            unfold remset_partial_graph. split; [exact Holdvalid |].
-           split; [exact Hnonfrom_vertices |].
            split; [exact Hnonfrom_edges | exact Hunmarked].
 Qed.
 
@@ -3190,7 +3153,7 @@ Proof.
   destruct (split l) as [from_l to_l] eqn:Hsplit.
   destruct Hspec as [[_ Hfrom] [[_ [Hto_valid Hto_gen]] [_ Hpartial]]].
   unfold remset_partial_graph_pending in Hpartial.
-  destruct Hpartial as [_ [_ [Hedges _]]].
+  destruct Hpartial as [_ [Hedges _]].
   specialize (Hedges e Hevalid Hsrcgen).
   assert (Hge: graph_has_e base e) by
       (apply (proj1 (Hev_base _)); exact Hevalid).
@@ -3351,7 +3314,7 @@ Proof.
   destruct (split l) as [from_l to_l] eqn:Hsplit.
   destruct Hspec as [[_ Hfrom] [[_ [Hto_valid Hto_gen]] [_ Hpartial]]].
   unfold remset_partial_graph in Hpartial.
-  destruct Hpartial as [_ [_ [Hedges _]]].
+  destruct Hpartial as [_ [Hedges _]].
   specialize (Hedges e Hevalid Hsrcgen).
   destruct Hedges as [_ [_ Hdst_map]].
   assert (Hge: graph_has_e base e) by
@@ -3842,7 +3805,7 @@ Proof.
   - destruct (split l) as [from_l to_l].
     destruct Hspec as [Hfrom [Hto [Hlabel Hpartial]]].
     unfold remset_partial_graph in Hpartial.
-    destruct Hpartial as [_ [Hvertices [Hedges _]]].
+    destruct Hpartial as [Holdvalid [Hedges _]].
     split.
     + destruct Hfrom as [Hnodup Hfrom].
       split; [exact Hnodup |].
@@ -3850,7 +3813,7 @@ Proof.
       unfold roots_reachable_in_gen, marked_in_gen in Hr.
       now rewrite Hr, Hfrom.
     + split; [exact Hto |]. split; [exact Hlabel |].
-      split; assumption.
+      split; [exact Holdvalid | exact Hedges].
 Qed.
 
 Lemma reachable_from_roots: forall (g: LGraph) (roots: roots_t) v,
@@ -5634,7 +5597,7 @@ Proof.
       (eapply gc_graph_remset_semi_iso_parts_partial; exact Hsemi).
   assert (Hcurrent: evalid g e /\ src g e = src base e). {
     eapply old_nonfrom_edges_mapped_pending_current_edge; eauto.
-    exact (proj1 (proj2 (proj2 Hpartial))).
+    exact (proj1 (proj2 Hpartial)).
   }
   destruct Hcurrent as [Hevalid_g Hsrc_g].
   assert (Hmarked_or_current:
@@ -5984,7 +5947,7 @@ Proof.
       (eapply gc_graph_remset_semi_iso_parts_partial; exact Hsemi).
   assert (Hcurrent: evalid g e /\ src g e = src base e). {
     eapply old_nonfrom_edges_mapped_pending_current_edge; eauto.
-    exact (proj1 (proj2 (proj2 Hpartial))).
+    exact (proj1 (proj2 Hpartial)).
   }
   destruct Hcurrent as [Hevalid_g Hsrc_g].
   inversion Hfr; subst; clear Hfr; try contradiction.
@@ -7620,66 +7583,40 @@ Lemma forward_remset_gh_remset_semi_iso_closed_effective_roots:
 Proof.
   intros from to g h rh rmst g' h' rh' rmst'
          Hneq Hsound Hto Hcc Hct Hrnd Hrgc Hrrhc Hndd Hunmarked Hfirst Hunrec Hfrg.
+  destruct (forward_remset_gh_remset_semi_iso_closed
+              from to g h rh rmst g' h' rh' rmst'
+              Hneq Hsound Hto Hcc Hrnd Hrgc Hrrhc Hndd Hunmarked
+              Hfirst Hunrec Hfrg)
+    as [l [Hsemi Hclosed]].
+  exists l. split; [exact Hsemi |].
+  split; [exact Hclosed |].
   assert (Hrrsc:
             remset_and_remset_space_compatible
               g from rmst (nth_remset_space rh from)). {
     rewrite nth_remset_space_Znth.
     eapply rrhc_forall_rrsc; exact Hrrhc.
   }
-  assert (Hbase_src:
-            Forall
-              (fun item =>
-                 match item with
-                 | RemSetExterior _ => True
-                 | RemSetInterior (InteriorVertexPos v _) =>
-                     vgeneration v <> from -> vvalid g v
-                 end) (nth_remset_space rh from)) by
-      (eapply remset_space_base_sources_valid; eauto).
-  assert (Hsemi0:
-            gc_graph_pending_remset_semi_iso
-              g g from to (nth_remset_space rh from) nil) by
-      (eapply pending_remset_semi_iso_refl; eauto).
-  assert (Hpending:
-            unmarked_old_nonfrom_edges_to_are_pending
-              g g from (nth_remset_space rh from)) by
-      (eapply no_unrecorded_backward_edge_unmarked_old_nonfrom_edges_pending;
-       eauto).
   unfold forward_remset_gh in Hfrg.
   rewrite <- nth_remset_space_Znth in Hfrg.
-  destruct (forward_remset_item_fold_pending_remset_semi_iso
-              from to g (nth_remset_space rh from) g h rh rmst
-              g' h' rh' rmst' nil Hneq Hsound Hsound Hto Hcc Hrnd Hrgc
-              Hrrsc Hndd Hbase_src Hsemi0 Hpending Hfrg)
-    as [l [Hpending_nil Hpending_empty]].
-  exists l.
-  assert (Hsemi: gc_graph_remset_semi_iso g g' from to l). {
-    simpl in Hpending_nil.
-    rewrite app_nil_r in Hpending_nil.
-    now apply pending_remset_semi_iso_nil.
+  intros v Hin_fst.
+  pose proof Hsemi as Hsemi_copy.
+  destruct Hsemi_copy as [_ Hspec].
+  destruct (split l) as [from_l to_l] eqn:Hsplit.
+  destruct Hspec as [[_ Hfrom] _].
+  rewrite map_fst_split, Hsplit in Hin_fst.
+  simpl in Hin_fst.
+  apply (proj2 (Hfrom v)) in Hin_fst.
+  destruct Hin_fst as [Hmark [Hvvalid Hgen]].
+  assert (Hgv: graph_has_v g v) by
+      (destruct Hsound as [Hvv _]; apply (proj1 (Hvv _)); exact Hvvalid).
+  assert (Hmark0: raw_mark (vlabel g v) = false). {
+    destruct v as [vgen vidx]. simpl in Hgen. subst vgen.
+    destruct Hgv as [Hgen_has Hidx].
+    exact (Hunmarked Hgen_has vidx Hidx).
   }
-  split; [exact Hsemi |].
-  split.
-  - eapply unmarked_old_nonfrom_edges_pending_nil_no_unmarked.
-    exact Hpending_empty.
-  - intros v Hin_fst.
-    pose proof Hsemi as Hsemi_copy.
-    destruct Hsemi_copy as [_ Hspec].
-    destruct (split l) as [from_l to_l] eqn:Hsplit.
-    destruct Hspec as [[_ Hfrom] _].
-    rewrite map_fst_split, Hsplit in Hin_fst.
-    simpl in Hin_fst.
-    apply (proj2 (Hfrom v)) in Hin_fst.
-    destruct Hin_fst as [Hmark [Hvvalid Hgen]].
-    assert (Hgv: graph_has_v g v) by
-        (destruct Hsound as [Hvv _]; apply (proj1 (Hvv _)); exact Hvvalid).
-    assert (Hmark0: raw_mark (vlabel g v) = false). {
-      destruct v as [vgen vidx]. simpl in Hgen. subst vgen.
-      destruct Hgv as [Hgen_has Hidx].
-      exact (Hunmarked Hgen_has vidx Hidx).
-    }
-    unfold effective_remset_roots.
-    eapply forward_remset_item_fold_marked_from_unmarked_effective_root;
-      eauto.
+  unfold effective_remset_roots.
+  eapply forward_remset_item_fold_marked_from_unmarked_effective_root;
+    eauto.
 Qed.
 
 Lemma forward_remset_gh_backward_edge_prop_mapped_roots_effective:
@@ -8188,7 +8125,7 @@ Proof.
     destruct (split l) as [from_l to_l] eqn:Hsplit.
     destruct Hspec as [_ [_ [_ Hpartial]]].
     unfold remset_partial_graph in Hpartial.
-    destruct Hpartial as [_ [_ [_ Hunmarked_edges]]].
+    destruct Hpartial as [_ [_ Hunmarked_edges]].
     destruct (Hunmarked_edges e Hevalid Hsrc_gen Hsrc_mark)
       as [He_current [Hsrc_eq Hdst_eq]].
     assert (Hstep: current |= (fst e) ~> (dst base e)). {
@@ -9316,7 +9253,7 @@ Qed.
 
 Definition remset_ready_marked_state
     (from to: nat) (roots: roots_t) (g: LGraph)
-    (rh: remset_heap) (rmst: remset) (g_rem g_scan: LGraph)
+    (rh: remset_heap) (rmst: remset) (g_rem: LGraph)
     (l: list (VType * VType)) (marked: VType -> Prop): Prop :=
   gc_graph_remset_semi_iso g g_rem from to l /\
   no_unmarked_old_nonfrom_dst g g_rem from /\
@@ -9334,14 +9271,14 @@ Definition remset_ready_marked_bridge
     (from to: nat) (roots: roots_t) (g: LGraph)
     (rh: remset_heap) (rmst: remset) (g_rem g_scan: LGraph): Prop :=
   exists l,
-    remset_ready_marked_state from to roots g rh rmst g_rem g_scan l
+    remset_ready_marked_state from to roots g rh rmst g_rem l
       (fun v => marked_in_gen g_rem g_scan from v).
 
 Definition remset_ready_marked_base_bridge
     (from to: nat) (roots: roots_t) (g: LGraph)
     (rh: remset_heap) (rmst: remset) (g_rem g_scan: LGraph): Prop :=
   exists l,
-    remset_ready_marked_state from to roots g rh rmst g_rem g_scan l
+    remset_ready_marked_state from to roots g rh rmst g_rem l
       (fun v => marked_in_gen g g_scan from v).
 
 Lemma remset_ready_marked_bridge_base:

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -2033,7 +2033,7 @@ Lemma ucov_rawmark: forall g old_v new_v,
 Proof.
   intros. unfold update_copied_old_vlabel, update_vlabel. rewrite if_true; easy.
 Qed.
-(*here*)
+
 Lemma lcv_raw_mark_old: forall g v to,
     raw_mark (vlabel (lgraph_copy_v g v to) v) = true.
 Proof. intros. simpl. apply ucov_rawmark. Qed.
@@ -2127,26 +2127,6 @@ Proof.
     rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
     eapply fr_graph_has_v; eauto.
   - inversion Hfri; subst. exact Hv.
-Qed.
-
-Lemma forward_remset_item_raw_mark_true_pres:
-  forall from to g h rh rmst item g' h' rh' rmst' v,
-    graph_has_gen g to ->
-    graph_has_v g v ->
-    raw_mark (vlabel g v) = true ->
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    raw_mark (vlabel g' v) = true.
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' v Hto Hv Hmark Hfri.
-  unfold forward_remset_item in Hfri.
-  destruct (negb (remset_item_in_gen item rmst g from)).
-  - destruct (forward_graph_and_heap from to O (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap from to O (remset_item2forward_t item rmst g) g h
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
-    eapply fr_O_raw_mark_true_pres; eauto.
-  - inversion Hfri; subst. exact Hmark.
 Qed.
 
 Lemma forward_remset_item_fold_raw_mark_true_pres:
@@ -5343,151 +5323,6 @@ Proof.
   unfold unmarked_old_nonfrom_edges_to_are_pending.
   intros g rh from Hsound Hfirst Hunrec v Hgen _.
   eapply no_unrecorded_backward_edge_old_nonfrom_edges_pending; eauto.
-Qed.
-
-Definition old_nonfrom_edges_to_are_pending_or_recorded
-           (g: LGraph) (v: VType) (from: nat)
-           (pending recorded: remset_space): Prop :=
-  forall e,
-    evalid g e ->
-    vgeneration (fst e) <> from ->
-    dst g e = v ->
-    remset_space_records_edge pending e \/
-    remset_space_records_edge recorded e.
-
-Lemma remset_space_records_edge_interior:
-  forall pending e,
-    remset_space_records_edge pending e ->
-    In (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e))))
-       pending.
-Proof.
-  intros pending e [item [Hin Hrec]].
-  destruct item as [addr | [src pos]]; simpl in Hrec; [contradiction |].
-  destruct Hrec as [Hsrc Hpos].
-  subst src pos.
-  exact Hin.
-Qed.
-
-Lemma forward_remset_item_pending_or_recorded:
-  forall from to base g h rh rmst item g' h' rh' rmst' pending v,
-    0 <= Z.of_nat to < Zlength rh ->
-    old_nonfrom_edges_to_are_pending_or_recorded
-      base v from (item :: pending) (nth_remset_space rh to) ->
-    (g', h', rh', rmst') =
-      forward_remset_item from to (g, h, rh, rmst) item ->
-    old_nonfrom_edges_to_are_pending_or_recorded
-      base v from pending (nth_remset_space rh' to).
-Proof.
-  unfold old_nonfrom_edges_to_are_pending_or_recorded.
-  intros from to base g h rh rmst item g' h' rh' rmst' pending v
-         Hrange Hpending Hfri e Hevalid Hsrcgen Hdst.
-  specialize (Hpending e Hevalid Hsrcgen Hdst).
-  destruct Hpending as [Hpending | Hrecorded].
-  - destruct Hpending as [item0 [[Hhead | Htail] Hrec]].
-    + subst item0.
-      right.
-      assert (Hin_gen: remset_item_in_gen item rmst g from = false). {
-        destruct item as [addr | [src pos]]; simpl in Hrec; [contradiction |].
-        destruct Hrec as [Hsrc _].
-        subst src.
-        simpl.
-        apply Nat.eqb_neq.
-        exact Hsrcgen.
-      }
-      Opaque forward_graph_and_heap.
-      unfold forward_remset_item in Hfri.
-      rewrite Hin_gen in Hfri.
-      simpl in Hfri.
-      Transparent forward_graph_and_heap.
-      destruct (forward_graph_and_heap
-                  from to 0 (remset_item2forward_t item rmst g) g h)
-        as [new_g new_h] eqn:Hfgh.
-      inversion Hfri; subst; clear Hfri.
-      exists item.
-      split; [|exact Hrec].
-      apply nth_remset_space_upd_remset_heap_new.
-      exact Hrange.
-    + left.
-      exists item0.
-      split; assumption.
-  - right.
-    destruct Hrecorded as [item0 [Hin Hrec]].
-    exists item0.
-    split; [|exact Hrec].
-    Opaque forward_graph_and_heap.
-    unfold forward_remset_item in Hfri.
-    Transparent forward_graph_and_heap.
-    destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hdo.
-    + destruct (forward_graph_and_heap
-                  from to 0 (remset_item2forward_t item rmst g) g h)
-        as [new_g new_h] eqn:Hfgh.
-      inversion Hfri; subst; clear Hfri.
-      apply nth_remset_space_upd_remset_heap_old; assumption.
-    + inversion Hfri; subst; clear Hfri.
-      exact Hin.
-Qed.
-
-Lemma forward_remset_item_fold_pending_or_recorded:
-  forall from to base r g h rh rmst g' h' rh' rmst',
-    0 <= Z.of_nat to < Zlength rh ->
-    (g', h', rh', rmst') =
-      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
-    forall v,
-      old_nonfrom_edges_to_are_pending_or_recorded
-        base v from r (nth_remset_space rh to) ->
-      old_nonfrom_edges_to_are_pending_or_recorded
-        base v from nil (nth_remset_space rh' to).
-Proof.
-  intros from to base r g h rh rmst g' h' rh' rmst' Hrange Hfold v Hpending.
-  eapply (forward_remset_item_fold_space_property
-            (fun r rh =>
-               old_nonfrom_edges_to_are_pending_or_recorded
-                 base v from r (nth_remset_space rh to))); eauto.
-  intros item rest g0 h0 rh0 rmst0 g2 h2 rh2 rmst2 Hrange0 Hpending0 Hfri.
-  eapply forward_remset_item_pending_or_recorded; eauto.
-Qed.
-
-Lemma forward_remset_gh_old_edges_to_from_recorded:
-  forall from to base g h rh rmst g' h' rh' rmst',
-    sound_gc_graph base ->
-    firstn_gen_clear base from ->
-    no_unrecorded_backward_edge base rh ->
-    0 <= Z.of_nat to < Zlength rh ->
-    (g', h', rh', rmst') = forward_remset_gh from to g h rh rmst ->
-    forall e,
-      evalid base e ->
-      vgeneration (fst e) <> from ->
-      vgeneration (dst base e) = from ->
-      In (RemSetInterior (InteriorVertexPos (fst e) (Z.of_nat (snd e))))
-         (nth_remset_space rh' to).
-Proof.
-  intros from to base g h rh rmst g' h' rh' rmst'
-         Hsound Hfirst Hunrec Hrange Hfrg e Hevalid Hsrcgen Hdstgen.
-  assert (Hpending:
-            old_nonfrom_edges_to_are_pending
-              base (dst base e) from (nth_remset_space rh from)) by
-      (eapply no_unrecorded_backward_edge_old_nonfrom_edges_pending;
-       eauto).
-  assert (Hpor:
-            old_nonfrom_edges_to_are_pending_or_recorded
-              base (dst base e) from (nth_remset_space rh from)
-              (nth_remset_space rh to)). {
-    unfold old_nonfrom_edges_to_are_pending_or_recorded.
-    intros e0 He0 Hsrc0 Hdst0.
-    left.
-    eapply Hpending; eauto.
-  }
-  unfold forward_remset_gh in Hfrg.
-  rewrite <- nth_remset_space_Znth in Hfrg.
-  pose proof (forward_remset_item_fold_pending_or_recorded
-                from to base (nth_remset_space rh from)
-                g h rh rmst g' h' rh' rmst'
-                Hrange Hfrg (dst base e) Hpor) as Hrecorded.
-  specialize (Hrecorded e Hevalid Hsrcgen eq_refl).
-  destruct Hrecorded as [Hnil | Hrecorded].
-  - destruct Hnil as [item [Hin _]].
-    contradiction.
-  - now apply remset_space_records_edge_interior.
 Qed.
 
 Lemma forward_remset_item_recorded_old_edge_target_marked:

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -8575,27 +8575,6 @@ Proof.
     apply firstn_gen_clear_add; auto.
 Qed.
 
-Lemma ngr_no_unrecorded_backward_edge: forall g1 g2 rh gen,
-    no_unrecorded_backward_edge g1 rh ->
-    new_gen_relation gen g1 g2 ->
-    no_unrecorded_backward_edge g2 rh.
-Proof.
-  intros g1 g2 rh gen Hnur Hngr.
-  unfold new_gen_relation in Hngr.
-  destruct (graph_has_gen_dec g1 gen).
-  - subst g2. assumption.
-  - destruct Hngr as [gen_i [Hempty Hg2]].
-    subst g2.
-    unfold no_unrecorded_backward_edge in *.
-    intros e He Hback.
-    apply Hnur; auto.
-    destruct e as [v idx].
-    destruct He as [Hv Hin].
-    split.
-    + eapply ang_graph_has_v_inv; eauto.
-    + exact Hin.
-Qed.
-
 Lemma new_gen_heap_graph_unmarked: forall g1 h1 g2 h2 gen,
     graph_unmarked g1 -> new_gen_heap_relation gen g1 h1 g2 h2 ->
     graph_unmarked g2.
@@ -8618,15 +8597,6 @@ Lemma new_gen_heap_no_dangling_dst: forall g1 h1 g2 h2 gen,
     no_dangling_dst g2.
 Proof.
   intros. eapply ngr_no_dangling_dst; eauto.
-  eapply new_gen_heap_new_gen_relation; eauto.
-Qed.
-
-Lemma new_gen_heap_no_unrecorded_backward_edge: forall g1 h1 g2 h2 rh gen,
-    no_unrecorded_backward_edge g1 rh ->
-    new_gen_heap_relation gen g1 h1 g2 h2 ->
-    no_unrecorded_backward_edge g2 rh.
-Proof.
-  intros. eapply ngr_no_unrecorded_backward_edge; eauto.
   eapply new_gen_heap_new_gen_relation; eauto.
 Qed.
 
@@ -10185,7 +10155,7 @@ Proof.
     assert (Hun3: graph_unmarked g3) by
         (eapply new_gen_heap_graph_unmarked; eauto).
     assert (Hunrec3: no_unrecorded_backward_edge g3 rh1) by
-        (eapply new_gen_heap_no_unrecorded_backward_edge; eauto).
+        (eapply new_gen_heap_no_unrecorded_backward_edge_pres; eauto).
     assert (Hrgc3: roots_graph_compatible roots1 g3) by
         (eapply new_gen_heap_roots_graph_compatible; eauto).
     assert (Hndd3: no_dangling_dst g3) by
@@ -10346,4 +10316,63 @@ Proof.
               [lia | exact Hto3 | apply graph_unmarked_copy_compatible; exact Hun3
                | exact Hrgc3 | exact H2]
             | exact H15 ].
+Qed.
+
+Lemma remset_graph_state_from_spec_pre:
+  forall g outlier from rmst rh h,
+    remset_nodup rmst ->
+    remset_compatible g outlier from rmst rh h ->
+    remset_generation_compatible from rmst rh ->
+    remset_graph_state g from rmst rh.
+Proof.
+  intros g outlier from rmst rh h Hrnd Hremc Hremgen.
+  split; [|exact Hremgen].
+  unfold remset_forward_compatible.
+  split; [exact Hrnd | split].
+  - destruct Hremc as [Hrgoc _].
+    now apply remset_graph_outlier_compatible_weakened with (outlier := outlier).
+  - destruct Hremc as [_ [Hrrhc _]]. exact Hrrhc.
+Qed.
+
+Lemma remset_compatible_remset_heap_covers_graph:
+  forall g h rootpairs roots outlier from rmst rh,
+    super_compatible g h rootpairs roots outlier ->
+    remset_compatible g outlier from rmst rh h ->
+    remset_heap_covers_graph g rh.
+Proof.
+  intros g h rootpairs roots outlier from rmst rh Hsc Hremc.
+  split.
+  - destruct Hremc as [_ [_ Hrhhc]].
+    apply Forall2_length in Hrhhc.
+    rewrite Zlength_correct, Hrhhc.
+    rewrite <- Zlength_correct.
+    apply spaces_size.
+  - intros gen Hgen.
+    destruct Hsc as [Hghc _].
+    eapply gen_range; eauto.
+Qed.
+
+Theorem garbage_collect_spec_preconditions_imply_isomorphism:
+  forall rootpairs roots roots' g h rh rmst g' h' rh' rmst' outlier,
+    super_compatible g h rootpairs roots outlier ->
+    garbage_collect_condition g h ->
+    no_unrecorded_backward_edge g rh ->
+    remset_compatible g outlier O rmst rh h ->
+    remset_generation_compatible O rmst rh ->
+    remset_nodup rmst ->
+    sound_gc_graph g ->
+    garbage_collect_relation roots roots' g h rh rmst g' h' rh' rmst' ->
+    gc_graph_iso g roots g' roots'.
+Proof.
+  intros rootpairs roots roots' g h rh rmst g' h' rh' rmst' outlier
+         Hsc Hgcc Hunrec Hremc Hremgen Hrnd Hsound Hrel.
+  eapply garbage_collect_isomorphism.
+  - destruct Hgcc as [Hun _]. exact Hun.
+  - exact Hunrec.
+  - destruct Hgcc as [_ [Hndd _]]. exact Hndd.
+  - destruct Hsc as [_ [_ [[_ Hroots] _]]]. exact Hroots.
+  - exact Hsound.
+  - eapply remset_graph_state_from_spec_pre; eauto.
+  - eapply remset_compatible_remset_heap_covers_graph; eauto.
+  - exact Hrel.
 Qed.

--- a/CertiGC/gc_spec.v
+++ b/CertiGC/gc_spec.v
@@ -597,6 +597,7 @@ Definition garbage_collect_spec :=
     PROP (readable_share rsh; writable_share sh;
           super_compatible g (ti_heap t_info).(pt_heap) (frames2rootpairs (ti_frames t_info)) roots outlier;
           garbage_collect_condition g (ti_heap t_info).(pt_heap);
+          no_unrecorded_backward_edge g rh;
           safe_to_copy_heap g (ti_heap t_info).(pt_heap);
           remset_compatible g outlier O rmst rh (ti_heap t_info).(pt_heap);
           remset_generation_compatible O rmst rh)

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -223,136 +223,6 @@ intuition.
 apply andp_left2; auto.
 Qed.
 
-Lemma field_compatible0_Tarray_offset:
-(* can delete this after VST issue #700 is resolved in a release *)
- forall {cs: compspecs} t n i n' i' p p',
-  field_compatible0 (Tarray t n' noattr) (ArraySubsc i' :: nil) p ->
-  0 <= n <= n' ->
-  0 <= i <= n ->
-  n-i <= n'-i' ->
-  i <= i' ->
-  p' = offset_val (sizeof t * (i'-i)) p ->
-  field_compatible0 (Tarray t n noattr) (ArraySubsc i :: nil) p'.
-Proof.
-intros until 1. intros ?H ?H Hni Hii Hp. subst p'.
-  assert (SP := sizeof_pos t).
-  assert (SS: sizeof t * n <= sizeof t * n').
-  apply Zmult_le_compat_l. lia. lia.
-  assert (SS': (sizeof t * n + sizeof t * (n'-n) = sizeof t * n')%Z).
-  rewrite <- Z.mul_add_distr_l. f_equal. lia.
-  hnf in H|-*.
-  intuition auto with field_compatible.
-  *
-  destruct p; try contradiction.
-  clear - SP SS SS' H H4 H0 H5 H3 H8 Hni Hii.
-  red in H3|-*.
-  unfold expr.sizeof in *.
-  simpl in H3,H8|-*. rewrite Z.max_r in H3|-* by lia.
-  rename i0 into j.
-   pose proof (Ptrofs.unsigned_range j).
-   fold (sizeof t) in *.
-   assert (0 <= sizeof t * (i'-i) <= sizeof t * n').
-   split. apply Z.mul_nonneg_nonneg; lia.
-   apply Zmult_le_compat_l. lia. lia.
-  assert (sizeof t * (i'-i+n) <= sizeof t * n').
-   apply Zmult_le_compat_l. lia. lia.
-  unfold Ptrofs.add.
-  rewrite (Ptrofs.unsigned_repr (_ * _))
-    by (change Ptrofs.max_unsigned with (Ptrofs.modulus -1); lia).
-  rewrite Ptrofs.unsigned_repr_eq.
-  rewrite Zmod_small by lia.
-  pose proof Z.mul_add_distr_l (sizeof t) (i' - i) n.
-  lia.
- *
-   destruct p; try contradiction.
-   simpl in H3, H6 |- *.
-  unfold expr.sizeof in *.
-   simpl in H3, H6 |- *.
-   rewrite Z.max_r in H3 by lia.
-   constructor; intros.
-  unfold Ptrofs.add.
-   rewrite !Ptrofs.unsigned_repr_eq.
-  assert (Ptrofs.modulus <> 0) by computable.
-  rewrite Z.add_mod by auto.
-  rewrite Z.mod_mod by auto.
-  rewrite <- Z.add_mod by auto.
-  inv_int i0.
-   fold (sizeof t) in *.
-  pose_size_mult cs t (0 :: i' - i :: i' - i + i1 ::  n' :: nil).
-  rewrite Zmod_small by lia.
-  rewrite <- Z.add_assoc, <- H14.
-  eapply align_compatible_rec_Tarray_inv; [eassumption |].
-  lia.
-Qed.
-
-Lemma iter_sepcon_frame2rootpairs':
- forall (sh: share) (r: val) (s: list val),
- field_compatible0 (tarray int_or_ptr_type (Zlength s)) [] r ->
-  iter_sepcon (frame2rootpairs' r 0 s)
-    (fun av  =>  data_at sh int_or_ptr_type (rp_val av) (rp_adr av)) =
-  data_at sh (tarray int_or_ptr_type (Zlength s)) s r.
-Proof.
-  intros.
-  replace r with (offset_val (0*WORD_SIZE) r) at 2 by (apply isptr_offset_val_zero; auto with field_compatible).
-  set (n := Zlength s) in *.
-  unfold n.
-  replace 0 with (n - Zlength s) by lia.
-  assert (Zlength s <= n) by lia. clearbody n.
-  induction s; simpl.
-  change (Zlength nil) with 0.
-  rewrite data_at_zero_array_eq; try reflexivity. auto with field_compatible.
-  change (a::s) with ([a]++s).
-  rewrite split2_data_at_Tarray_app with (mid:=1) by list_solve.
-  f_equal.
-  symmetry.
-  apply data_at_singleton_array_eq; auto.
-  replace (Z.succ _) with (n - Zlength s) by list_solve.
-  rewrite IHs by list_solve.
-  replace (Zlength _ - _) with (Zlength s) by list_solve.
-  f_equal.
-  replace (Zlength (_ ++ _)) with (1 + Zlength s) by list_solve.
-  unfold field_address0.
-  rewrite if_true.
-  simpl. rewrite offset_offset_val. f_equal.
-  change WORD_SIZE with 8.
-  lia.
-  eapply (field_compatible0_Tarray_offset int_or_ptr_type (1+Zlength s) 1).
-  apply arr_field_compatible0. apply H.
-  instantiate (1:= n - Zlength s).
-  1,2,3,4,5: list_solve.
-  f_equal.
-  simpl. change WORD_SIZE with 8. lia.
-Qed.
-
-(*
-Lemma frames_rep_eq: forall sh frs, frames_rep sh frs =
-Proof.
-  induction frs as [ | [a r s] frs'].
-  - simpl; rewrite emp_sepcon; auto.
-  - unfold frames_rep; fold frames_rep. rewrite IHfrs'; clear IHfrs'.
-    unfold frames2rootpairs; fold frames2rootpairs.
-    unfold map; fold (map frame2rootpairs).
-    change (concat (?A :: ?B)) with (A ++ concat B).
-    unfold frames_shell_rep; fold frames_shell_rep.
-    unfold roots_rep.
-    rewrite iter_sepcon_app_sepcon.
-    rewrite <- !sepcon_assoc.
-    pull_right (frames_shell_rep sh frs').
-    f_equal.
-    f_equal.
-    unfold frame2rootpairs. simpl.
-    symmetry.
-    rewrite sepcon_andp_prop'.
-    rewrite sepcon_comm.
-    rewrite <- sepcon_andp_prop'.
-    rewrite sepcon_comm.
-    f_equal.
-    rewrite data_at_tarray_field_compatible0.
-    apply andp_prop_ext. reflexivity. intro. clear a frs'.
-    apply iter_sepcon_frame2rootpairs'; auto.
-Qed.
-*)
-
 Lemma frames_shell_rep_update:
  forall (sh: share) (frs: list frame) (rootvals: list val),
   Zlength rootvals = Zlength (frames2rootpairs frs) ->
@@ -997,29 +867,6 @@ Proof.
                                  (nat_inc_list (length (g_gen (glabel g)))) gen);
     [rewrite nat_inc_list_In_iff; assumption | apply derives_refl].
 Qed.
-
-(*
-Lemma graph_and_heap_rest_valid_ptr: forall (g: LGraph) (h: heap) gen,
-    graph_has_gen g gen -> ti_size_spec h ->
-    graph_heap_compatible g h ->
-    graph_rep g * heap_unused_rep h |-- valid_pointer (space_start (nth_space h gen)).
-Proof.
-  intros. sep_apply (graph_and_heap_rest_data_at_ _ _ _ H H1).
-  unfold generation_data_at_. destruct (gt_gs_compatible _ _ H1 _ H) as [? [? ?]].
-  sep_apply (data_at__memory_block_cancel
-               (nth_sh g gen)
-               (tarray int_or_ptr_type (available_size h gen)) (gen_start g gen)).
-  simpl sizeof. rewrite Z.max_r by
-      (unfold available_size; apply (proj1 (available_space_range (nth_space h gen)))).
-  unfold gen_start. if_tac. 2: contradiction.
-  rewrite H2. fold WORD_SIZE.
-  sep_apply (memory_block_valid_ptr
-               (nth_sh g gen) (WORD_SIZE * available_size h gen)
-               (space_start (nth_space h gen))); unfold WORD_SIZE;
-    [|pose proof (ti_size_gt_0 g h gen H1 H5 H0); lia | entailer!!].
-  unfold nth_sh. apply readable_nonidentity, writable_readable,
-                 generation_share_writable.
-Qed. *)
 
 Lemma heap_space_remset_rep: forall g h rh gen,
     graph_has_gen g gen ->
@@ -1963,34 +1810,6 @@ Proof.
   rewrite generation_rep_reset_same by assumption.
   rewrite emp_sepcon, sepcon_comm. reflexivity.
 Qed.
-
-(*
-Lemma heap_unused_rep_reset: forall (g: LGraph) h gen,
-    graph_heap_compatible g h -> graph_has_gen g gen ->
-    heap_unused_rep h *
-    generation_rep g gen |-- heap_unused_rep (reset_nth_heap gen h).
-Proof.
-  intros. unfold heap_unused_rep. simpl.
-  assert (gen < length (spaces h))%nat by
-      (red in H0; destruct H as [_ [_ ?]]; lia).
-  destruct (reset_nth_space_Permutation _ _ H1) as [l [? ?]].
-  rewrite (iter_sepcon_permutation _ H3). rewrite (iter_sepcon_permutation _ H2).
-  simpl. cancel. destruct (gt_gs_compatible _ _ H _ H0) as [? [? ?]].
-  fold (nth_space h gen). unfold space_unused_rep. unfold reset_space at 1.
-  assert (isptr (space_start (nth_space h gen))) by
-      (rewrite <- H4; apply start_isptr).
-  assert (space_start (nth_space h gen) <> nullval). {
-    destruct (space_start (nth_space h gen)); try contradiction.
-    intro; inversion H8. } simpl space_start. rewrite !if_false by assumption.
-  sep_apply (generation_rep_data_at_ g gen H0). unfold graph_gen_size. rewrite H6.
-  unfold gen_start. rewrite if_true by assumption. rewrite H4. unfold nth_sh.
-  rewrite H5. simpl. remember (nth_space h gen).
-  replace (WORD_SIZE * 0)%Z with 0 by lia.
-  rewrite isptr_offset_val_zero by assumption.
-  replace (available_space s - 0) with (available_space s) by lia.
-  rewrite <- data_at__tarray_value by apply used_leq_available. cancel.
-Qed.
-*)
 
 Definition space_token_rep (sp: space): mpred :=
   if Val.eq (space_start sp) nullval then emp

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -898,6 +898,13 @@ Proof.
   now apply derives_unfash_fash.
 Qed.
 
+Lemma weak_derives_strong: forall (P Q: mpred), P |-- Q -> P |-- (weak_derives P Q && emp) * P.
+Proof.
+  intros. cancel; apply andp_right; [|cancel].
+  assert (HS: emp |-- TT) by entailer; sep_apply HS; clear HS.
+  now apply derives_weak.
+Qed.
+
 Definition heap_rest_gen_data_at_ (g: LGraph) (h: part_heap) (gen: nat) :=
   data_at_ (nth_sh g gen)
            (tarray int_or_ptr_type

--- a/CertiGC/verif_do_generation.v
+++ b/CertiGC/verif_do_generation.v
@@ -372,12 +372,7 @@ Proof.
           eapply (forward_remset_item_fold_roots_graph_compatible_pres
                     from to g h rh rmst (Znth (Z.of_nat from) rh)
                     g0 h0 rh0 rmst0 roots).
-          -- exact H1.
           -- exact Hto.
-          -- exact Hcc.
-          -- exact Hrmnd.
-          -- exact Hrcw.
-          -- exact Hrrsc.
           -- exact Hfrg0'.
           -- exact Hrgc.
         * eapply (forward_remset_item_fold_oc

--- a/CertiGC/verif_do_generation.v
+++ b/CertiGC/verif_do_generation.v
@@ -9,7 +9,6 @@ Require Import CertiGraph.CertiGC.env_graph_gc.
 Require Import CertiGraph.CertiGC.spatial_gcgraph.
 Require Import CertiGraph.msl_ext.iter_sepcon.
 Require Import CertiGraph.CertiGC.gc_spec.
-Require Import CertiGraph.CertiGC.forward_lemmas.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
 
 Local Open Scope logic.

--- a/CertiGC/verif_forward_remset.v
+++ b/CertiGC/verif_forward_remset.v
@@ -10,7 +10,6 @@ Require Import CertiGraph.CertiGC.spatial_gcgraph.
 Require Import CertiGraph.msl_ext.iter_sepcon.
 Require Import CertiGraph.CertiGC.gc_spec.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
-Require Import CertiGraph.CertiGC.forward_lemmas.
 
 #[local] Open Scope logic.
 

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -467,11 +467,12 @@ Proof.
                        space_address (ti_heap_p tif) (Z.to_nat j)). {
           intros. unfold space_address. now rewrite Z2Nat.id. }
   unfold before_gc_thread_info_rep, heap_management_rep, heap_struct_rep. Intros.
-  rename H1 into Hsafeh. rename H2 into Hremc. rename H3 into Hremgen.
+  rename H1 into Hunrec_init. rename H2 into Hsafeh.
+  rename H3 into Hremc. rename H4 into Hremgen.
   pose proof H0 as Hgcc_init.
   assert (Hsafe_graph: safe_to_copy g) by
       (eapply safe_to_copy_heap_implies_safe_to_copy;
-       [apply (proj1 H) | destruct H0 as [_ [_ [_ Hsize]]]; exact Hsize | exact Hsafeh]).
+       [apply (proj1 H) | destruct H0 as [_ [_ Hsize]]; exact Hsize | exact Hsafeh]).
   forward.
   pose proof H as Hsc_init.
   destruct Hsc_init as [Hghc_init _].
@@ -505,6 +506,7 @@ Proof.
      EX rh': remset_heap, EX rmst': remset,
      PROP (super_compatible g' (ti_heap t_info').(pt_heap) (frames2rootpairs (ti_frames t_info')) roots' outlier;
            garbage_collect_condition g' (ti_heap t_info').(pt_heap);
+           no_unrecorded_backward_edge g' rh';
            safe_to_copy_to_except g' (Z.to_nat i);
            safe_to_copy_to_except_heap g' (ti_heap t_info').(pt_heap) (Z.to_nat i);
            firstn_gen_clear g' (Z.to_nat i);
@@ -525,7 +527,7 @@ Proof.
           all_string_constants rsh gv;
           outlier_rep outlier;
           graph_rep g')).
-  - Exists g roots t_info rh rmst. destruct Hgcc_init as [? [? [? ?]]].
+  - Exists g roots t_info rh rmst. destruct Hgcc_init as [? [? ?]].
     pose proof (graph_has_gen_O g). entailer!!.
     repeat split.
     + apply stc_stcte_O_iff; assumption.
@@ -535,11 +537,11 @@ Proof.
     + apply frame_shells_eq_refl.
   - cbv beta. Intros g' roots' t_info' rh' rmst'.
     rename H5 into Hsc_loop. rename H6 into Hgcc_loop.
-    rename H7 into Hstcte_loop. rename H8 into Hstcteh_loop.
-    rename H9 into Hfirst_loop. rename H10 into Hgcl_loop.
-    rename H11 into Hhas_i_loop. rename H12 into FSE.
-    rename H13 into HN. rename H14 into Hremc_loop.
-    rename H15 into Hremgen_loop.
+    rename H7 into Hunrec_loop. rename H8 into Hstcte_loop.
+    rename H9 into Hstcteh_loop. rename H10 into Hfirst_loop.
+    rename H11 into Hgcl_loop. rename H12 into Hhas_i_loop.
+    rename H13 into FSE. rename H14 into HN.
+    rename H15 into Hremc_loop. rename H16 into Hremgen_loop.
     unfold thread_info_rep, heap_rep. Intros.
     unfold heap_struct_rep.
     assert (Hi1_range: 0 <= i + 1 < Zlength (spaces (ti_heap t_info').(pt_heap))) by
@@ -554,6 +556,7 @@ Proof.
        EX rh1: remset_heap, EX rmst1: remset,
        PROP (super_compatible g1 (pt_heap (ti_heap t_info1)) (frames2rootpairs (ti_frames t_info1)) roots' outlier;
              garbage_collect_condition g1 (pt_heap (ti_heap t_info1));
+             no_unrecorded_backward_edge g1 rh1;
              safe_to_copy_to_except g1 (Z.to_nat i);
              safe_to_copy_to_except_heap g1 (pt_heap (ti_heap t_info1)) (Z.to_nat i);
              firstn_gen_clear g1 (Z.to_nat i);
@@ -586,7 +589,7 @@ Proof.
         pose proof Hremc_loop as Hremc'.
         destruct Hremc' as [_ [_ Hrhhc']].
         pose proof (Forall2_length Hrhhc') as Hrh_len'.
-        destruct Hgcc_loop as [_ [_ [_ Hsize']]].
+        destruct Hgcc_loop as [_ [_ Hsize']].
         sep_apply (graph_and_heap_remset_valid_ptr
                      g' (pt_heap (ti_heap t_info')) rh' _ H14 Hghc' Hrh_len' Hsize').
         rewrite nth_space_Znth, Z2Nat.id by lia.
@@ -613,7 +616,7 @@ Proof.
       subst s.
       rewrite sem_sub_pp_total_space by exact Hstart_i.
       pose proof Hgcc_loop as Hgcc'.
-      destruct Hgcc' as [_ [_ [_ Hsize_spec']]].
+      destruct Hgcc' as [_ [_ Hsize_spec']].
       pose proof (ti_size_gen _ _ _ (proj1 Hsc_loop) Hhas_i_loop Hsize_spec') as Htotal_i.
       unfold total_size in Htotal_i.
       rewrite nth_space_Znth, Z2Nat.id in Htotal_i by lia.
@@ -750,7 +753,7 @@ Proof.
         2: exact Hgi_empty.
         2: { destruct Hgcc_loop as [Hunmarked _].
              apply graph_unmarked_copy_compatible; assumption. }
-        2: { destruct Hgcc_loop as [_ [_ [Hndd _]]]. exact Hndd. }
+        2: { destruct Hgcc_loop as [_ [Hndd _]]. exact Hndd. }
         rewrite <- Heqg1.
         assert (Hi1_nat: Z.to_nat (i + 1) = S (Z.to_nat i)) by
             (rewrite Z2Nat.inj_add by lia; simpl; lia).
@@ -767,7 +770,7 @@ Proof.
           - apply (proj1 Hsc_loop).
           - exact Hhas_i_loop.
           - intro Hnext. apply Hnext_null. rewrite Hi1_nat. exact Hnext.
-          - destruct Hgcc_loop as [_ [_ [_ Hsize']]]. exact Hsize'.
+          - destruct Hgcc_loop as [_ [_ Hsize']]. exact Hsize'.
           - subst sp; simpl. rewrite Hi1_nat. reflexivity.
           - exact Hfresh_sp.
           - subst sp; simpl; reflexivity.
@@ -775,6 +778,8 @@ Proof.
         }
         assert (garbage_collect_condition g1 (pt_heap (ti_heap t_info1))) by
             (subst g1 t_info1; apply gcc_add; assumption).
+        assert (no_unrecorded_backward_edge g1 rh') by
+            (subst g1 t_info1; eapply new_gen_heap_no_unrecorded_backward_edge_pres; eauto).
         pose proof Hremc_loop as Hremc_parts.
         destruct Hremc_parts as [Hrgo [Hrgh Hrhh]].
         assert (remset_compatible g1 outlier (Z.to_nat i) rmst' rh'
@@ -806,12 +811,12 @@ Proof.
     + Intros g1 t_info1 rh1 rmst1.
       clear FSE HN.
       rename H6 into Hsc1. rename H7 into Hgcc1.
-      rename H8 into Hstcte1. rename H9 into Hstcteh1.
-      rename H10 into Hfirst1. rename H11 into Hnewgen1.
-      rename H12 into Hgen1_next. rename H13 into FSE.
-      rename H14 into HN. rename H15 into Hrh1_eq.
-      rename H16 into Hrmst1_eq. rename H17 into Hremc1.
-      rename H18 into Hremgen1.
+      rename H8 into Hunrec1. rename H9 into Hstcte1.
+      rename H10 into Hstcteh1. rename H11 into Hfirst1.
+      rename H12 into Hnewgen1. rename H13 into Hgen1_next.
+      rename H14 into FSE. rename H15 into HN.
+      rename H16 into Hrh1_eq. rename H17 into Hrmst1_eq.
+      rename H18 into Hremc1. rename H19 into Hremgen1.
       assert_PROP (isptr (ti_heap_p t_info1)) as Hheap_p1
         by (unfold thread_info_rep, heap_rep, heap_struct_rep; entailer!).
       assert_PROP (remset_nodup rmst1) as Hrmnd1. {
@@ -895,7 +900,7 @@ Proof.
       rewrite Znth_map by assumption. unfold space_quad at 1 2. rewrite Hi1_nat2 in *.
 
       assert (Hgcc2: garbage_collect_condition g2 (pt_heap (ti_heap t_info2))). {
-        destruct Hgcc1 as [Hun1 [Hnbe1 [Hndd1 Hsize1]]].
+        destruct Hgcc1 as [Hun1 [Hndd1 Hsize1]].
         eapply (do_generation_relation_gcc
                   g1 (pt_heap (ti_heap t_info1)) rh1 rmst1
                   g_rem h_rem rh2 rmst2 g2
@@ -915,7 +920,7 @@ Proof.
         eapply do_generation_relation_stcteh; eauto.
         - apply (proj1 Hsc1).
         - apply (proj1 H9).
-        - destruct Hgcc1 as [_ [_ [_ Hsize1]]]. exact Hsize1.
+        - destruct Hgcc1 as [_ [_ Hsize1]]. exact Hsize1.
       }
       sep_apply gather_thread_info_rep.
       assert (Hrel_loop:
@@ -972,7 +977,7 @@ Proof.
         end.
         2: apply rest_space_repable_signed. 2: apply total_space_repable_signed.
         assert (safe_to_copy_gen g2 (Z.to_nat i) (S (Z.to_nat i))). {
-          red. destruct H9 as [Hghc2 _]. destruct Hgcc2 as [_ [_ [_ Hsize2]]].
+          red. destruct H9 as [Hghc2 _]. destruct Hgcc2 as [_ [_ Hsize2]].
           pose proof (ti_size_gen g2 h2 (Z.to_nat i) Hghc2 Hhas_i_g2 Hsize2)
             as Htotal_from.
           pose proof (ti_size_gen g2 h2 (S (Z.to_nat i)) Hghc2 Hhas_i1_g2 Hsize2)
@@ -1226,10 +1231,36 @@ Proof.
                      (pt_heap (ti_heap t_info2)) outlier
                      Hto1 Hrel_loop Hnofrom Hrgoc_rem Hrrhc_rem
                      Hrhhc_rem Hremgen_next).
+        assert (Hunrec1':
+                  no_unrecorded_backward_edge g1 rh') by
+            (rewrite <- Hrh1_eq; exact Hunrec1).
+        assert (Hremc1':
+                  remset_compatible g1 outlier (Z.to_nat i) rmst'
+                    rh' (pt_heap (ti_heap t_info1))) by
+            (rewrite <- Hrmst1_eq, <- Hrh1_eq; exact Hremc1).
+        assert (Hroots1: roots_graph_compatible roots' g1) by
+            (destruct Hsc1 as [_ [_ [[_ Hroots1] _]]]; exact Hroots1).
+        assert (Hgun1: graph_unmarked g1) by
+            (destruct Hgcc1 as [Hgun1 _]; exact Hgun1).
+        assert (Hfirst2': firstn_gen_clear g2 (S (Z.to_nat i))) by
+            (rewrite <- Hi1_nat2; exact Hfirst2).
+        assert (Hndd2': no_dangling_dst g2) by
+            (destruct Hgcc2 as [_ [Hndd2' _]]; exact Hndd2').
+        assert (Hunrec_next:
+                  no_unrecorded_backward_edge g2
+                    (reset_nth_remset_heap (Z.to_nat i) rh2)). {
+          exact (do_generation_relation_no_unrecorded_backward_edge_reset
+                   g1 (pt_heap (ti_heap t_info1)) rh' rmst'
+                   g_rem h_rem rh2 rmst2 g2
+                   (pt_heap (ti_heap t_info2)) roots' roots2
+                   (Z.to_nat i) outlier Hto1 Hgun1 Hcc1 Hndd1
+                   Hunrec1' Hfirst1 Hroots1 Hrmnd1' Hremc1'
+                   Hfirst2' Hndd2' Hrange_to_rh1 Hrel_loop).
+        }
         assert (Hrgc_rem: remset_graph_compatible g_rem rmst2) by
             (eapply remset_graph_outlier_compatible_weakened; exact Hrgoc_rem).
         rewrite <- Hi1_nat2 in *. entailer!!; try exact Hremc_next;
-          try exact Hremgen_next.
+          try exact Hremgen_next; try exact Hunrec_next.
         assert (Hlen_rem: length rh2 = length (spaces h_rem)) by
             (apply rhhc_length_eq; exact Hrhhc_rem).
         assert (Hfrom_h2: (Z.to_nat i < length (spaces h2))%nat). {

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -3,6 +3,25 @@ Require Import CertiGraph.msl_ext.iter_sepcon.
 
 Local Open Scope logic.
 
+Lemma sem_sub_pp_word_offsets: forall base hi lo, isptr base ->
+    Ptrofs.min_signed <= WORD_SIZE * (hi - lo) <= Ptrofs.max_signed ->
+    force_val (sem_sub_pp int_or_ptr_type (offset_val (WORD_SIZE * hi) base)
+                            (offset_val (WORD_SIZE * lo) base)) =
+    if Archi.ptr64 then Vlong (Int64.repr (hi - lo)) else
+      Vint (Int.repr (hi - lo)).
+Proof.
+  intros base hi lo Hptr Hrange; destruct base; try contradiction; simpl.
+  destruct (eq_block b b); [|contradiction n; reflexivity].
+  inv_int i; unfold sem_sub_pp; destruct eq_block; [|easy].
+  rewrite !ptrofs_add_repr, ptrofs_sub_repr.
+  replace (ofs + WORD_SIZE * hi - (ofs + WORD_SIZE * lo))
+    with (WORD_SIZE * (hi - lo))%Z by (rewrite Z.mul_sub_distr_l; lia).
+  simpl; rewrite Vptrofs_unfold_true by reflexivity.
+  unfold Ptrofs.divs; rewrite !Ptrofs.signed_repr by rep_lia.
+  rewrite ptrofs_to_int64_repr by reflexivity.
+  do 2 f_equal; unfold WORD_SIZE; rewrite Z.mul_comm, Z.quot_mul by lia; auto.
+Qed.
+
 Lemma sem_sub_pp_available_space: forall s,
     isptr (space_start s) ->
     force_val
@@ -12,17 +31,10 @@ Lemma sem_sub_pp_available_space: forall s,
     if Archi.ptr64 then Vlong (Int64.repr (available_space s)) else
       Vint (Int.repr (available_space s)).
 Proof.
-  intros. destruct (space_start s); try contradiction. simpl. destruct (eq_block b b).
-  2: exfalso; apply n; reflexivity.
-  unfold sem_sub_pp; destruct eq_block; [|easy].
-  inv_int i. rewrite ptrofs_add_repr, ptrofs_sub_repr.
-  replace (ofs + WORD_SIZE * available_space s - ofs) with
-      (WORD_SIZE * available_space s)%Z by lia. simpl.
-  pose proof (available_space_signed_range s). unfold Ptrofs.divs.
-  rewrite !Ptrofs.signed_repr by rep_lia.
-  rewrite Vptrofs_unfold_true, ptrofs_to_int64_repr by reflexivity.
-  do 2 f_equal.
-  unfold WORD_SIZE. rewrite Z.mul_comm, Z.quot_mul by lia. auto.
+  intros s Hptr; rewrite <- (isptr_offset_val_zero (space_start s)) at 2 by exact Hptr.
+  replace (offset_val 0 (space_start s)) with (offset_val (WORD_SIZE * 0) (space_start s))
+    by (f_equal; lia); rewrite (sem_sub_pp_word_offsets (space_start s) (available_space s) 0)
+    by (try exact Hptr; pose proof (available_space_signed_range s); lia); now rewrite Z.sub_0_r.
 Qed.
 
 Lemma sem_sub_pp_total_space: forall s,
@@ -34,17 +46,10 @@ Lemma sem_sub_pp_total_space: forall s,
     if Archi.ptr64 then Vlong (Int64.repr (total_space s)) else
       Vint (Int.repr (total_space s)).
 Proof.
-  intros. destruct (space_start s); try contradiction. simpl. destruct (eq_block b b).
-  2: exfalso; apply n; reflexivity.
-  unfold sem_sub_pp; destruct eq_block; [|easy].
-  inv_int i. rewrite ptrofs_add_repr, ptrofs_sub_repr.
-  replace (ofs + WORD_SIZE * total_space s - ofs) with
-      (WORD_SIZE * total_space s)%Z by lia. simpl.
-  pose proof (total_space_signed_range s). unfold Ptrofs.divs.
-  rewrite !Ptrofs.signed_repr by rep_lia.
-  rewrite Vptrofs_unfold_true, ptrofs_to_int64_repr by reflexivity.
-  do 2 f_equal.
-  unfold WORD_SIZE. rewrite Z.mul_comm, Z.quot_mul by lia. auto.
+  intros s Hptr; rewrite <- (isptr_offset_val_zero (space_start s)) at 2 by exact Hptr.
+  replace (offset_val 0 (space_start s)) with (offset_val (WORD_SIZE * 0) (space_start s))
+    by (f_equal; lia); rewrite (sem_sub_pp_word_offsets (space_start s) (total_space s) 0)
+    by (try exact Hptr; pose proof (total_space_signed_range s); lia); now rewrite Z.sub_0_r.
 Qed.
 
 Lemma sem_sub_pp_rest_space: forall s,
@@ -56,20 +61,10 @@ Lemma sem_sub_pp_rest_space: forall s,
     if Archi.ptr64 then Vlong (Int64.repr (available_space s - used_space s)) else
       Vint (Int.repr (available_space s - used_space s)).
 Proof.
-  intros. destruct (space_start s); try contradiction. simpl. destruct (eq_block b b).
-  2: exfalso; apply n; reflexivity.
-  inv_int i. unfold sem_sub_pp; destruct eq_block; [|easy].
-  rewrite !ptrofs_add_repr, ptrofs_sub_repr.
-  replace (ofs + WORD_SIZE * available_space s - (ofs + WORD_SIZE * used_space s)) with
-          (WORD_SIZE * (available_space s - used_space s))%Z by
-      (rewrite Z.mul_sub_distr_l; lia). simpl.
-  pose proof (rest_space_signed_range s). rewrite <- Z.mul_sub_distr_l in H0.
-  rewrite Vptrofs_unfold_true by reflexivity.
-  unfold Ptrofs.divs. rewrite !Ptrofs.signed_repr by rep_lia.
-  rewrite ptrofs_to_int64_repr by reflexivity.
-  do 2 f_equal.
-  unfold WORD_SIZE.
-  rewrite Z.mul_comm, Z.quot_mul by lia. auto.
+  intros s Hptr; rewrite (sem_sub_pp_word_offsets (space_start s) (available_space s) (used_space s)) by
+      (try exact Hptr; pose proof (rest_space_signed_range s);
+       rewrite <- Z.mul_sub_distr_l in H; exact H).
+  reflexivity.
 Qed.
 
 Lemma t_info_space_address: forall t_info i,

--- a/CoqMakefile.local
+++ b/CoqMakefile.local
@@ -111,10 +111,20 @@ GENERATED_FILES += dijkstra/dijkstra3.v
 dijkstra/dijkstra3.v: dijkstra/dijkstra3.c binheap/binary_heap_pro.h
 	$(CLIGHTGEN) $(CLG_FLAGS) $< -o $@
 
-generated_files: $(GENERATED_FILES)
-		 
+POSTPROCESS_GENERATED_FILES_STAMP := .generated_files.postprocessed
+
+generated_files: $(GENERATED_FILES) $(POSTPROCESS_GENERATED_FILES_STAMP)
+
+$(POSTPROCESS_GENERATED_FILES_STAMP): $(GENERATED_FILES)
+	@for f in $(GENERATED_FILES); do \
+		if [ -f "$$f" ]; then \
+			perl -pi -e 's/^From Coq Require /From Stdlib Require /' "$$f"; \
+		fi; \
+	done
+	@touch $@
 
 clean::
 #	rm -f CoqMakefile CoqMakefile.conf
 #	rm -f */{*.vo,*.vos,*.vok,*.glob} 
 	rm -f $(GENERATED_FILES)
+	rm -f $(POSTPROCESS_GENERATED_FILES_STAMP)

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,9 @@
 KNOWNTARGETS := CoqMakefile
 # KNOWNFILES will not get implicit targets from the final rule, and so
 # depending on them won't invoke the submake
-# Warning: These files get declared as PHONY, so any targets depending
-# on them always get rebuilt
 KNOWNFILES   := Makefile _CoqProject
-GENERATED_VFILES := CertiGC/gc_stack.v summatrix/summatrix.v \
-	kruskal/kruskal_edgelist.v unionfind/unionfind.v \
-	unionfind/unionfind_iter.v unionfind/unionfind_arr.v append/append.v \
-	mark/mark_bin.v binheap/binary_heap_pro.v binheap/binary_heap.v \
-	prim/noroot_prim.v prim/prim1.v prim/prim2.v prim/prim3.v \
-	priq/priq_arr.v dispose/dispose_bin.v copy/copy_bin.v \
-	dijkstra/dijkstra1.v dijkstra/dijkstra2.v dijkstra/dijkstra3.v
+
+$(KNOWNFILES): ;
 
 .DEFAULT_GOAL := invoke-coqmakefile
 
@@ -21,20 +14,10 @@ CoqMakefile: Makefile _CoqProject
 invoke-coqmakefile: CoqMakefile
 ifneq (clean,$(MAKECMDGOALS))
 	$(MAKE) -f CoqMakefile generated_files
-	$(MAKE) postprocess-generated-files
 endif
 	$(MAKE) --no-print-directory -f CoqMakefile $(filter-out $(KNOWNTARGETS),$(MAKECMDGOALS))
 
-.PHONY: invoke-coqmakefile $(KNOWNFILES)
-
-postprocess-generated-files:
-	@for f in $(GENERATED_VFILES); do \
-		if [ -f "$$f" ]; then \
-			perl -pi -e 's/^From Coq Require /From Stdlib Require /' "$$f"; \
-		fi; \
-	done
-
-.PHONY: postprocess-generated-files
+.PHONY: invoke-coqmakefile
 
 ####################################################################
 ##                      Your targets here                         ##


### PR DESCRIPTION
## Summary

This PR replaces the old `no_backward_edge`-based GC correctness route with a
remembered-set-aware invariant.

The previous invariant is not valid for mutable GC: mutator writes may create
old-to-young/backward edges. What the write barrier guarantees is not that such
edges never exist, but that they are recorded in the remembered set. The proof
therefore now uses `no_unrecorded_backward_edge`, which matches the mutable GC
semantics.

Main changes:

- replace the obsolete `no_backward_edge` route with
  `no_unrecorded_backward_edge`
- thread the remset invariant through `garbage_collect_spec`,
  `garbage_collect_relation`, and the main isomorphism proof
- prove that the `garbage_collect_spec` preconditions imply the final
  `garbage_collect_isomorphism` theorem
- repair the affected VST proofs for the mutable GC path
- preserve incremental builds for generated files
- remove stale proof leftovers and unused helper lemmas

## Verification

- `make -j8`

## Notes

The final mathematical theorem remains roots-level graph isomorphism. Remembered
sets are internal write-barrier state: they justify forwarding old-to-young
edges during collection, but they are not exposed in the final isomorphism
statement.
