### PR TITLE
CertiGC: verify mutable updates and streamline collector invariants

### DIFF
--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -361,6 +361,18 @@ Record part_heap: Type :=
     spaces_size: Zlength spaces = MAX_SPACES;
   }.
 
+Lemma part_heap_spaces_length_eq: forall h h',
+    length (spaces h) = length (spaces h').
+Proof.
+  intros. rewrite <- !ZtoNat_Zlength, !spaces_size. reflexivity.
+Qed.
+
+Lemma upd_heap_Zlength: forall (hp : part_heap) (sp : space) (i : Z),
+    0 <= i < MAX_SPACES -> Zlength (upd_Znth i (spaces hp) sp) = MAX_SPACES.
+Proof.
+  intros. rewrite upd_Znth_Zlength; rewrite spaces_size; [reflexivity | assumption].
+Qed.
+
 Lemma heap_spaces_nil: forall h: part_heap, nil = spaces h -> False.
 Proof.
   intros. pose proof spaces_size h. rewrite <- H, Zlength_nil in H0. discriminate.
@@ -1500,7 +1512,11 @@ Ltac unfold_cut_space := unfold cut_space; destruct (has_space_dec _ _); [| cont
 Lemma cut_heap_size: forall (h : part_heap) (i s : Z) ,
     0 <= i < Zlength (spaces h) ->
     Zlength (upd_Znth i (spaces h) (cut_space (Znth i (spaces h)) s)) = MAX_SPACES.
-Proof. intros. rewrite upd_Znth_Zlength; [apply spaces_size | assumption]. Qed.
+Proof.
+  intros h i s Hi.
+  apply (upd_heap_Zlength h (cut_space (Znth i (spaces h)) s) i).
+  rewrite <- (spaces_size h). exact Hi.
+Qed.
 
 Lemma spaces_index_dec: forall i h,
     { 0 <= i < Zlength (spaces h) } + { ~ 0 <= i < Zlength (spaces h) }.
@@ -1687,6 +1703,16 @@ Proof.
       remember (labeledgraph_gen_dst _ _ _) as gg. remember (cut_heap _ _ _) as hh.
       apply fr_e_to_not_forwarded_Sn; [assumption..|]. rewrite <- Heqgg.
       apply (H _ (gg ,hh)).
+Qed.
+
+Lemma fr_forward_graph_and_heap_eq:
+  forall from to depth p g h g' h',
+    (g', h') = forward_graph_and_heap from to depth p g h ->
+    forward_relation from to depth p g g'.
+Proof.
+  intros from to depth p g h g' h' Hfgh.
+  pose proof (fr_forward_graph_and_heap from to depth p g h) as Hfr.
+  rewrite <- Hfgh in Hfr. simpl in Hfr. exact Hfr.
 Qed.
 
 Lemma fl_fwd_gh_loop: forall from to depth l gh,
@@ -2220,6 +2246,21 @@ Lemma nth_space_Znth: forall h n,
 Proof.
   intros. unfold nth_space, Znth. rewrite if_false. 2: lia.
   rewrite Nat2Z.id. reflexivity.
+Qed.
+
+Lemma heap_head_nth_space_O: forall h,
+    heap_head h = nth_space h O.
+Proof.
+  intros h. destruct (heap_head_cons h) as [sp [rest [Hspaces Hhead]]].
+  unfold nth_space. rewrite Hspaces, Hhead. reflexivity.
+Qed.
+
+Lemma reset_nth_heap_nth_space_diff: forall h reset gen,
+    reset <> gen ->
+    nth_space (reset_nth_heap reset h) gen = nth_space h gen.
+Proof.
+  intros h reset gen Hneq. unfold nth_space, reset_nth_heap; simpl.
+  rewrite reset_nth_space_diff by lia. reflexivity.
 Qed.
 
 Definition available_size h n := available_space (nth_space h n).
@@ -3406,6 +3447,24 @@ Definition weak_heap_relation (h h': part_heap) :=
   (forall n, space_start (nth_space h n) = space_start (nth_space h' n)) /\
     forall n, total_size h n = total_size h' n.
 
+Lemma heap_relation_available_size: forall h h' n,
+    heap_relation h h' -> available_size h n = available_size h' n.
+Proof. intros h h' n [H _]. apply H. Qed.
+
+Lemma heap_relation_space_start: forall h h' n,
+    heap_relation h h' ->
+    space_start (nth_space h n) = space_start (nth_space h' n).
+Proof. intros h h' n [_ [H _]]. apply H. Qed.
+
+Lemma heap_relation_total_size: forall h h' n,
+    heap_relation h h' -> total_size h n = total_size h' n.
+Proof. intros h h' n [_ [_ [H _]]]. apply H. Qed.
+
+Lemma heap_relation_space_sh: forall h h' n,
+    heap_relation h h' ->
+    space_sh (nth_space h n) = space_sh (nth_space h' n).
+Proof. intros h h' n [_ [_ [_ H]]]. apply H. Qed.
+
 Lemma heap_relation_weakened: forall h h', heap_relation h h' -> weak_heap_relation h h'.
 Proof. intros h h' [? [? ?]]. now split. Qed.
 
@@ -4024,12 +4083,7 @@ Proof.
     + destruct (Nat.eq_dec n gen).
       * subst. rewrite reset_nth_space_same by assumption. reflexivity.
       * rewrite reset_nth_space_diff by assumption. reflexivity.
-  - unfold total_size, nth_space, reset_nth_heap; simpl.
-    destruct (le_lt_dec (length (spaces h)) gen).
-    + rewrite reset_nth_space_overflow by assumption. reflexivity.
-    + destruct (Nat.eq_dec n gen).
-      * subst. rewrite reset_nth_space_same by assumption. reflexivity.
-      * rewrite reset_nth_space_diff by assumption. reflexivity.
+  - symmetry. apply reset_nth_heap_total_size.
 Qed.
 
 #[global] Instance hr_Reflexive: Reflexive heap_relation := hr_refl.
@@ -6082,12 +6136,6 @@ Definition garbage_collect_condition (g: LGraph) (h : part_heap) : Prop :=
 
 #[local] Open Scope Z_scope.
 
-Lemma upd_heap_Zlength: forall (hp : part_heap) (sp : space) (i : Z),
-    0 <= i < MAX_SPACES -> Zlength (upd_Znth i (spaces hp) sp) = MAX_SPACES.
-Proof.
-  intros. rewrite upd_Znth_Zlength; rewrite spaces_size; [reflexivity | assumption].
-Qed.
-
 Definition add_new_space (hp: part_heap) (sp: space) i (Hs: 0 <= i < MAX_SPACES): part_heap :=
   Build_part_heap (upd_Znth i (spaces hp) sp) (upd_heap_Zlength hp sp i Hs).
 
@@ -7129,8 +7177,8 @@ Lemma forward_graph_and_heap_fc: forall from to depth p g h,
     forall g' h', (g', h') = forward_graph_and_heap from to depth p g h ->
              forward_condition g' h' from to.
 Proof.
-  intros. pose proof fr_forward_graph_and_heap from to depth p g h. rewrite <- H2 in H3.
-  simpl in H3. destruct H1 as [? [? [? [? ?]]]]. split; [|split; [|split; [|split]]].
+  intros. pose proof (fr_forward_graph_and_heap_eq from to depth p g h g' h' H2) as H3.
+  destruct H1 as [? [? [? [? ?]]]]. split; [|split; [|split; [|split]]].
   - eapply forward_graph_and_heap_estc; eassumption.
   - rewrite <- (fr_graph_has_gen depth from to); eassumption.
   - rewrite <- (fr_graph_has_gen depth from to); eassumption.
@@ -7170,6 +7218,16 @@ Proof.
       etransitivity; [| apply Hloop]. simpl. apply cut_heap_relation.
 Qed.
 
+Lemma heaprel_forward_graph_and_heap_eq:
+  forall from to depth p g h g' h',
+    (g', h') = forward_graph_and_heap from to depth p g h ->
+    heap_relation h h'.
+Proof.
+  intros from to depth p g h g' h' Hfgh.
+  pose proof (heaprel_forward_graph_and_heap from to depth p g h) as Hhr.
+  rewrite <- Hfgh in Hhr. simpl in Hhr. exact Hhr.
+Qed.
+
 Lemma forward_gh_loop_ghc: forall from to depth v l g h,
     from <> to ->
     no_dangling_dst g ->
@@ -7186,8 +7244,8 @@ Proof.
   induction l; intros g h H H0 H1 H2 H3 H4 H5 Hl g' h' Hgh'; simpl in *.
   1: inversion Hgh'; assumption.
   remember (forward_graph_and_heap from to _ _ _ _) as gh. destruct gh as [gg hh].
-  pose proof (fr_forward_graph_and_heap from to depth (interior2forward a g) g h) as Hfr.
-  rewrite <- Heqgh in Hfr. simpl fst in Hfr. rewrite Forall_cons_iff in Hl.
+  pose proof (fr_forward_graph_and_heap_eq from to depth (interior2forward a g) g h gg hh Heqgh) as Hfr.
+  rewrite Forall_cons_iff in Hl.
   destruct Hl as [Ha Hl]. destruct Ha as [i [Ha Hi]]. subst a. simpl interior2forward in *.
   assert (Ha: forward_t_compatible (field2forward (Znth i (make_fields g v))) g). {
     apply vertex_pos_forward_t_compatible; auto.
@@ -7214,8 +7272,8 @@ Proof.
   intros from to depth v l. induction l; intros g h H H0 Hfc Hl g' h' Hgh'; simpl in *.
   1: inversion Hgh'; assumption.
   remember (forward_graph_and_heap from to _ _ _ _) as gh. destruct gh as [gg hh].
-  pose proof (fr_forward_graph_and_heap from to depth (interior2forward a g) g h) as Hfr.
-  rewrite <- Heqgh in Hfr. simpl fst in Hfr. rewrite Forall_cons_iff in Hl.
+  pose proof (fr_forward_graph_and_heap_eq from to depth (interior2forward a g) g h gg hh Heqgh) as Hfr.
+  rewrite Forall_cons_iff in Hl.
   destruct Hl as [Ha Hl]. destruct Ha as [i [Ha Hi]]. subst a. simpl interior2forward in *.
   assert (Ha: forward_t_compatible (field2forward (Znth i (make_fields g v))) g). {
     apply vertex_pos_forward_t_compatible; auto.
@@ -7788,7 +7846,11 @@ Definition incr_remset_space (sp: space) : space :=
 Lemma incr_remset_heap_size: forall (h : part_heap) (i : Z) ,
     0 <= i < Zlength (spaces h) ->
     Zlength (upd_Znth i (spaces h) (incr_remset_space (Znth i (spaces h)))) = MAX_SPACES.
-Proof. intros. rewrite upd_Znth_Zlength; [apply spaces_size | assumption]. Qed.
+Proof.
+  intros h i Hi.
+  apply (upd_heap_Zlength h (incr_remset_space (Znth i (spaces h))) i).
+  rewrite <- (spaces_size h). exact Hi.
+Qed.
 
 Definition incr_remset_heap (h: part_heap) (i: Z): part_heap :=
   match spaces_index_dec i h with
@@ -8014,9 +8076,9 @@ Lemma forward_remset_item_ghg: forall from to g h rh rmst item g' h' rh' rmst',
 Proof.
   intros from to g h rh rmst item g' h' rh' rmst' Hghg Hfri gen. simpl in Hfri.
   destruct (negb _) eqn:?H. 2: inversion Hfri; tauto.
-  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:?H.
-  pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h.
-  rewrite H0 in H1. simpl in H1. inversion Hfri. eapply fr_graph_has_gen; eauto.
+  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh.
+  pose proof (fr_forward_graph_and_heap_eq from to 0 (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
+  inversion Hfri. eapply fr_graph_has_gen; eauto.
 Qed.
 
 Lemma forward_remset_item_fold_graph_property:
@@ -8052,9 +8114,9 @@ Lemma fri_copy_compatible: forall from to g h rh rmst item g' h' rh' rmst',
 Proof.
   intros from to g h rh rmst item g' h' rh' rmst' Hfr Hghg Hcc Hfri. simpl in Hfri.
   destruct (negb _) eqn:?H. 2: inversion Hfri; tauto.
-  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:?H.
-  pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h.
-  rewrite H0 in H1. simpl in H1. inversion Hfri. eapply fr_copy_compatible; eauto.
+  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh.
+  pose proof (fr_forward_graph_and_heap_eq from to 0 (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hrel.
+  inversion Hfri. eapply fr_copy_compatible; eauto.
 Qed.
 
 Lemma fri_no_dangling_dst: forall from to g h rh rmst item g' h' rh' rmst',
@@ -8067,9 +8129,9 @@ Lemma fri_no_dangling_dst: forall from to g h rh rmst item g' h' rh' rmst',
 Proof.
   intros from to g h rh rmst item g' h' rh' rmst' Hghg Hcc Hrc Hric Hndd Hfri. simpl in Hfri.
   destruct (negb _) eqn:?H. 2: inversion Hfri; tauto.
-  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:?H.
-  pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h.
-  rewrite H0 in H1. simpl in H1. inversion Hfri. eapply fr_O_no_dangling_dst ; eauto.
+  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh.
+  pose proof (fr_forward_graph_and_heap_eq from to 0 (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
+  inversion Hfri. eapply fr_O_no_dangling_dst ; eauto.
   eapply remset_item2forward_t_ftc; eauto.
 Qed.
 
@@ -8201,8 +8263,9 @@ Proof.
   intros from to g h rh rmst item g' h' rh' rmst' outlier Hghg Hcc Hrnd Hrc Hric Hfri.
   simpl in Hfri. destruct (negb _) eqn:?H. 2: inversion Hfri; assumption.
   destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh.
-  pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-  rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri. clear H Hfri. subst.
+  pose proof (fr_forward_graph_and_heap_eq from to 0
+                (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
+  inversion Hfri. clear H Hfri. subst.
   destruct item as [addr | intr]; simpl in *.
   - apply find_remset_ext_In_some in Hric. destruct Hric as [rext [Hfre Heae]].
     rewrite Hfre in Hfgh, Hfr. Transparent forward_graph_and_heap. destruct rext as [gpv | vtx].
@@ -8236,8 +8299,9 @@ Proof.
   intros from to g h rh rmst item g' h' rh' rmst' Hghg Hcc Hrnd Hrc Hric Hfri.
   simpl in Hfri. destruct (negb _) eqn:?H. 2: inversion Hfri; assumption.
   destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh.
-  pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-  rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri. clear H Hfri. subst. destruct item as [addr | intr]; simpl in *.
+  pose proof (fr_forward_graph_and_heap_eq from to 0
+                (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
+  inversion Hfri. clear H Hfri. subst. destruct item as [addr | intr]; simpl in *.
   - apply find_remset_ext_In_some in Hric. destruct Hric as [rext [Hfre Heae]].
     rewrite Hfre in Hfgh, Hfr. Transparent forward_graph_and_heap. destruct rext as [gpv | vtx].
     + simpl in *. inversion Hfgh. subst. apply find_remset_ext_some in Hfre. destruct Hfre as [Hfre _].
@@ -8532,24 +8596,13 @@ Proof.
     now apply cut_heap_rhhc. Opaque forward_graph_and_heap.
 Qed.
 
-Lemma cut_heap_spaces_len: forall n h i s,
-    n = length (spaces h) -> n = length (spaces (cut_heap h i s)).
-Proof.
-  intros. unfold cut_heap. destruct (spaces_index_dec i h); auto. simpl.
-  rewrite <- ZtoNat_Zlength in H |- *. rewrite Zlength_upd_Znth. assumption.
-Qed.
-
 Lemma fgh_O_heap_len: forall from to f g h n g' h',
     n = length (spaces h) ->
     (g',h') = forward_graph_and_heap from to O f g h ->
     n = length (spaces h').
 Proof.
-  intros from to f g h n g' h' Hlen Hfrh. Transparent forward_graph_and_heap.
-  destruct f; simpl in Hfrh; try now inversion Hfrh.
-  - destruct (Nat.eq_dec _ _). 2: now inversion Hfrh. destruct (raw_mark _); inversion Hfrh; auto.
-    now apply cut_heap_spaces_len.
-  - destruct (Nat.eq_dec _ _). 2: now inversion Hfrh. destruct (raw_mark _); inversion Hfrh; auto.
-    now apply cut_heap_spaces_len. Opaque forward_graph_and_heap.
+  intros from to f g h n g' h' Hlen Hfrh. rewrite Hlen.
+  apply part_heap_spaces_length_eq.
 Qed.
 
 Lemma upd_remset_heap_len: forall rh item gen, Zlength (upd_remset_heap item rh gen) = Zlength rh.
@@ -8557,7 +8610,7 @@ Proof. intros. unfold upd_remset_heap. now rewrite Zlength_upd_Znth. Qed.
 
 Lemma incr_remset_heap_len: forall h gen, Zlength (spaces (incr_remset_heap h gen)) = Zlength (spaces h).
 Proof.
-  intros. unfold incr_remset_heap. destruct (spaces_index_dec _ _); simpl; now rewrite ?Zlength_upd_Znth.
+  intros. now rewrite !spaces_size.
 Qed.
 
 Lemma upd_incr_remset_heap_len: forall rh h item gen,
@@ -8610,8 +8663,9 @@ Proof.
   intros from to g h rh rmst item g' h' rh' rmst' Hfri. simpl in Hfri.
   destruct (negb _). 2: now inversion Hfri.
   destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh. symmetry in Hfgh.
-  assert (Hhr: heap_relation h (snd (newg, newh))) by
-    (rewrite Hfgh; apply heaprel_forward_graph_and_heap). simpl in Hhr. inversion Hfri.
+  pose proof (heaprel_forward_graph_and_heap_eq from to 0
+                (remset_item2forward_t item rmst g) g h newg newh Hfgh) as Hhr.
+  inversion Hfri.
   transitivity newh; [now apply heap_relation_weakened | apply incr_remset_heap_whr].
 Qed.
 
@@ -8632,8 +8686,8 @@ Lemma total_size_irh: forall h from to,
     from <> to ->
     total_size (incr_remset_heap h (Z.of_nat to)) from = total_size h from.
 Proof.
-  intros h from to Hneq. unfold incr_remset_heap. destruct (spaces_index_dec _ h). 2: reflexivity.
-  unfold total_size. rewrite !nth_space_Znth. simpl. rewrite Znth_upd_Znth_diff by lia. reflexivity.
+  intros h from to Hneq. symmetry.
+  apply (proj2 (incr_remset_heap_whr h (Z.of_nat to))).
 Qed.
 
 Lemma available_size_irh: forall h from to,
@@ -8684,10 +8738,9 @@ Proof.
   destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh.
   inversion Hfri; subst; clear Hfri.
   rewrite available_size_irh by exact Hgen.
-  pose proof (heaprel_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-    as Hhr.
-  rewrite Hfgh in Hhr. destruct Hhr as [Hav _].
-  symmetry. apply Hav.
+  pose proof (heaprel_forward_graph_and_heap_eq from to 0
+                (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hhr.
+  symmetry. now apply heap_relation_available_size.
 Qed.
 
 Lemma forward_remset_item_fold_available_size_not_to:
@@ -8727,9 +8780,9 @@ Proof.
   simpl in Hfri.
   destruct (negb _) eqn:?H.
   - destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap
-      from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
+    inversion Hfri; subst.
     eapply (fr_O_graph_gen_size_unchanged from to); eauto.
   - inversion Hfri; reflexivity.
 Qed.
@@ -9072,8 +9125,9 @@ Proof.
   intros from to g h rh rmst item g' h' rh' rmst' outlier Hneq Hghg Hcc Hndd Hrc Hric Hoc Hfri.
   simpl in Hfri. destruct (negb _). 2: now inversion Hfri.
   destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh. symmetry in Hfgh.
-  pose proof fr_forward_graph_and_heap from to O (remset_item2forward_t item rmst g) g h as Hfr.
-  rewrite <- Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst; clear Hfri.
+  pose proof (fr_forward_graph_and_heap_eq from to O
+                (remset_item2forward_t item rmst g) g h newg newh Hfgh) as Hfr.
+  inversion Hfri; subst; clear Hfri.
   eapply fr_outlier_compatible; eauto. eapply remset_item2forward_t_ftc; eassumption.
 Qed.
 
@@ -9251,23 +9305,14 @@ Proof. intros g outlier ext H. destruct ext; simpl in *; auto. Qed.
 Lemma irh_space_start: forall h i gen,
     space_start (nth_space (incr_remset_heap h i) gen) = space_start (nth_space h gen).
 Proof.
-  intros. rewrite !nth_space_Znth. unfold incr_remset_heap.
-  destruct (spaces_index_dec _ _); auto. simpl.
-  destruct (Z.eq_dec i (Z.of_nat gen)).
-  - subst. rewrite upd_Znth_same; auto. unfold incr_remset_space.
-    destruct (Z_lt_ge_dec _ _); simpl; reflexivity.
-  - rewrite upd_Znth_diff_strong by lia. reflexivity.
+  intros. symmetry. apply (proj1 (incr_remset_heap_whr h i)).
 Qed.
 
 Lemma irh_total_space: forall h i gen,
     total_space (nth_space (incr_remset_heap h i) gen) = total_space (nth_space h gen).
 Proof.
-  intros. rewrite !nth_space_Znth. unfold incr_remset_heap.
-  destruct (spaces_index_dec _ _); auto. simpl.
-  destruct (Z.eq_dec i (Z.of_nat gen)).
-  - subst. rewrite upd_Znth_same; auto. unfold incr_remset_space.
-    destruct (Z_lt_ge_dec _ _); simpl; reflexivity.
-  - rewrite upd_Znth_diff_strong by lia. reflexivity.
+  intros. change (total_size (incr_remset_heap h i) gen = total_size h gen).
+  symmetry. apply (proj2 (incr_remset_heap_whr h i)).
 Qed.
 
 Lemma irh_available_space_same: forall h gen,
@@ -9676,10 +9721,10 @@ Proof.
   unfold forward_remset_item in Hfri.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hgen.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
+    as [newg newh] eqn:Hfgh.
     simpl in Hfri. inversion Hfri; subst; clear Hfri.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
     eapply fr_roots_graph_compatible; eauto.
   - now inversion Hfri.
 Qed.
@@ -9722,10 +9767,10 @@ Proof.
   unfold forward_remset_item in Hfri.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hgen.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
+    as [newg newh] eqn:Hfgh.
     simpl in Hfri. inversion Hfri; subst; clear Hfri.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
     eapply fr_gen_unmarked; eauto.
   - now inversion Hfri.
 Qed.
@@ -9768,10 +9813,10 @@ Proof.
   unfold forward_remset_item in Hfri.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hgen.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
+    as [newg newh] eqn:Hfgh.
     simpl in Hfri. inversion Hfri; subst; clear Hfri.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
     unfold firstn_gen_clear, graph_gen_clear in *. intros i Hi.
     erewrite <- (fr_O_nth_gen_unchanged from to _ g newg); eauto; lia.
   - inversion Hfri; subst; assumption.
@@ -9817,10 +9862,10 @@ Proof.
   unfold forward_remset_item in Hfri.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hitem.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
+    as [newg newh] eqn:Hfgh.
     simpl in Hfri. inversion Hfri; subst; clear Hfri.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
     eapply (fr_O_stcg from to); eauto.
   - inversion Hfri; subst; assumption.
 Qed.
@@ -10015,9 +10060,8 @@ Proof.
   - destruct (forward_graph_and_heap
                 from to 0 (remset_item2forward_t item rmst g) g h)
       as [new_g new_h] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap
-         from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h new_g new_h (eq_sym Hfgh)) as Hfr.
     inversion Hfri; subst; clear Hfri.
     eapply fr_O_dst_eq_unless_forward_edge; eauto.
     + exact (proj1 He).
@@ -10049,10 +10093,9 @@ Proof.
               from to 0
               (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h)
     as [new_g new_h] eqn:Hfgh.
-  pose proof fr_forward_graph_and_heap
-       from to 0
-       (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h as Hfr.
-  rewrite Hfgh in Hfr. simpl in Hfr.
+  pose proof (fr_forward_graph_and_heap_eq from to 0
+                (field2forward (Znth (Z.of_nat n) (make_fields g v)))
+                g h new_g new_h (eq_sym Hfgh)) as Hfr.
   inversion Hfri; subst; clear Hfri.
   eapply fr_O_dst_changed_field_to; eauto.
 Qed.
@@ -10691,9 +10734,9 @@ Proof.
   destruct (negb (remset_item_in_gen item rmst g from)).
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
+    inversion Hfri; subst.
     eapply fr_O_gen_v_num_to; eassumption.
   - inversion Hfri; subst. lia.
 Qed.
@@ -10783,9 +10826,9 @@ Proof.
   destruct (forward_graph_and_heap from to 0
               (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h)
     as [newg newh] eqn:Hfgh.
-  pose proof fr_forward_graph_and_heap
-       from to 0 (field2forward (Znth (Z.of_nat n) (make_fields g v))) g h as Hfr.
-  rewrite Hfgh in Hfr. simpl in Hfr.
+  pose proof (fr_forward_graph_and_heap_eq from to 0
+                (field2forward (Znth (Z.of_nat n) (make_fields g v)))
+                g h newg newh (eq_sym Hfgh)) as Hfr.
   inversion Hfri; subst; clear Hfri.
   pose proof (graph_has_e_Znth newg v n He) as [_ Hfield].
   eapply (fr_O_dst_changed_field from to v n g newg); eauto.
@@ -10809,9 +10852,8 @@ Proof.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hitem.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap
-         from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
     inversion Hfri; subst; clear Hfri.
     eapply fr_O_old_edge_graph_has_e_inv; eauto.
   - inversion Hfri; subst. exact He.
@@ -10833,9 +10875,8 @@ Proof.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hitem.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap
-         from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hfr.
     inversion Hfri; subst; clear Hfri.
     eapply fr_O_old_edge_dst_eq_pres; eauto.
   - inversion Hfri; subst. reflexivity.
@@ -11939,7 +11980,7 @@ Proof.
   - specialize (Hsafe n Hn0 Hni Hhas).
     unfold safe_to_copy_gen_heap in *.
     destruct Hhrel as [Hav_rem [h_scan [Hhr Hreset]]].
-    destruct Hhr as [Hav_hr [_ [_ _]]]. subst h'.
+    pose proof (heap_relation_available_size h_rem h_scan n Hhr) as Hav_hr. subst h'.
     destruct Hwhr as [_ Htot].
     rewrite <- Htot.
     assert (Hrest: rest_gen_size (reset_nth_heap i h_scan) n = rest_gen_size h n). {

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -3205,9 +3205,14 @@ Proof.
    destruct a; auto. destruct v0; auto. simpl in H0. inv H0; auto.
 Qed.
 
-Lemma upd_Znth_unchanged: forall {A : Type} {d : Inhabitant A} (i : Z) (l : list A),
-    0 <= i < Zlength l -> upd_Znth i l (Znth i l) = l.
-Proof. intros. list_solve. Qed.
+Lemma upd_Znth_unchanged': forall {A} `{d: Inhabitant A} (i: Z) (al: list A),
+    upd_Znth i al (Znth i al) = al.
+Proof.
+  intros.
+  unfold upd_Znth. unfold Sumbool.sumbool_and.
+  if_tac; auto.
+  list_solve.
+Qed.
 
 Lemma upd_rootpairs_compatible': forall g rootpairs roots i extr,
     rootpairs_compatible g rootpairs roots ->
@@ -3295,7 +3300,7 @@ Proof.
                              (cut_space (Znth (Z.of_nat to) (spaces h))
                                 (vertex_size g v)))). {
     rewrite <- upd_Znth_map. unfold_cut_space. simpl. rewrite <- Znth_map by assumption.
-    rewrite upd_Znth_unchanged; [reflexivity | rewrite Zlength_map; assumption]. }
+    rewrite upd_Znth_unchanged'. reflexivity. }
   unfold_cut_heap. split; [|split]; [|simpl; rewrite cvmgil_length by assumption..].
   - rewrite gsc_iff in *; simpl. 2: assumption.
     + intros. unfold nth_space. simpl.
@@ -3312,7 +3317,7 @@ Proof.
                 map space_sh (spaces h)). {
           rewrite <- upd_Znth_map. unfold_cut_space. simpl.
           rewrite <- Znth_map by assumption.
-          rewrite upd_Znth_unchanged; [reflexivity|rewrite Zlength_map; assumption]. }
+          rewrite upd_Znth_unchanged'. reflexivity. }
         rewrite <- map_nth, H7, map_nth. clear -H5 H. unfold nth_gen, nth_space in *.
         simpl. destruct (Nat.eq_dec gen to).
         -- subst gen. rewrite cvmgil_eq; simpl; assumption.
@@ -3464,27 +3469,6 @@ Proof.
   unfold updateEdgeFunc; if_tac; [exfalso; apply H; rewrite H0|]; reflexivity.
 Qed.
 
-Lemma Znth_list_eq {X: Type} {d: Inhabitant X}: forall (l1 l2: list X),
-    l1 = l2 <-> (Zlength l1 = Zlength l2 /\
-                 forall j, 0 <= j < Zlength l1 -> Znth j l1 = Znth j l2).
-Proof.
-  induction l1; destruct l2; split; intros.
-  - split; intros; reflexivity.
-  - reflexivity.
-  - inversion H.
-  - destruct H. rewrite Zlength_nil, Zlength_cons in H. exfalso; rep_lia.
-  - inversion H.
-  - destruct H. rewrite Zlength_nil, Zlength_cons in H. exfalso; rep_lia.
-  - inversion H. subst a. subst l1. split; intros; reflexivity.
-  - destruct H. assert (0 <= 0 < Zlength (a :: l1)) by
-        (rewrite Zlength_cons; rep_lia). apply H0 in H1. rewrite !Znth_0_cons in H1.
-    subst a. rewrite !Zlength_cons in H. f_equal. rewrite IHl1. split. 1: rep_lia.
-    intros. assert (0 < j + 1) by lia.
-    assert (0 <= j + 1 < Zlength (x :: l1)) by (rewrite Zlength_cons; rep_lia).
-    specialize (H0 _ H3). rewrite !Znth_pos_cons in H0 by assumption.
-    replace (j + 1 - 1) with j in H0 by lia. assumption.
-Qed.
-
 Lemma lgd_map_f2v_diff_vert_eq: forall tag g v v' v1 e n,
     0 <= n < Zlength (make_fields g v) ->
     Znth n (make_fields g v) = FieldEdge e ->
@@ -3495,14 +3479,13 @@ Lemma lgd_map_f2v_diff_vert_eq: forall tag g v v' v1 e n,
 Proof.
     intros.
     rewrite lgd_make_fields_eq.
-    apply Znth_list_eq. split.
-    1: repeat rewrite Zlength_map; reflexivity.
-    intros. rewrite Zlength_map in H2.
+    apply List_ext.list_eq_Znth.
+    - repeat rewrite Zlength_map; reflexivity.
+    - intros j Hj. rewrite Zlength_map in Hj.
     repeat rewrite Znth_map by assumption.
-    apply lgd_f2v_eq_except_one. intro.
-    pose proof (make_fields_edge_unique g e v v1 n j H H2 H0 H3).
-    destruct H4. unfold not in H1. symmetry in H5.
-    apply (H1 H5).
+    apply lgd_f2v_eq_except_one. intro Hfd.
+    pose proof (make_fields_edge_unique g e v v1 n j H Hj H0 Hfd) as [_ Hv].
+    apply H1. symmetry. exact Hv.
 Qed.
 
 Lemma lgd_f2v_eq_after_update: forall tag g v v' e n j,
@@ -3542,18 +3525,18 @@ Lemma lgd_mfv_change_in_one_spot: forall g v e v' n,
     (make_fields_vals (labeledgraph_gen_dst g e v') v).
 Proof.
   intros.
-  rewrite (Znth_list_eq (upd_Znth n (make_fields_vals g v)
-               (vertex_address g v')) (make_fields_vals
-                     (labeledgraph_gen_dst g e v') v)).
-  rewrite upd_Znth_Zlength, fields_eq_length.
-  2: rewrite fields_eq_length; rewrite make_fields_eq_length in H; assumption.
-  split. 1: rewrite fields_eq_length; reflexivity.
-  intros.
-  unfold make_fields_vals.
-  replace (raw_mark (vlabel (labeledgraph_gen_dst g e v') v))
-    with (raw_mark (vlabel g v)) by reflexivity.
-  rewrite H0; rewrite <- make_fields_eq_length in H2.
-  apply lgd_f2v_eq_after_update; assumption.
+  apply List_ext.list_eq_Znth.
+  - rewrite upd_Znth_Zlength, fields_eq_length.
+    2: rewrite fields_eq_length; rewrite make_fields_eq_length in H; assumption.
+    rewrite fields_eq_length; reflexivity.
+  - intros j Hj.
+    rewrite upd_Znth_Zlength in Hj.
+    2: rewrite fields_eq_length; rewrite make_fields_eq_length in H; assumption.
+    unfold make_fields_vals.
+    replace (raw_mark (vlabel (labeledgraph_gen_dst g e v') v))
+      with (raw_mark (vlabel g v)) by reflexivity.
+    rewrite H0; rewrite fields_eq_length, <- make_fields_eq_length in Hj.
+    apply lgd_f2v_eq_after_update; assumption.
 Qed.
 
 Lemma lgd_no_dangling_dst: forall g e v',
@@ -3606,17 +3589,16 @@ Proof.
   apply (H v H0).
 Qed.
 
-Lemma mutable_graph_update_dst_other:
-  forall (g: LGraph) (src: VType) pos new g' (e: EType),
-    fst e <> src ->
+Lemma mutable_graph_update_dst_neq:
+  forall (g: LGraph) src pos new g' (e: EType),
+    e <> (src, Z.to_nat pos) ->
     mutable_location_compatible g (InteriorVertexPos src pos) ->
     mutable_graph_update g (InteriorVertexPos src pos) new g' ->
     dst g' e = dst g e.
 Proof.
-  intros g src pos new g' e Hfst Hloc Hupd.
+  intros g src pos new g' e Hneq Hloc Hupd.
   unfold mutable_graph_update, internal_write_at in Hupd.
-  assert (Hedge: (src, Z.to_nat pos) <> e).
-  { intro Heq. apply Hfst. rewrite <- Heq. reflexivity. }
+  assert (Hedge: (src, Z.to_nat pos) <> e) by congruence.
   destruct new as [z | p | new_dst].
   - destruct Hupd as [rvb' [_ ->]]. reflexivity.
   - destruct Hupd as [rvb' [_ ->]]. reflexivity.
@@ -3649,8 +3631,10 @@ Proof.
     pose proof (e_in_make_fields g v e Hin) as [n He]. subst e.
     rewrite (mutable_graph_update_vertex_address
                g (InteriorVertexPos src pos) new g' (dst g' (v, n)) Hloc Hupd).
-    rewrite (mutable_graph_update_dst_other
-               g src pos new g' (v, n) Hneq Hloc Hupd).
+    assert (Hedge: (v, n) <> (src, Z.to_nat pos)).
+    { intro Heq. inversion Heq. contradiction. }
+    rewrite (mutable_graph_update_dst_neq
+               g src pos new g' (v, n) Hedge Hloc Hupd).
     reflexivity.
   }
   unfold make_fields_vals.
@@ -4511,7 +4495,7 @@ Proof.
       assert (0 <= Z.of_nat gen < Zlength l0) by (rewrite Zlength_correct; lia).
       replace (space_start (Znth (Z.of_nat gen) l0))
         with (Znth (Z.of_nat gen) (map space_start l0)) by (rewrite Znth_map; auto).
-      rewrite upd_Znth_unchanged; [|rewrite Zlength_map]; assumption.
+      rewrite upd_Znth_unchanged'. assumption.
   - rewrite remove_ve_glabel_unchanged, reset_nth_space_length. assumption.
 Qed.
 
@@ -4547,15 +4531,6 @@ Proof.
   cut (roots_graph_compatible roots g2).
   - intros. apply (IHl g2 _ v); try assumption. rewrite <- fr_graph_has_gen; eauto.
   - eapply fr_roots_graph_compatible; eassumption.
-Qed.
-
-Lemma upd_Znth_unchanged': forall {A} `{d: Inhabitant A} (i: Z) (al: list A),
-   upd_Znth i al (Znth i al) = al.
-Proof.
-  intros.
-  unfold upd_Znth. unfold Sumbool.sumbool_and.
-  if_tac; auto.
-  list_solve.
 Qed.
 
 Lemma labeledgraph_vgen_vlabel_eq:
@@ -4597,27 +4572,6 @@ Proof.
       rewrite labeledgraph_vgen_vlabel_eq. exact Hu.
     + destruct Hupd as [rvb' [Hu ->]].
       rewrite labeledgraph_vgen_vlabel_eq. exact Hu.
-Qed.
-
-Lemma mutable_graph_update_dst_neq:
-  forall (g: LGraph) src pos new g' (e: EType),
-    e <> (src, Z.to_nat pos) ->
-    mutable_location_compatible g (InteriorVertexPos src pos) ->
-    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
-    dst g' e = dst g e.
-Proof.
-  intros g src pos new g' e Hneq Hloc Hupd.
-  unfold mutable_graph_update, internal_write_at in Hupd.
-  assert (Hedge: (src, Z.to_nat pos) <> e) by congruence.
-  destruct new as [z | p | new_dst].
-  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
-  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
-  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
-    + subst g'. apply lgd_dst_old. exact Hedge.
-    + destruct Hupd as [rvb' [_ ->]].
-      apply add_edge_preserves_dst. exact Hedge.
-    + destruct Hupd as [rvb' [_ ->]].
-      apply add_edge_preserves_dst. exact Hedge.
 Qed.
 
 Lemma mutable_graph_update_dst_new:
@@ -4685,8 +4639,7 @@ Proof.
   pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc' Hupd) as Hsrc.
   unfold raw_vertex_field_update in Hsrc.
   destruct Hsrc as [Hfields [Hmark' [_ [_ Htag']]]].
-  apply (proj2 (Znth_list_eq _ _)).
-  split.
+  apply List_ext.list_eq_Znth.
   - rewrite upd_Znth_Zlength by (rewrite fields_eq_length; exact Hpos).
     rewrite !fields_eq_length, Hfields, Zlength_upd_Znth. reflexivity.
   - intros j Hjnew.
@@ -8125,16 +8078,8 @@ Proof. intros. unfold remset_nodup in *. simpl. rewrite NoDup_cons_iff. tauto. Q
 
 Lemma remset_nodup_perm: forall l1 l2, Permutation l1 l2 -> remset_nodup l1 -> remset_nodup l2.
 Proof.
-  intros. revert H0. induction H; intros; auto.
-  - rewrite remset_nodup_cons_iff in H0 |- *. destruct H0. split; auto.
-    intro. apply H0. apply (Permutation_map extract_address) in H. symmetry in H.
-    eapply Permutation_in; eassumption.
-  - rewrite remset_nodup_cons_iff in *. simpl map in *. destruct H0.
-    rewrite remset_nodup_cons_iff in *. destruct H0. split; [|split]; auto.
-    + simpl. intro. destruct H2.
-      * apply H. simpl. left; auto.
-      * apply H0; assumption.
-    + intro. apply H. simpl. right. assumption.
+  intros l1 l2 Hperm Hnodup. unfold remset_nodup in *.
+  apply (Permutation_NoDup (Permutation_map extract_address Hperm)), Hnodup.
 Qed.
 
 Lemma upd_remset_addr_perm: forall from to g addr rmst1 rmst2,
@@ -9322,13 +9267,13 @@ Proof.
   pose proof incr_remset_heap_len h gen as Hlen2.
   rewrite (split3_full_length_list 0 gen MAX_SPACES (spaces (incr_remset_heap h gen))) by lia. simpl.
   rewrite Z.sub_0_r. f_equal; [|f_equal].
-  - rewrite Znth_list_eq. split. 1: rewrite !Zlength_firstn; lia. intros j Hj.
+  - apply List_ext.list_eq_Znth. 1: rewrite !Zlength_firstn; lia. intros j Hj.
     rewrite Zlength_firstn, Hlen2, Hlen1 in Hj.
     replace (Z.min _ _) with gen in Hj by lia. rewrite !Znth_firstn by lia.
     apply irh_Znth_spaces_not_eq. lia.
   - unfold incr_remset_heap. destruct (spaces_index_dec _ _). 2: lia. simpl.
     rewrite Znth_upd_Znth_same by lia. reflexivity.
-  - rewrite Znth_list_eq. split. 1: rewrite !Zlength_skipn; lia. intros j Hj.
+  - apply List_ext.list_eq_Znth. 1: rewrite !Zlength_skipn; lia. intros j Hj.
     rewrite Zlength_skipn, Hlen2, Hlen1 in Hj.
     replace (Z.max _ _) with (MAX_SPACES - (gen + 1)) in Hj by lia.
     rewrite !Znth_skipn by lia. apply irh_Znth_spaces_not_eq. lia.
@@ -9343,12 +9288,12 @@ Proof.
   intros rh gen item Hrg. pose proof upd_remset_heap_len rh item gen as Hlenu.
   rewrite (split3_full_length_list 0 (Z.of_nat gen) (Zlength rh) (upd_remset_heap item rh gen)) by lia.
   simpl. rewrite Z.sub_0_r. f_equal; [|f_equal].
-  - rewrite Znth_list_eq. split. 1: rewrite !Zlength_firstn; lia.
+  - apply List_ext.list_eq_Znth. 1: rewrite !Zlength_firstn; lia.
     intros j Hj. rewrite Zlength_firstn, Hlenu in Hj.
     replace (Z.min _ _) with (Z.of_nat gen) in Hj by lia. rewrite !Znth_firstn by lia.
     unfold upd_remset_heap. rewrite Znth_upd_Znth_diff by lia. reflexivity.
   - unfold upd_remset_heap. rewrite Znth_upd_Znth_same by lia. reflexivity.
-  - rewrite Znth_list_eq. split. 1: rewrite !Zlength_skipn; lia. intros j Hj.
+  - apply List_ext.list_eq_Znth. 1: rewrite !Zlength_skipn; lia. intros j Hj.
     rewrite Zlength_skipn, Hlenu in Hj.
     replace (Z.max _ _) with (Zlength rh - (Z.of_nat gen + 1)) in Hj by lia.
     rewrite !Znth_skipn by lia. unfold upd_remset_heap. rewrite Znth_upd_Znth_diff by lia. reflexivity.

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -3606,18 +3606,6 @@ Proof.
   apply (H v H0).
 Qed.
 
-Lemma mutable_graph_update_nth_sh:
-  forall g it new g' gen,
-    mutable_location_compatible g it ->
-    mutable_graph_update g it new g' ->
-    nth_sh g' gen = nth_sh g gen.
-Proof.
-  intros g it new g' gen Hloc Hupd.
-  unfold nth_sh, nth_gen.
-  rewrite (mutable_graph_update_glabel _ _ _ _ Hloc Hupd).
-  reflexivity.
-Qed.
-
 Lemma mutable_graph_update_dst_other:
   forall (g: LGraph) (src: VType) pos new g' (e: EType),
     fst e <> src ->
@@ -6720,8 +6708,6 @@ Proof.
   rewrite ?Ptrofs.signed_repr by rep_lia;
   auto.
 Qed.
-
-#[export] Instance Inh_rootpair : Inhabitant rootpair := {| rp_adr:=Vundef; rp_val:=Vundef|}.
 
 Lemma Znth_frame2rootpairs' :
 forall z r s,

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -1225,7 +1225,7 @@ Proof.
   - rewrite Z2Nat.id; [assumption | lia].
 Qed.
 
-Lemma make_fields'_n_doesnt_matter: forall i l v n m gcptr,
+#[local] Lemma make_fields'_n_doesnt_matter: forall i l v n m gcptr,
     nth i (make_fields' l v n) field_t_inhabitant = FieldOutlier gcptr ->
     nth i (make_fields' l v m) field_t_inhabitant = FieldOutlier gcptr.
 Proof.
@@ -1241,7 +1241,7 @@ Proof.
     - destruct a; simpl; intro; apply IHl with (m:=(m+1)%nat) in H; assumption.
 Qed.
 
-Lemma make_fields'_item_was_in_list: forall l v n gcptr,
+#[local] Lemma make_fields'_item_was_in_list: forall l v n gcptr,
     0 <= n < Zlength l ->
     Znth n (make_fields' l v 0) = FieldOutlier gcptr ->
     Znth n l = RawOutlier gcptr.
@@ -1760,7 +1760,7 @@ Definition mutable_graph_update
   | InteriorVertexPos src pos => internal_write_at g src pos new g'
   end.
 
-Lemma raw_vertex_field_update_exists:
+#[local] Lemma raw_vertex_field_update_exists:
   forall rvb pos rf,
     raw_tag rvb < NO_SCAN_TAG ->
     exists rvb', raw_vertex_field_update rvb pos rf rvb'.
@@ -1782,7 +1782,7 @@ Proof.
   repeat split; reflexivity.
 Qed.
 
-Lemma raw_vertex_field_update_unique:
+#[local] Lemma raw_vertex_field_update_unique:
   forall rvb pos rf rvb1 rvb2,
     raw_vertex_field_update rvb pos rf rvb1 ->
     raw_vertex_field_update rvb pos rf rvb2 ->
@@ -1798,7 +1798,7 @@ Proof.
   f_equal; apply proof_irrelevance.
 Qed.
 
-Lemma internal_write_at_exists:
+#[local] Lemma internal_write_at_exists:
   forall g src pos new,
     raw_tag (vlabel g src) < NO_SCAN_TAG ->
     exists g', internal_write_at g src pos new g'.
@@ -1831,7 +1831,7 @@ Proof.
   apply internal_write_at_exists; exact Htag.
 Qed.
 
-Lemma internal_write_at_deterministic:
+#[local] Lemma internal_write_at_deterministic:
   forall g src pos new g1 g2,
     internal_write_at g src pos new g1 ->
     internal_write_at g src pos new g2 ->
@@ -1910,7 +1910,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma rvfu_vgen_raw_fields_length:
+#[local] Lemma rvfu_vgen_raw_fields_length:
   forall (g: LGraph) (src: VType) pos rf rvb' (v: VType),
     raw_vertex_field_update (vlabel g src) pos rf rvb' ->
     Zlength (raw_fields (vlabel (labeledgraph_vgen g src rvb') v)) =
@@ -2014,7 +2014,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma rvfu_vgen_make_header:
+#[local] Lemma rvfu_vgen_make_header:
   forall (g: LGraph) (src: VType) pos rf rvb' (v: VType),
     raw_vertex_field_update (vlabel g src) pos rf rvb' ->
     make_header (labeledgraph_vgen g src rvb') v = make_header g v.
@@ -2597,7 +2597,7 @@ Proof.
   intros. unfold make_header. rewrite lacv_vlabel_old by assumption. reflexivity.
 Qed.
 
-Lemma e_in_make_fields': forall l v n e,
+#[local] Lemma e_in_make_fields': forall l v n e,
     In (FieldEdge e) (make_fields' l v n) -> exists s, e = (v, s).
 Proof.
   induction l; intros; simpl in *. 1: exfalso; assumption. destruct a.
@@ -2612,7 +2612,7 @@ Lemma e_in_make_fields: forall g v e,
     In (FieldEdge e) (make_fields g v) -> exists s, e = (v, s).
 Proof. unfold make_fields. intros. apply e_in_make_fields' in H. assumption. Qed.
 
-Lemma flcvae_dst_old: forall g new (l: list (EType * VType)) e,
+#[local] Lemma flcvae_dst_old: forall g new (l: list (EType * VType)) e,
     ~ In e (map fst l) -> dst (fold_left (copy_v_add_edge new) l g) e = dst g e.
 Proof.
   intros. revert g H. induction l; intros; simpl. 1: reflexivity.
@@ -2621,7 +2621,7 @@ Proof.
   apply H. simpl. left; assumption.
 Qed.
 
-Lemma flcvae_dst_new: forall g new (l: list (EType * VType)) e v,
+#[local] Lemma flcvae_dst_new: forall g new (l: list (EType * VType)) e v,
     NoDup (map fst l) -> In (e, v) l ->
     dst (fold_left (copy_v_add_edge new) l g) e = v.
 Proof.
@@ -2648,7 +2648,7 @@ Proof.
   intros. unfold get_edges. rewrite <- (filter_proj_In_iff field_proj_edge_spec). tauto.
 Qed.
 
-Lemma e_in_get_edges: forall g v e, In e (get_edges g v) -> exists s, e = (v, s).
+#[local] Lemma e_in_get_edges: forall g v e, In e (get_edges g v) -> exists s, e = (v, s).
 Proof. intros. rewrite get_edges_In_iff in H. apply e_in_make_fields in H. assumption. Qed.
 
 Lemma pcv_dst_new: forall g old new n,
@@ -4218,7 +4218,7 @@ Proof.
   - eapply svfl_gen_unmarked; eauto.
 Qed.
 
-Lemma make_header_tag_prep64: forall z,
+#[local] Lemma make_header_tag_prep64: forall z,
     0 <= z < two_p (8 * 8) ->
     Int64.and (Int64.repr z) (Int64.repr 255) =
     Int64.sub (Int64.repr z)
@@ -4237,7 +4237,7 @@ Proof.
     simpl Z.of_nat. lia.
 Qed.
 
-Lemma make_header_tag_prep32: forall z,
+#[local] Lemma make_header_tag_prep32: forall z,
     0 <= z < two_p (4 * 8) ->
     Int.and (Int.repr z) (Int.repr 255) =
     Int.sub (Int.repr z)
@@ -4588,7 +4588,7 @@ Proof.
   - destruct Hupd as [rvb' [_ ->]]. apply add_edge_dst.
 Qed.
 
-Lemma nth_make_fields':
+#[local] Lemma nth_make_fields':
   forall l v base i,
     (i < length l)%nat ->
     nth i (make_fields' l v base) field_t_inhabitant =
@@ -5699,7 +5699,7 @@ Qed.
 Definition is_field_same_v (g: LGraph) (v: VType) (p: interior_t) : Prop :=
   exists i : Z, p = InteriorVertexPos v i /\ (0 <= i < Zlength (make_fields g v))%Z.
 
-Lemma fr_is_field_same_v: forall (from to depth: nat) p (g1 g2: LGraph) (v: VType) l,
+#[local] Lemma fr_is_field_same_v: forall (from to depth: nat) p (g1 g2: LGraph) (v: VType) l,
     graph_has_gen g1 to ->
     graph_has_v g1 v ->
     forward_relation from to depth p g1 g2 ->
@@ -5710,7 +5710,7 @@ Proof.
   - rewrite !make_fields_eq_length. f_equal. eapply fr_raw_fields; eassumption.
 Qed.
 
-Lemma fl_no_dangling_dst_helper: forall (from to depth: nat) (g' : LGraph) (vv : VType)
+#[local] Lemma fl_no_dangling_dst_helper: forall (from to depth: nat) (g' : LGraph) (vv : VType)
                                    (l : list interior_t) (gg : LGraph),
     from <> to ->
     (forall (p : forward_t) (g g' : LGraph),
@@ -6963,7 +6963,7 @@ Proof.
     apply estc_has_space; [|assumption..]. destruct H. apply (H0 _ H _ H4).
 Qed.
 
-Lemma forward_gh_loop_ghc_helper: forall (from to depth: nat) (vv : VType)
+#[local] Lemma forward_gh_loop_ghc_helper: forall (from to depth: nat) (vv : VType)
                              (l : list interior_t) (gg : LGraph) (hh : part_heap),
     from <> to ->
     (forall (p : forward_t) (g : LGraph) (h : part_heap),
@@ -7056,7 +7056,7 @@ Proof.
     apply estc_has_space; [|assumption..]. destruct H; apply (H0 _ H _ H6).
 Qed.
 
-Lemma raw_tag_biteq: forall (g: LGraph) (v: VType),
+#[local] Lemma raw_tag_biteq: forall (g: LGraph) (v: VType),
     raw_mark (vlabel g v) = false ->
     Int64.unsigned (Int64.and (Int64.repr (make_header g v)) (Int64.repr 255)) =
       (raw_tag (vlabel g v)) mod 256.
@@ -7225,7 +7225,7 @@ Proof.
   - destruct Hfc as [? [? [? [? ?]]]]. rewrite <- fr_is_field_same_v; eassumption.
 Qed.
 
-Lemma fl_outlier_compatible_helper:
+#[local] Lemma fl_outlier_compatible_helper:
   forall (from to depth: nat) outlier (g g' : LGraph) (v : VType) (l : list interior_t),
     from <> to ->
     (forall (p : forward_t) (g1 g2 : LGraph),
@@ -7495,7 +7495,7 @@ Definition no_unrecorded_backward_edge_from
 Definition no_unrecorded_backward_edge (g: LGraph) (rh: remset_heap): Prop :=
   no_unrecorded_backward_edge_from O g rh.
 
-Lemma firstn_gen_clear_edge_source_gt:
+#[local] Lemma firstn_gen_clear_edge_source_gt:
   forall g from e,
     firstn_gen_clear g from ->
     graph_has_e g e ->

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -1,5 +1,6 @@
 Require Import Stdlib.ZArith.ZArith.
 Require Export Stdlib.Program.Basics.
+Require Import Stdlib.Logic.ProofIrrelevance.
 Require Import Stdlib.micromega.Lia.
 Require Import compcert.lib.Integers.
 Require Import compcert.common.Values.
@@ -1109,6 +1110,10 @@ Proof. intros. destruct r; simpl; split; intro S; inversion S; subst; reflexivit
 Definition get_edges (g: LGraph) (v: VType): list EType :=
   filter_proj field_proj_edge (make_fields g v).
 
+Definition lgraph_remove_edge (g: LGraph) (e: EType): LGraph :=
+  Build_LabeledGraph _ _ _ (pregraph_remove_edge (pg_lg g) e)
+                     (vlabel g) (elabel g) (glabel g).
+
 Definition pregraph_remove_vertex_and_edges
            (g: LGraph) (v: VType): PreGraph VType EType :=
   fold_left pregraph_remove_edge (get_edges g v) (pregraph_remove_vertex g v).
@@ -1699,6 +1704,428 @@ Definition interior_compatible (g: LGraph) (from: nat) (intr: interior_t) : Prop
                              (vlabel g v).(raw_tag) < NO_SCAN_TAG /\
                               vgeneration v <> from
   end.
+
+Definition raw_vertex_field_update
+    (rvb: raw_vertex_block) (pos: Z) (rf: raw_field)
+    (rvb': raw_vertex_block): Prop :=
+  raw_fields rvb' = upd_Znth pos (raw_fields rvb) rf /\
+  raw_mark rvb' = raw_mark rvb /\
+  copied_vertex rvb' = copied_vertex rvb /\
+  raw_color rvb' = raw_color rvb /\
+  raw_tag rvb' = raw_tag rvb.
+
+Definition mutable_location_compatible (g: LGraph) (it: interior_t): Prop :=
+  match it with
+  | InteriorVertexPos src pos =>
+      graph_has_v g src /\
+      0 <= pos < Zlength (raw_fields (vlabel g src)) /\
+      raw_mark (vlabel g src) = false /\
+      raw_tag (vlabel g src) < NO_SCAN_TAG
+  end.
+
+Definition internal_write_at
+    (g: LGraph) (src: VType) (pos: Z)
+    (new: exterior_t) (g': LGraph): Prop :=
+  let e : EType := (src, Z.to_nat pos) in
+  match new with
+  | ExteriorVertex dst =>
+      match Znth pos (raw_fields (vlabel g src)) with
+      | RawInternal => g' = labeledgraph_gen_dst g e dst
+      | RawUnboxed _ =>
+          exists rvb',
+            raw_vertex_field_update (vlabel g src) pos RawInternal rvb' /\
+            g' = labeledgraph_vgen
+                   (labeledgraph_add_edge g e src dst (Z.to_nat pos))
+                   src rvb'
+      | RawOutlier _ =>
+          exists rvb',
+            raw_vertex_field_update (vlabel g src) pos RawInternal rvb' /\
+            g' = labeledgraph_vgen
+                   (labeledgraph_add_edge g e src dst (Z.to_nat pos))
+                   src rvb'
+      end
+  | ExteriorUnboxed z =>
+      exists rvb',
+        raw_vertex_field_update (vlabel g src) pos (RawUnboxed z) rvb' /\
+        g' = labeledgraph_vgen (lgraph_remove_edge g e) src rvb'
+  | ExteriorOutlier p =>
+      exists rvb',
+        raw_vertex_field_update (vlabel g src) pos (RawOutlier p) rvb' /\
+        g' = labeledgraph_vgen (lgraph_remove_edge g e) src rvb'
+  end.
+
+Definition mutable_graph_update
+    (g: LGraph) (it: interior_t) (new: exterior_t) (g': LGraph): Prop :=
+  match it with
+  | InteriorVertexPos src pos => internal_write_at g src pos new g'
+  end.
+
+Lemma raw_vertex_field_update_exists:
+  forall rvb pos rf,
+    raw_tag rvb < NO_SCAN_TAG ->
+    exists rvb', raw_vertex_field_update rvb pos rf rvb'.
+Proof.
+  intros rvb pos rf Htag.
+  assert (Hrange:
+    0 < Zlength (upd_Znth pos (raw_fields rvb) rf) <
+        two_p (WORD_SIZE * 8 - 10)).
+  { rewrite Zlength_upd_Znth. apply raw_fields_range. }
+  assert (Hnoscan:
+    NO_SCAN_TAG <= raw_tag rvb ->
+    ~ In RawInternal (upd_Znth pos (raw_fields rvb) rf)).
+  { intros. exfalso. lia. }
+  exists (Build_raw_vertex_block
+      (raw_mark rvb) (copied_vertex rvb)
+      (upd_Znth pos (raw_fields rvb) rf)
+      (raw_color rvb) (raw_tag rvb)
+      (raw_tag_range rvb) (raw_color_range rvb) Hrange Hnoscan).
+  repeat split; reflexivity.
+Qed.
+
+Lemma raw_vertex_field_update_unique:
+  forall rvb pos rf rvb1 rvb2,
+    raw_vertex_field_update rvb pos rf rvb1 ->
+    raw_vertex_field_update rvb pos rf rvb2 ->
+    rvb1 = rvb2.
+Proof.
+  intros rvb pos rf
+    [m1 c1 fs1 col1 tag1 tr1 cr1 fr1 ns1]
+    [m2 c2 fs2 col2 tag2 tr2 cr2 fr2 ns2] H1 H2.
+  unfold raw_vertex_field_update in H1, H2; simpl in H1, H2.
+  destruct H1 as [? [? [? [? ?]]]].
+  destruct H2 as [? [? [? [? ?]]]].
+  subst fs1 fs2 m1 m2 c1 c2 col1 col2 tag1 tag2.
+  f_equal; apply proof_irrelevance.
+Qed.
+
+Lemma internal_write_at_exists:
+  forall g src pos new,
+    raw_tag (vlabel g src) < NO_SCAN_TAG ->
+    exists g', internal_write_at g src pos new g'.
+Proof.
+  intros g src pos new Htag.
+  unfold internal_write_at.
+  destruct new as [z | p | dst].
+  - destruct (raw_vertex_field_update_exists
+                (vlabel g src) pos (RawUnboxed z) Htag) as [rvb' Hu].
+    eexists. exists rvb'. split; [exact Hu | reflexivity].
+  - destruct (raw_vertex_field_update_exists
+                (vlabel g src) pos (RawOutlier p) Htag) as [rvb' Hu].
+    eexists. exists rvb'. split; [exact Hu | reflexivity].
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + eexists; reflexivity.
+    + destruct (raw_vertex_field_update_exists
+                  (vlabel g src) pos RawInternal Htag) as [rvb' Hu].
+      eexists. exists rvb'. split; [exact Hu | reflexivity].
+    + destruct (raw_vertex_field_update_exists
+                  (vlabel g src) pos RawInternal Htag) as [rvb' Hu].
+      eexists. exists rvb'. split; [exact Hu | reflexivity].
+Qed.
+
+Lemma mutable_graph_update_exists:
+  forall g it new,
+    mutable_location_compatible g it ->
+    exists g', mutable_graph_update g it new g'.
+Proof.
+  intros g [src pos] new [_ [_ [_ Htag]]].
+  apply internal_write_at_exists; exact Htag.
+Qed.
+
+Lemma internal_write_at_deterministic:
+  forall g src pos new g1 g2,
+    internal_write_at g src pos new g1 ->
+    internal_write_at g src pos new g2 ->
+    g1 = g2.
+Proof.
+  intros g src pos new g1 g2 H1 H2.
+  unfold internal_write_at in H1, H2.
+  destruct new as [z | p | dst].
+  - destruct H1 as [rvb1 [Hu1 Hg1]].
+    destruct H2 as [rvb2 [Hu2 Hg2]].
+    pose proof (raw_vertex_field_update_unique _ _ _ _ _ Hu1 Hu2).
+    subst rvb2. congruence.
+  - destruct H1 as [rvb1 [Hu1 Hg1]].
+    destruct H2 as [rvb2 [Hu2 Hg2]].
+    pose proof (raw_vertex_field_update_unique _ _ _ _ _ Hu1 Hu2).
+    subst rvb2. congruence.
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + congruence.
+    + destruct H1 as [rvb1 [Hu1 Hg1]].
+      destruct H2 as [rvb2 [Hu2 Hg2]].
+      pose proof (raw_vertex_field_update_unique _ _ _ _ _ Hu1 Hu2).
+      subst rvb2. congruence.
+    + destruct H1 as [rvb1 [Hu1 Hg1]].
+      destruct H2 as [rvb2 [Hu2 Hg2]].
+      pose proof (raw_vertex_field_update_unique _ _ _ _ _ Hu1 Hu2).
+      subst rvb2. congruence.
+Qed.
+
+Lemma mutable_graph_update_deterministic:
+  forall g it new g1 g2,
+    mutable_graph_update g it new g1 ->
+    mutable_graph_update g it new g2 ->
+    g1 = g2.
+Proof.
+  intros g [src pos] new g1 g2.
+  apply internal_write_at_deterministic.
+Qed.
+
+Lemma mutable_graph_update_glabel:
+  forall g it new g',
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    glabel g' = glabel g.
+Proof.
+  intros g [src pos] new g' Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dst].
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. reflexivity.
+    + destruct Hupd as [rvb' [_ ->]]. reflexivity.
+    + destruct Hupd as [rvb' [_ ->]]. reflexivity.
+Qed.
+
+Lemma mutable_graph_update_graph_has_v:
+  forall g it new g' v,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    (graph_has_v g' v <-> graph_has_v g v).
+Proof.
+  intros g it new g' v Hloc Hupd.
+  pose proof (mutable_graph_update_glabel _ _ _ _ Hloc Hupd) as Hglabel.
+  unfold graph_has_v, graph_has_gen, gen_has_index, nth_gen.
+  rewrite Hglabel. reflexivity.
+Qed.
+
+Lemma mutable_graph_update_nth_gen:
+  forall g it new g' gen,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    nth_gen g' gen = nth_gen g gen.
+Proof.
+  intros. unfold nth_gen.
+  rewrite (mutable_graph_update_glabel _ _ _ _ H H0).
+  reflexivity.
+Qed.
+
+Lemma rvfu_vgen_raw_fields_length:
+  forall (g: LGraph) (src: VType) pos rf rvb' (v: VType),
+    raw_vertex_field_update (vlabel g src) pos rf rvb' ->
+    Zlength (raw_fields (vlabel (labeledgraph_vgen g src rvb') v)) =
+    Zlength (raw_fields (vlabel g v)).
+Proof.
+  intros g src pos rf rvb' v Hupd.
+  unfold raw_vertex_field_update in Hupd.
+  destruct Hupd as [Hfields _].
+  unfold labeledgraph_vgen; simpl.
+  unfold update_vlabel.
+  destruct (EquivDec.equiv_dec src v) as [Heq | Hneq].
+  - hnf in Heq. subst v. rewrite Hfields, Zlength_upd_Znth. reflexivity.
+  - reflexivity.
+Qed.
+
+Lemma mutable_graph_update_raw_fields_length:
+  forall g it new g' v,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    Zlength (raw_fields (vlabel g' v)) =
+    Zlength (raw_fields (vlabel g v)).
+Proof.
+  intros g [src pos] new g' v Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dst].
+  - destruct Hupd as [rvb' [Hu ->]].
+    change (Zlength (raw_fields (vlabel (labeledgraph_vgen g src rvb') v)) =
+            Zlength (raw_fields (vlabel g v))).
+    exact (rvfu_vgen_raw_fields_length g src pos (RawUnboxed z) rvb' v Hu).
+  - destruct Hupd as [rvb' [Hu ->]].
+    change (Zlength (raw_fields (vlabel (labeledgraph_vgen g src rvb') v)) =
+            Zlength (raw_fields (vlabel g v))).
+    exact (rvfu_vgen_raw_fields_length g src pos (RawOutlier p) rvb' v Hu).
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. reflexivity.
+    + destruct Hupd as [rvb' [Hu ->]].
+      change (Zlength (raw_fields (vlabel (labeledgraph_vgen g src rvb') v)) =
+              Zlength (raw_fields (vlabel g v))).
+      exact (rvfu_vgen_raw_fields_length g src pos RawInternal rvb' v Hu).
+    + destruct Hupd as [rvb' [Hu ->]].
+      change (Zlength (raw_fields (vlabel (labeledgraph_vgen g src rvb') v)) =
+              Zlength (raw_fields (vlabel g v))).
+      exact (rvfu_vgen_raw_fields_length g src pos RawInternal rvb' v Hu).
+Qed.
+
+Lemma mutable_graph_update_vertex_size:
+  forall g it new g' v,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    vertex_size g' v = vertex_size g v.
+Proof.
+  intros. unfold vertex_size.
+  rewrite (mutable_graph_update_raw_fields_length g it new g' v H H0).
+  reflexivity.
+Qed.
+
+Lemma mutable_graph_update_previous_vertices_size:
+  forall g it new g' gen i,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    previous_vertices_size g' gen i = previous_vertices_size g gen i.
+Proof.
+  intros g it new g' gen i Hloc Hupd.
+  induction i.
+  - reflexivity.
+  - rewrite !pvs_S, IHi.
+    rewrite (mutable_graph_update_vertex_size g it new g' (gen, i) Hloc Hupd).
+    reflexivity.
+Qed.
+
+Lemma mutable_graph_update_gen_start:
+  forall g it new g' gen,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    gen_start g' gen = gen_start g gen.
+Proof.
+  intros g it new g' gen Hloc Hupd.
+  unfold gen_start.
+  destruct (graph_has_gen_dec g' gen) as [Hg' | Hg'];
+    destruct (graph_has_gen_dec g gen) as [Hg | Hg].
+  - rewrite (mutable_graph_update_nth_gen _ _ _ _ _ Hloc Hupd). reflexivity.
+  - exfalso. apply Hg. unfold graph_has_gen in *.
+    rewrite (mutable_graph_update_glabel _ _ _ _ Hloc Hupd) in Hg'. exact Hg'.
+  - exfalso. apply Hg'. unfold graph_has_gen in *.
+    rewrite (mutable_graph_update_glabel _ _ _ _ Hloc Hupd). exact Hg.
+  - reflexivity.
+Qed.
+
+Lemma mutable_graph_update_vertex_address:
+  forall g it new g' v,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    vertex_address g' v = vertex_address g v.
+Proof.
+  intros g it new g' v Hloc Hupd.
+  unfold vertex_address, vertex_offset.
+  rewrite (mutable_graph_update_previous_vertices_size
+             g it new g' (vgeneration v) (vindex v) Hloc Hupd).
+  rewrite (mutable_graph_update_gen_start
+             g it new g' (vgeneration v) Hloc Hupd).
+  reflexivity.
+Qed.
+
+Lemma rvfu_vgen_make_header:
+  forall (g: LGraph) (src: VType) pos rf rvb' (v: VType),
+    raw_vertex_field_update (vlabel g src) pos rf rvb' ->
+    make_header (labeledgraph_vgen g src rvb') v = make_header g v.
+Proof.
+  intros g src pos rf rvb' v Hupd.
+  unfold raw_vertex_field_update in Hupd.
+  destruct Hupd as [Hfields [Hmark [_ [Hcolor Htag]]]].
+  unfold make_header, labeledgraph_vgen; simpl.
+  unfold update_vlabel.
+  destruct (EquivDec.equiv_dec src v) as [Heq | Hneq].
+  - hnf in Heq. subst v.
+    rewrite Hmark, Htag, Hcolor, Hfields, Zlength_upd_Znth.
+    reflexivity.
+  - reflexivity.
+Qed.
+
+Lemma mutable_graph_update_make_header:
+  forall g it new g' v,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    make_header g' v = make_header g v.
+Proof.
+  intros g [src pos] new g' v Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dst].
+  - destruct Hupd as [rvb' [Hu ->]].
+    change (make_header (labeledgraph_vgen g src rvb') v = make_header g v).
+    exact (rvfu_vgen_make_header g src pos (RawUnboxed z) rvb' v Hu).
+  - destruct Hupd as [rvb' [Hu ->]].
+    change (make_header (labeledgraph_vgen g src rvb') v = make_header g v).
+    exact (rvfu_vgen_make_header g src pos (RawOutlier p) rvb' v Hu).
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. reflexivity.
+    + destruct Hupd as [rvb' [Hu ->]].
+      change (make_header (labeledgraph_vgen g src rvb') v = make_header g v).
+      exact (rvfu_vgen_make_header g src pos RawInternal rvb' v Hu).
+    + destruct Hupd as [rvb' [Hu ->]].
+      change (make_header (labeledgraph_vgen g src rvb') v = make_header g v).
+      exact (rvfu_vgen_make_header g src pos RawInternal rvb' v Hu).
+Qed.
+
+Lemma mutable_graph_update_exterior2val:
+  forall g it new g',
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    exterior2val g' new = exterior2val g new.
+Proof.
+  intros g it new g' Hloc Hupd.
+  destruct new; simpl; try reflexivity.
+  eapply mutable_graph_update_vertex_address; eassumption.
+Qed.
+
+Lemma labeledgraph_vgen_vlabel_neq:
+  forall (g: LGraph) src rvb v,
+    v <> src ->
+    vlabel (labeledgraph_vgen g src rvb) v = vlabel g v.
+Proof.
+  intros g src rvb v Hneq.
+  unfold labeledgraph_vgen; simpl; unfold update_vlabel.
+  destruct (EquivDec.equiv_dec src v) as [Heq | Hne].
+  - hnf in Heq. subst v. exfalso. apply Hneq. reflexivity.
+  - reflexivity.
+Qed.
+
+Lemma mutable_graph_update_vlabel_other:
+  forall g src pos new g' v,
+    v <> src ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    vlabel g' v = vlabel g v.
+Proof.
+  intros g src pos new g' v Hneq Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dst].
+  - destruct Hupd as [rvb' [_ ->]].
+    change (vlabel (labeledgraph_vgen g src rvb') v = vlabel g v).
+    apply labeledgraph_vgen_vlabel_neq; exact Hneq.
+  - destruct Hupd as [rvb' [_ ->]].
+    change (vlabel (labeledgraph_vgen g src rvb') v = vlabel g v).
+    apply labeledgraph_vgen_vlabel_neq; exact Hneq.
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. reflexivity.
+    + destruct Hupd as [rvb' [_ ->]].
+      change (vlabel (labeledgraph_vgen g src rvb') v = vlabel g v).
+      apply labeledgraph_vgen_vlabel_neq; exact Hneq.
+    + destruct Hupd as [rvb' [_ ->]].
+      change (vlabel (labeledgraph_vgen g src rvb') v = vlabel g v).
+      apply labeledgraph_vgen_vlabel_neq; exact Hneq.
+Qed.
+
+Lemma mutable_graph_update_graph_heap_compatible:
+  forall g it new g' h,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    graph_heap_compatible g h ->
+    graph_heap_compatible g' h.
+Proof.
+  intros g it new g' h Hloc Hupd [Hgens [Hnull Hlen]].
+  pose proof (mutable_graph_update_glabel _ _ _ _ Hloc Hupd) as Hglabel.
+  unfold graph_heap_compatible.
+  rewrite Hglabel.
+  split; [|split; assumption].
+  eapply Forall_impl; [|exact Hgens].
+  intros [[gen gi] sp] Hcomp.
+  unfold generation_space_compatible in Hcomp |- *.
+  destruct Hcomp as [Hstart [Hsh Hused]].
+  split; [exact Hstart | split; [exact Hsh |]].
+  rewrite (mutable_graph_update_previous_vertices_size
+             g it new g' gen (number_of_vertices gi) Hloc Hupd).
+  exact Hused.
+Qed.
 
 Definition forward_p_compatible
   (p: forward_p_type) (outlier: outlier_t) (g: LGraph) (from: nat): Prop :=
@@ -3179,6 +3606,75 @@ Proof.
   apply (H v H0).
 Qed.
 
+Lemma mutable_graph_update_nth_sh:
+  forall g it new g' gen,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    nth_sh g' gen = nth_sh g gen.
+Proof.
+  intros g it new g' gen Hloc Hupd.
+  unfold nth_sh, nth_gen.
+  rewrite (mutable_graph_update_glabel _ _ _ _ Hloc Hupd).
+  reflexivity.
+Qed.
+
+Lemma mutable_graph_update_dst_other:
+  forall (g: LGraph) (src: VType) pos new g' (e: EType),
+    fst e <> src ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    dst g' e = dst g e.
+Proof.
+  intros g src pos new g' e Hfst Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  assert (Hedge: (src, Z.to_nat pos) <> e).
+  { intro Heq. apply Hfst. rewrite <- Heq. reflexivity. }
+  destruct new as [z | p | new_dst].
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. apply lgd_dst_old. exact Hedge.
+    + destruct Hupd as [rvb' [_ ->]].
+      apply add_edge_preserves_dst. exact Hedge.
+    + destruct Hupd as [rvb' [_ ->]].
+      apply add_edge_preserves_dst. exact Hedge.
+Qed.
+
+Lemma mutable_graph_update_make_fields_vals_other:
+  forall g src pos new g' v,
+    v <> src ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    make_fields_vals g' v = make_fields_vals g v.
+Proof.
+  intros g src pos new g' v Hneq Hloc Hupd.
+  pose proof (mutable_graph_update_vlabel_other
+                g src pos new g' v Hneq Hloc Hupd) as Hvlabel.
+  assert (Hfields: make_fields g' v = make_fields g v).
+  { unfold make_fields. rewrite Hvlabel. reflexivity. }
+  assert (Hmap:
+    map (field2val (raw_tag (vlabel g v)) g') (make_fields g v) =
+    map (field2val (raw_tag (vlabel g v)) g) (make_fields g v)).
+  {
+    apply map_ext_in. intros fd Hin.
+    destruct fd as [z | p | e]; simpl; try reflexivity.
+    pose proof (e_in_make_fields g v e Hin) as [n He]. subst e.
+    rewrite (mutable_graph_update_vertex_address
+               g (InteriorVertexPos src pos) new g' (dst g' (v, n)) Hloc Hupd).
+    rewrite (mutable_graph_update_dst_other
+               g src pos new g' (v, n) Hneq Hloc Hupd).
+    reflexivity.
+  }
+  unfold make_fields_vals.
+  rewrite Hvlabel, Hfields.
+  destruct (raw_mark (vlabel g v)) eqn:Hmark.
+  - rewrite (mutable_graph_update_vertex_address
+               g (InteriorVertexPos src pos) new g'
+               (copied_vertex (vlabel g v)) Hloc Hupd).
+    rewrite Hmap. reflexivity.
+  - exact Hmap.
+Qed.
+
 Lemma fr_general_prop_bootstrap: forall depth from to p g g'
                                         (P: nat -> LGraph -> LGraph -> Prop),
     (forall to g, P to g g) ->
@@ -4072,6 +4568,189 @@ Proof.
   unfold upd_Znth. unfold Sumbool.sumbool_and.
   if_tac; auto.
   list_solve.
+Qed.
+
+Lemma labeledgraph_vgen_vlabel_eq:
+  forall (g: LGraph) src rvb,
+    vlabel (labeledgraph_vgen g src rvb) src = rvb.
+Proof.
+  intros. unfold labeledgraph_vgen; simpl; unfold update_vlabel.
+  destruct (EquivDec.equiv_dec src src); [reflexivity|].
+  exfalso. apply c. reflexivity.
+Qed.
+
+Lemma mutable_graph_update_vlabel_src:
+  forall g src pos new g',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    raw_vertex_field_update (vlabel g src) pos
+      (match new with
+       | ExteriorUnboxed z => RawUnboxed z
+       | ExteriorOutlier p => RawOutlier p
+       | ExteriorVertex _ => RawInternal
+       end)
+      (vlabel g' src).
+Proof.
+  intros g src pos new g' Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dst].
+  - destruct Hupd as [rvb' [Hu ->]].
+    rewrite labeledgraph_vgen_vlabel_eq. exact Hu.
+  - destruct Hupd as [rvb' [Hu ->]].
+    rewrite labeledgraph_vgen_vlabel_eq. exact Hu.
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. change (raw_vertex_field_update (vlabel g src) pos RawInternal
+                          (vlabel g src)).
+      unfold raw_vertex_field_update.
+      split.
+      * rewrite <- Hold, upd_Znth_unchanged'. reflexivity.
+      * repeat split; reflexivity.
+    + destruct Hupd as [rvb' [Hu ->]].
+      rewrite labeledgraph_vgen_vlabel_eq. exact Hu.
+    + destruct Hupd as [rvb' [Hu ->]].
+      rewrite labeledgraph_vgen_vlabel_eq. exact Hu.
+Qed.
+
+Lemma mutable_graph_update_dst_neq:
+  forall (g: LGraph) src pos new g' (e: EType),
+    e <> (src, Z.to_nat pos) ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    dst g' e = dst g e.
+Proof.
+  intros g src pos new g' e Hneq Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  assert (Hedge: (src, Z.to_nat pos) <> e) by congruence.
+  destruct new as [z | p | new_dst].
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. apply lgd_dst_old. exact Hedge.
+    + destruct Hupd as [rvb' [_ ->]].
+      apply add_edge_preserves_dst. exact Hedge.
+    + destruct Hupd as [rvb' [_ ->]].
+      apply add_edge_preserves_dst. exact Hedge.
+Qed.
+
+Lemma mutable_graph_update_dst_new:
+  forall g src pos dstv g',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) (ExteriorVertex dstv) g' ->
+    dst g' (src, Z.to_nat pos) = dstv.
+Proof.
+  intros g src pos dstv g' Hloc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+  - subst g'. apply lgd_dst_new.
+  - destruct Hupd as [rvb' [_ ->]]. apply add_edge_dst.
+  - destruct Hupd as [rvb' [_ ->]]. apply add_edge_dst.
+Qed.
+
+Lemma nth_make_fields':
+  forall l v base i,
+    (i < length l)%nat ->
+    nth i (make_fields' l v base) field_t_inhabitant =
+    match nth i l raw_field_inhabitant with
+    | RawInternal => FieldEdge (v, (base + i)%nat)
+    | RawUnboxed z => FieldUnboxed z
+    | RawOutlier p => FieldOutlier p
+    end.
+Proof.
+  induction l as [|rf l IH]; intros v base i Hi; [simpl in Hi; lia|].
+  destruct i as [|i].
+  - destruct rf; simpl; rewrite ?Nat.add_0_r; reflexivity.
+  - destruct rf; simpl in Hi |- *.
+    all: rewrite (IH v (base + 1)%nat i) by lia.
+    all: destruct (nth i l raw_field_inhabitant); simpl; try reflexivity.
+    all: replace (base + 1 + i)%nat with (base + S i)%nat by lia; reflexivity.
+Qed.
+
+Lemma Znth_make_fields:
+  forall g v pos,
+    0 <= pos < Zlength (raw_fields (vlabel g v)) ->
+    Znth pos (make_fields g v) =
+    match Znth pos (raw_fields (vlabel g v)) with
+    | RawInternal => FieldEdge (v, Z.to_nat pos)
+    | RawUnboxed z => FieldUnboxed z
+    | RawOutlier p => FieldOutlier p
+    end.
+Proof.
+  intros g v pos Hpos.
+  unfold make_fields.
+  rewrite <- nth_Znth by (rewrite make_fields'_eq_Zlength; exact Hpos).
+  rewrite <- nth_Znth by exact Hpos.
+  rewrite nth_make_fields' by (rewrite <- ZtoNat_Zlength; lia).
+  simpl. reflexivity.
+Qed.
+
+Lemma mutable_graph_update_make_fields_vals_src:
+  forall g src pos new g',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    make_fields_vals g' src =
+    upd_Znth pos (make_fields_vals g src) (exterior2val g new).
+Proof.
+  intros g src pos new g' Hloc Hupd.
+  destruct Hloc as [Hv [Hpos [Hmark Htag]]].
+  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos)).
+  { exact (conj Hv (conj Hpos (conj Hmark Htag))). }
+  pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc' Hupd) as Hsrc.
+  unfold raw_vertex_field_update in Hsrc.
+  destruct Hsrc as [Hfields [Hmark' [_ [_ Htag']]]].
+  apply (proj2 (Znth_list_eq _ _)).
+  split.
+  - rewrite upd_Znth_Zlength by (rewrite fields_eq_length; exact Hpos).
+    rewrite !fields_eq_length, Hfields, Zlength_upd_Znth. reflexivity.
+  - intros j Hjnew.
+    assert (Hjnewraw: 0 <= j < Zlength (raw_fields (vlabel g' src))) by
+      (rewrite <- fields_eq_length; exact Hjnew).
+    assert (Hjoldraw: 0 <= j < Zlength (raw_fields (vlabel g src))).
+    { rewrite Hfields, Zlength_upd_Znth in Hjnewraw. exact Hjnewraw. }
+    unfold make_fields_vals.
+    rewrite Hmark', Hmark, Htag'.
+    rewrite Znth_map by (rewrite make_fields_eq_length; exact Hjnewraw).
+    assert (Hposmap:
+      0 <= pos < Zlength
+        (map (field2val (raw_tag (vlabel g src)) g) (make_fields g src))).
+    { rewrite Zlength_map, make_fields_eq_length. exact Hpos. }
+    destruct (Z.eq_dec j pos) as [Heq | Hneq].
+    + subst j.
+      rewrite upd_Znth_same by exact Hposmap.
+      rewrite (Znth_make_fields g' src pos Hjnewraw).
+      assert (Hrawnew:
+        Znth pos (raw_fields (vlabel g' src)) =
+        match new with
+        | ExteriorUnboxed z => RawUnboxed z
+        | ExteriorOutlier p => RawOutlier p
+        | ExteriorVertex _ => RawInternal
+        end).
+      { rewrite Hfields, upd_Znth_same by exact Hpos. reflexivity. }
+      rewrite Hrawnew. destruct new as [z | p | dstv]; simpl.
+      * destruct (zlt (raw_tag (vlabel g src)) NO_SCAN_TAG); [reflexivity|lia].
+      * reflexivity.
+      * rewrite (mutable_graph_update_dst_new g src pos dstv g' Hloc' Hupd).
+        rewrite (mutable_graph_update_vertex_address
+                   g (InteriorVertexPos src pos) (ExteriorVertex dstv) g' dstv
+                   Hloc' Hupd).
+        reflexivity.
+    + rewrite upd_Znth_diff_strong; [|exact Hposmap|exact Hneq].
+      rewrite Znth_map by (rewrite make_fields_eq_length; exact Hjoldraw).
+      rewrite (Znth_make_fields g' src j Hjnewraw).
+      rewrite (Znth_make_fields g src j Hjoldraw).
+      assert (Hrawsame:
+        Znth j (raw_fields (vlabel g' src)) =
+        Znth j (raw_fields (vlabel g src))).
+      { rewrite Hfields. apply upd_Znth_diff; lia. }
+      rewrite Hrawsame.
+      destruct (Znth j (raw_fields (vlabel g src))) eqn:Hraw; simpl; try reflexivity.
+      assert (Hedge: (src, Z.to_nat j) <> (src, Z.to_nat pos)).
+      { intro He. inversion He. apply Hneq. apply Z2Nat.inj; lia. }
+      rewrite (mutable_graph_update_vertex_address
+                 g (InteriorVertexPos src pos) new g'
+                 (dst g' (src, Z.to_nat j)) Hloc' Hupd).
+      rewrite (mutable_graph_update_dst_neq
+                 g src pos new g' (src, Z.to_nat j) Hedge Hloc' Hupd).
+      reflexivity.
 Qed.
 
 Lemma fr_roots_outlier_compatible: forall from to i g roots outlier,

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -7848,6 +7848,36 @@ Definition forward_remset_gh (from to : nat) (g: LGraph) (h: part_heap) (rh: rem
   (rmst: remset) : (LGraph * part_heap * remset_heap * remset) :=
   fold_left (forward_remset_item from to) (Znth (Z.of_nat from) rh) (g, h, rh, rmst).
 
+Lemma forward_remset_item_fold_suffix_invariant:
+  forall (Inv: remset_space -> LGraph -> part_heap -> remset_heap -> remset -> Prop)
+    from to r g h rh rmst g' h' rh' rmst',
+    (forall item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1,
+        Inv (item :: rest) g0 h0 rh0 rmst0 ->
+        (g1, h1, rh1, rmst1) =
+          forward_remset_item from to (g0, h0, rh0, rmst0) item ->
+        Inv rest g1 h1 rh1 rmst1) ->
+    Inv r g h rh rmst ->
+    (g', h', rh', rmst') =
+      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    Inv nil g' h' rh' rmst'.
+Proof.
+  intros Inv from to r g h rh rmst g' h' rh' rmst' Hstep HInv Hfold.
+  change (let '(g0, h0, rh0, rmst0) := (g', h', rh', rmst') in
+          Inv nil g0 h0 rh0 rmst0).
+  rewrite Hfold.
+  eapply (List_ext.fold_left_suffix_invariant
+            (forward_remset_item from to)
+            (fun rest s =>
+               let '(g0, h0, rh0, rmst0) := s in
+               Inv rest g0 h0 rh0 rmst0)).
+  - intros item rest [[[g0 h0] rh0] rmst0] HInv0.
+    destruct (forward_remset_item from to (g0, h0, rh0, rmst0) item)
+      as [[[g1 h1] rh1] rmst1] eqn:Hitem.
+    simpl.
+    eapply Hstep; [exact HInv0 | symmetry; exact Hitem].
+  - exact HInv.
+Qed.
+
 Lemma remset_ext_compatible_weakened: forall g outlier re,
     remset_ext_compatible g outlier re -> remset_ext_compatible' g re.
 Proof. intros g outlier re Hrec. destruct re; simpl in *; auto. Qed.
@@ -8528,11 +8558,11 @@ Lemma forward_remset_item_fold_len: forall from to r g h rh rmst g' h' rh' rmst'
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     length rh' = length (spaces h').
 Proof.
-  intros from to r. Opaque forward_remset_item.
-  induction r; intros g h rh rmst g' h' rh' rmst' Hlen Hfold; simpl in Hfold.
-  1: inversion Hfold; assumption. Transparent forward_remset_item.
-  destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-  symmetry in Hfri. apply forward_remset_item_len in Hfri; auto. eapply IHr; eassumption.
+  intros from to r g h rh rmst g' h' rh' rmst' Hlen Hfold.
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun _ _ h0 rh0 _ => length rh0 = length (spaces h0)));
+    [| exact Hlen | exact Hfold].
+  intros. eapply forward_remset_item_len; eassumption.
 Qed.
 
 Lemma incr_remset_heap_whr: forall h gen, weak_heap_relation h (incr_remset_heap h gen).
@@ -8563,11 +8593,13 @@ Lemma forward_remset_item_fold_whr: forall from to r g h rh rmst g' h' rh' rmst'
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     weak_heap_relation h h'.
 Proof.
-  intros from to r. Opaque forward_remset_item.
-  induction r; intros g h rh rmst g' h' rh' rmst' Hfold; simpl in Hfold. 1: now inversion Hfold.
-  Transparent forward_remset_item.
-  destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-  symmetry in Hfri. apply forward_remset_item_whr in Hfri. transitivity h2; auto. eapply IHr; eassumption.
+  intros from to r g h rh rmst g' h' rh' rmst' Hfold.
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun _ _ h0 _ _ => weak_heap_relation h h0));
+    [| reflexivity | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 Hinv Hstep.
+  transitivity h0; [exact Hinv |].
+  eapply forward_remset_item_whr. exact Hstep.
 Qed.
 
 Lemma total_size_irh: forall h from to,
@@ -8638,19 +8670,14 @@ Lemma forward_remset_item_fold_available_size_not_to:
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     available_size h' gen = available_size h gen.
 Proof.
-  intros from to r. induction r; intros g h rh rmst g' h' rh' rmst' gen Hgen Hfold.
-  - simpl in Hfold. inversion Hfold. reflexivity.
-  - simpl in Hfold.
-    destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
-    rewrite Hfri in Hfold.
-    assert (Hav_step: available_size h2 gen = available_size h gen). {
-      symmetry in Hfri.
-      eapply fri_available_size_not_to; eassumption.
-    }
-    pose proof (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' gen Hgen Hfold) as Hav_tail.
-    rewrite Hav_tail. exact Hav_step.
+  intros from to r g h rh rmst g' h' rh' rmst' gen Hgen Hfold.
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun _ _ h0 _ _ =>
+               available_size h0 gen = available_size h gen));
+    [| reflexivity | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 HInv Hstep.
+  rewrite <- HInv.
+  eapply fri_available_size_not_to; eassumption.
 Qed.
 
 Lemma forward_remset_gh_available_size_not_to:
@@ -8741,12 +8768,14 @@ Lemma fold_fri_remset_gen_size: forall from to r g h rh rmst g' h' rh' rmst',
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     remset_gen_size h' from = remset_gen_size h from.
 Proof.
-  intros from to r g h rh rmst g' h' rh' rmst' Hneq. revert g h rh rmst g' h' rh' rmst'.
-  Opaque forward_remset_item.
-  induction r; intros g h rh rmst g' h' rh' rmst' Hfold; simpl in Hfold. 1: now inversion Hfold.
-  Transparent forward_remset_item.
-  destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-  symmetry in Hfri. apply fri_remset_gen_size in Hfri; auto. rewrite <- Hfri. eapply IHr; eassumption.
+  intros from to r g h rh rmst g' h' rh' rmst' Hneq Hfold.
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun _ _ h0 _ _ =>
+               remset_gen_size h0 from = remset_gen_size h from));
+    [| reflexivity | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 HInv Hstep.
+  rewrite <- HInv.
+  eapply fri_remset_gen_size; eassumption.
 Qed.
 
 Lemma nth_remset_space_Znth: forall rh n, nth_remset_space rh n = Znth (Z.of_nat n) rh.
@@ -9195,11 +9224,11 @@ Lemma fri_remset_nodup_fold: forall from to g h rh rmst r g' h' rh' rmst',
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     remset_nodup rmst'.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' Hrnd Hfri. 1: simpl in Hfri; now inversion Hfri.
-  Opaque forward_remset_item. simpl in Hfri. Transparent forward_remset_item.
-  destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-  eapply (IHr g2); [|eassumption]. symmetry in Hfri2. eapply fri_remset_nodup; eassumption.
+  intros from to g h rh rmst r g' h' rh' rmst' Hrnd Hfold.
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun _ _ _ _ rmst0 => remset_nodup rmst0));
+    [| exact Hrnd | exact Hfold].
+  intros. eapply fri_remset_nodup; eassumption.
 Qed.
 
 Lemma exterior_forward_t_compatible: forall g outlier ext,

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -8023,18 +8023,18 @@ Lemma fgah_O_total_size: forall from to p g h g' h',
     (g', h') = forward_graph_and_heap from to O p g h ->
     total_size h' from = total_size h from.
 Proof.
-  simpl. intros. destruct p; [inversion H; reflexivity.. | |];
-    destruct (Nat.eq_dec _ _); [| inversion H; reflexivity | | inversion H; reflexivity];
-    destruct (raw_mark _); inversion H; try reflexivity; rewrite cti_total_size; reflexivity.
+  intros from to p g h g' h' Hfgh. symmetry.
+  apply heap_relation_total_size.
+  eapply heaprel_forward_graph_and_heap_eq; exact Hfgh.
 Qed.
 
 Lemma fgah_O_available_size: forall from to p g h g' h',
     (g', h') = forward_graph_and_heap from to O p g h ->
     available_size h' from = available_size h from.
 Proof.
-  simpl. intros. destruct p; [inversion H; reflexivity.. | |];
-    destruct (Nat.eq_dec _ _); [| inversion H; reflexivity | | inversion H; reflexivity];
-    destruct (raw_mark _); inversion H; try reflexivity; rewrite cti_available_size; reflexivity.
+  intros from to p g h g' h' Hfgh. symmetry.
+  apply heap_relation_available_size.
+  eapply heaprel_forward_graph_and_heap_eq; exact Hfgh.
 Qed.
 
 Lemma fgah_O_remset_gen_size: forall from to p g h g' h',
@@ -8555,6 +8555,17 @@ Qed.
 Lemma rhhc_length_eq: forall rh h, remset_heap_and_heap_compatible rh h -> length rh = length (spaces h).
 Proof. intros. hnf in H. apply Forall2_length in H. assumption. Qed.
 
+Lemma heap_relation_rhhc: forall h1 h2 rh,
+    heap_relation h1 h2 -> remset_heap_and_heap_compatible rh h1 -> remset_heap_and_heap_compatible rh h2.
+Proof.
+  intros h1 h2 rh [Has [Hss [Hts Hsh]]] Hrhhc. hnf in Hrhhc |- * . rewrite Forall2_forall_Znth in *.
+  destruct Hrhhc as [Hlen Hrssc]. pose proof spaces_size h1 as Hlen1. pose proof spaces_size h2 as Hlen2.
+  split. 1: lia. intros i Hi. specialize (Hrssc _ Hi). hnf in Hrssc |- * . unfold available_size in Has.
+  unfold total_size in Hts. specialize (Hss (Z.to_nat i)). specialize (Has (Z.to_nat i)).
+  specialize (Hts (Z.to_nat i)). rewrite !nth_space_Znth in *. rewrite Z2Nat.id in * by lia.
+  rewrite <- Hss. destruct (Val.eq _ _); auto. rewrite <- Has, <- Hts. assumption.
+Qed.
+
 Lemma reset_nth_remset_heap_rhhc: forall n rh h,
     remset_heap_and_heap_compatible rh h ->
     remset_heap_and_heap_compatible (reset_nth_remset_heap n rh)
@@ -8574,13 +8585,8 @@ Qed.
 Lemma cut_heap_rhhc: forall rh h i s,
     remset_heap_and_heap_compatible rh h -> remset_heap_and_heap_compatible rh (cut_heap h i s).
 Proof.
-  intros. unfold cut_heap. destruct (spaces_index_dec i h); auto. hnf in H |- *. simpl.
-  rewrite Forall2_forall_Znth in H |- *. destruct H as [Hlen Hf]. split.
-  - rewrite Zlength_upd_Znth. assumption.
-  - intros j Hj. destruct (Z.eq_dec j i).
-    + subst. rewrite upd_Znth_same by assumption. specialize (Hf i Hj). unfold cut_space.
-      destruct (has_space_dec _ _); auto.
-    + rewrite Znth_upd_Znth_diff by assumption. apply Hf. assumption.
+  intros rh h i s Hrhhc.
+  eapply heap_relation_rhhc; [apply cut_heap_relation | exact Hrhhc].
 Qed.
 
 Lemma forward_graph_and_heap_O_rhhc: forall from to f g h rh g' h',
@@ -8588,12 +8594,9 @@ Lemma forward_graph_and_heap_O_rhhc: forall from to f g h rh g' h',
     (g',h') = forward_graph_and_heap from to O f g h ->
     remset_heap_and_heap_compatible rh h'.
 Proof.
-  intros from to f g h rh g' h' Hrhhc Hfrh. Transparent forward_graph_and_heap.
-  destruct f; simpl in Hfrh; try now inversion Hfrh.
-  - destruct (Nat.eq_dec _ _). 2: now inversion Hfrh. destruct (raw_mark _); inversion Hfrh; auto.
-    now apply cut_heap_rhhc.
-  - destruct (Nat.eq_dec _ _). 2: now inversion Hfrh. destruct (raw_mark _); inversion Hfrh; auto.
-    now apply cut_heap_rhhc. Opaque forward_graph_and_heap.
+  intros from to f g h rh g' h' Hrhhc Hfrh.
+  eapply heap_relation_rhhc; [|exact Hrhhc].
+  eapply heaprel_forward_graph_and_heap_eq; exact Hfrh.
 Qed.
 
 Lemma fgh_O_heap_len: forall from to f g h n g' h',
@@ -8607,6 +8610,44 @@ Qed.
 
 Lemma upd_remset_heap_len: forall rh item gen, Zlength (upd_remset_heap item rh gen) = Zlength rh.
 Proof. intros. unfold upd_remset_heap. now rewrite Zlength_upd_Znth. Qed.
+
+Lemma fri_rh_Zlength_same: forall from to g h rh rmst item g' h' rh' rmst',
+    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
+    Zlength rh = Zlength rh'.
+Proof.
+  intros from to g h rh rmst item g' h' rh' rmst' Hfri. simpl in Hfri.
+  destruct (negb _). 2: inversion Hfri; reflexivity.
+  destruct (forward_graph_and_heap _ _ _ _ _ _) as [g2 h2] eqn: Hfgh. inversion Hfri.
+  rewrite upd_remset_heap_len. reflexivity.
+Qed.
+
+Lemma forward_remset_item_fold_space_property:
+  forall (Q: remset_space -> remset_heap -> Prop)
+         from to r g h rh rmst g' h' rh' rmst',
+    0 <= Z.of_nat to < Zlength rh ->
+    Q r rh ->
+    (forall item rest g h rh rmst g2 h2 rh2 rmst2,
+        0 <= Z.of_nat to < Zlength rh ->
+        Q (item :: rest) rh ->
+        (g2, h2, rh2, rmst2) =
+          forward_remset_item from to (g, h, rh, rmst) item ->
+        Q rest rh2) ->
+    (g', h', rh', rmst') =
+      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    Q nil rh'.
+Proof.
+  intros Q from to r g h rh rmst g' h' rh' rmst' Hrange HQ HQstep Hfold.
+  enough (0 <= Z.of_nat to < Zlength rh' /\ Q nil rh') as [_ H]; [exact H |].
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun rest _ _ rh0 _ =>
+               0 <= Z.of_nat to < Zlength rh0 /\ Q rest rh0));
+    [| split; [exact Hrange | exact HQ] | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 [Hrange0 HQ0] Hstep.
+  split.
+  - pose proof (fri_rh_Zlength_same from to g0 h0 rh0 rmst0 item
+                  g1 h1 rh1 rmst1 Hstep); lia.
+  - eapply HQstep; eassumption.
+Qed.
 
 Lemma incr_remset_heap_len: forall h gen, Zlength (spaces (incr_remset_heap h gen)) = Zlength (spaces h).
 Proof.
@@ -8710,21 +8751,9 @@ Lemma fri_total_size: forall from to g h rh rmst item g' h' rh' rmst',
     (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
     total_size h' from = total_size h from.
 Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' Hneq Hfri. simpl in Hfri.
-  destruct (negb _). 2: now inversion Hfri.
-  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh. symmetry in Hfgh.
-  apply fgah_O_total_size in Hfgh. rewrite <- Hfgh. inversion Hfri. now apply total_size_irh.
-Qed.
-
-Lemma fri_available_size: forall from to g h rh rmst item g' h' rh' rmst',
-    from <> to ->
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    available_size h' from = available_size h from.
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' Hneq Hfri. simpl in Hfri.
-  destruct (negb _). 2: now inversion Hfri.
-  destruct (forward_graph_and_heap _ _ _ _ _ _) as [newg newh] eqn:Hfgh. symmetry in Hfgh.
-  apply fgah_O_available_size in Hfgh. rewrite <- Hfgh. inversion Hfri. now apply available_size_irh.
+  intros from to g h rh rmst item g' h' rh' rmst' Hneq Hfri. symmetry.
+  apply (proj2 (forward_remset_item_whr
+                  from to g h rh rmst item g' h' rh' rmst' Hfri)).
 Qed.
 
 Lemma fri_available_size_not_to: forall from to g h rh rmst item g' h' rh' rmst' gen,
@@ -8741,6 +8770,15 @@ Proof.
   pose proof (heaprel_forward_graph_and_heap_eq from to 0
                 (remset_item2forward_t item rmst g) g h newg newh (eq_sym Hfgh)) as Hhr.
   symmetry. now apply heap_relation_available_size.
+Qed.
+
+Lemma fri_available_size: forall from to g h rh rmst item g' h' rh' rmst',
+    from <> to ->
+    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
+    available_size h' from = available_size h from.
+Proof.
+  intros from to g h rh rmst item g' h' rh' rmst' Hneq Hfri.
+  eapply fri_available_size_not_to; eassumption.
 Qed.
 
 Lemma forward_remset_item_fold_available_size_not_to:
@@ -9333,17 +9371,6 @@ Proof.
   rewrite Znth_upd_Znth_diff; easy.
 Qed.
 
-Lemma heap_relation_rhhc: forall h1 h2 rh,
-    heap_relation h1 h2 -> remset_heap_and_heap_compatible rh h1 -> remset_heap_and_heap_compatible rh h2.
-Proof.
-  intros h1 h2 rh [Has [Hss [Hts Hsh]]] Hrhhc. hnf in Hrhhc |- * . rewrite Forall2_forall_Znth in *.
-  destruct Hrhhc as [Hlen Hrssc]. pose proof spaces_size h1 as Hlen1. pose proof spaces_size h2 as Hlen2.
-  split. 1: lia. intros i Hi. specialize (Hrssc _ Hi). hnf in Hrssc |- * . unfold available_size in Has.
-  unfold total_size in Hts. specialize (Hss (Z.to_nat i)). specialize (Has (Z.to_nat i)).
-  specialize (Hts (Z.to_nat i)). rewrite !nth_space_Znth in *. rewrite Z2Nat.id in * by lia.
-  rewrite <- Hss. destruct (Val.eq _ _); auto. rewrite <- Has, <- Hts. assumption.
-Qed.
-
 Lemma spaces_incr_remset_heap_split: forall (h: part_heap) gen,
     0 <= gen < Zlength (spaces h) ->
     spaces (incr_remset_heap h gen) =
@@ -9399,29 +9426,20 @@ Proof.
   destruct (Nat.eq_dec gen to); [contradiction | reflexivity].
 Qed.
 
-Lemma fri_rh_Zlength_same: forall from to g h rh rmst item g' h' rh' rmst',
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    Zlength rh = Zlength rh'.
-Proof.
-  intros from to g h rh rmst item g' h' rh' rmst' Hfri. simpl in Hfri.
-  destruct (negb _). 2: inversion Hfri; reflexivity.
-  destruct (forward_graph_and_heap _ _ _ _ _ _) as [g2 h2] eqn: Hfgh. inversion Hfri.
-  rewrite upd_remset_heap_len. reflexivity.
-Qed.
-
 Lemma fri_fold_rh_same: forall from to r g h rh rmst g' h' rh' rmst' gen,
     gen <> to ->
     0 <= Z.of_nat to < Zlength rh ->
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     nth_remset_space rh gen = nth_remset_space rh' gen.
 Proof.
-  intros from to r g h rh rmst g' h' rh' rmst' gen Hneq Hrange. revert g h rh rmst g' h' rh' rmst' Hrange.
-  induction r; intros g h rh rmst g' h' rh' rmst' Hrange Hfold.
-  - simpl in Hfold. inversion Hfold. reflexivity.
-  - Opaque forward_remset_item. simpl in Hfold. Transparent forward_remset_item.
-    destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn: Hfri.
-    symmetry in Hfri. pose proof Hfri. apply fri_rh_same with (gen := gen) in Hfri; auto. rewrite Hfri.
-    eapply IHr; eauto. eapply fri_rh_Zlength_same in H. lia.
+  intros from to r g h rh rmst g' h' rh' rmst' gen Hneq Hrange Hfold.
+  eapply (forward_remset_item_fold_space_property
+            (fun _ rh0 => nth_remset_space rh gen = nth_remset_space rh0 gen)
+            from to r g h rh rmst g' h' rh' rmst');
+    [exact Hrange | reflexivity | | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1
+         Hrange0 Hsame Hstep.
+  rewrite Hsame. eapply fri_rh_same; eassumption.
 Qed.
 
 Definition do_generation_heap_relation (from to: nat)
@@ -9994,34 +10012,6 @@ Proof.
     apply nth_remset_space_upd_remset_heap_old; assumption.
   - inversion Hfri; subst; clear Hfri.
     exact Hin.
-Qed.
-
-Lemma forward_remset_item_fold_space_property:
-  forall (Q: remset_space -> remset_heap -> Prop)
-         from to r g h rh rmst g' h' rh' rmst',
-    0 <= Z.of_nat to < Zlength rh ->
-    Q r rh ->
-    (forall item rest g h rh rmst g2 h2 rh2 rmst2,
-        0 <= Z.of_nat to < Zlength rh ->
-        Q (item :: rest) rh ->
-        (g2, h2, rh2, rmst2) =
-          forward_remset_item from to (g, h, rh, rmst) item ->
-        Q rest rh2) ->
-    (g', h', rh', rmst') =
-      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
-    Q nil rh'.
-Proof.
-  intros Q from to r g h rh rmst g' h' rh' rmst' Hrange HQ HQstep Hfold.
-  enough (0 <= Z.of_nat to < Zlength rh' /\ Q nil rh') as [_ H]; [exact H |].
-  eapply (forward_remset_item_fold_suffix_invariant
-            (fun rest _ _ rh0 _ =>
-               0 <= Z.of_nat to < Zlength rh0 /\ Q rest rh0));
-    [| split; [exact Hrange | exact HQ] | exact Hfold].
-  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 [Hrange0 HQ0] Hstep.
-  split.
-  - pose proof (fri_rh_Zlength_same from to g0 h0 rh0 rmst0 item
-                  g1 h1 rh1 rmst1 Hstep); lia.
-  - eapply HQstep; eassumption.
 Qed.
 
 Lemma remset_item2forward_t_not_edge:

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -8019,6 +8019,32 @@ Proof.
   rewrite H0 in H1. simpl in H1. inversion Hfri. eapply fr_graph_has_gen; eauto.
 Qed.
 
+Lemma forward_remset_item_fold_graph_property:
+  forall (P: LGraph -> Prop) from to r g h rh rmst g' h' rh' rmst',
+    (forall item g0 h0 rh0 rmst0 g1 h1 rh1 rmst1,
+        graph_has_gen g0 to ->
+        P g0 ->
+        (g1, h1, rh1, rmst1) =
+          forward_remset_item from to (g0, h0, rh0, rmst0) item ->
+        P g1) ->
+    graph_has_gen g to ->
+    P g ->
+    (g', h', rh', rmst') =
+      fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
+    P g'.
+Proof.
+  intros P from to r g h rh rmst g' h' rh' rmst' Hstep Hto HP Hfold.
+  enough (graph_has_gen g' to /\ P g') as [_ H]; [exact H |].
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun _ g0 _ _ _ => graph_has_gen g0 to /\ P g0));
+    [| split; [exact Hto | exact HP] | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 [Hto0 HP0] Hitem.
+  split.
+  - apply (proj1 (forward_remset_item_ghg from to g0 h0 rh0 rmst0 item
+                    g1 h1 rh1 rmst1 Hto0 Hitem to)); exact Hto0.
+  - eapply Hstep; eassumption.
+Qed.
+
 Lemma fri_copy_compatible: forall from to g h rh rmst item g' h' rh' rmst',
     from <> to -> graph_has_gen g to -> copy_compatible g ->
     (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
@@ -8715,29 +8741,20 @@ Lemma forward_remset_item_fold_graph_gen_size_unchanged:
     fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     graph_gen_size g gen = graph_gen_size g' gen.
 Proof.
-  intros from to r. induction r;
-    intros g h rh rmst g' h' rh' rmst' gen Hto Hgen Hneq Hfold.
-  - simpl in Hfold. inversion Hfold. reflexivity.
-  - simpl in Hfold.
-    destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
-    rewrite Hfri in Hfold.
-    assert (Hfri_sym:
-              (g2, h2, rh2, rmst2) =
-              forward_remset_item from to (g, h, rh, rmst) a)
-      by (symmetry; exact Hfri).
-    transitivity (graph_gen_size g2 gen).
-    + eapply (forward_remset_item_graph_gen_size_unchanged from to); eauto.
-    + apply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' gen).
-      * rewrite <- (forward_remset_item_ghg
-                      from to g h rh rmst a g2 h2 rh2 rmst2
-                      Hto Hfri_sym to); exact Hto.
-      * rewrite <- (forward_remset_item_ghg
-                      from to g h rh rmst a g2 h2 rh2 rmst2
-                      Hto Hfri_sym gen); exact Hgen.
-      * exact Hneq.
-      * exact Hfold.
+  intros from to r g h rh rmst g' h' rh' rmst' gen Hto Hgen Hneq Hfold.
+  enough (graph_has_gen g' gen /\
+          graph_gen_size g gen = graph_gen_size g' gen) as [_ H]; [exact H |].
+  eapply (forward_remset_item_fold_graph_property
+            (fun g0 => graph_has_gen g0 gen /\
+               graph_gen_size g gen = graph_gen_size g0 gen));
+    [| exact Hto | split; [exact Hgen | reflexivity] | exact Hfold].
+  intros item g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 Hto0 [Hgen0 Hsize0] Hstep.
+  split.
+  - apply (proj1 (forward_remset_item_ghg from to g0 h0 rh0 rmst0 item
+                    g1 h1 rh1 rmst1 Hto0 Hstep gen)); exact Hgen0.
+  - transitivity (graph_gen_size g0 gen); [exact Hsize0 |].
+    eapply (forward_remset_item_graph_gen_size_unchanged
+              from to g0 h0 rh0 rmst0 item g1 h1 rh1 rmst1 gen); eassumption.
 Qed.
 
 Lemma forward_remset_gh_graph_gen_size_unchanged:
@@ -9127,14 +9144,10 @@ Lemma fri_copy_compatible_fold: forall from to g h rh rmst r g' h' rh' rmst',
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     copy_compatible g'.
 Proof.
-  intros from to g h rh rmst r g' h' rh' rmst' Hfr. revert g h rh rmst g' h' rh' rmst'.
-  Opaque forward_remset_item. induction r;
-    intros g h rh rmst g' h' rh' rmst' Hghg Hcc Hfri; simpl in Hfri.
-  1: inversion Hfri; assumption. Transparent forward_remset_item.
-  destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-  symmetry in Hfri2. eapply (IHr g2 h2 rh2 rmst2); eauto.
-  - eapply forward_remset_item_ghg with (g := g); eassumption.
-  - eapply (fri_copy_compatible from to); eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' Hfr Hto Hcc Hfold.
+  eapply (forward_remset_item_fold_graph_property copy_compatible);
+    [| exact Hto | exact Hcc | exact Hfold].
+  intros. eapply fri_copy_compatible; eassumption.
 Qed.
 
 Lemma fri_no_dangling_dst_fold: forall from to g h rh rmst r g' h' rh' rmst',
@@ -9678,16 +9691,11 @@ Lemma forward_remset_item_fold_roots_graph_compatible_pres:
     roots_graph_compatible roots g ->
     roots_graph_compatible roots g'.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' roots Hto Hfold Hrgc; simpl in Hfold.
-  - now inversion Hfold.
-  - destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    pose proof Hfri as Hfri'. unfold forward_remset_item in Hfri'. simpl in Hfri'.
-    rewrite Hfri' in Hfold. symmetry in Hfri.
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' roots); eauto.
-    + rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri to).
-      exact Hto.
-    + eapply forward_remset_item_roots_graph_compatible_pres; eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' roots Hto Hfold Hrgc.
+  eapply (forward_remset_item_fold_graph_property
+            (roots_graph_compatible roots));
+    [| exact Hto | exact Hrgc | exact Hfold].
+  intros. eapply forward_remset_item_roots_graph_compatible_pres; eassumption.
 Qed.
 
 Lemma forward_remset_gh_roots_graph_compatible:
@@ -9730,16 +9738,10 @@ Lemma forward_remset_item_fold_gen_unmarked_pres:
     gen_unmarked g gen ->
     gen_unmarked g' gen.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' gen Hto Hneq Hfold Hunmk; simpl in Hfold.
-  - now inversion Hfold.
-  - destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    pose proof Hfri2 as Hfri2'. unfold forward_remset_item in Hfri2'. simpl in Hfri2'.
-    rewrite Hfri2' in Hfold. symmetry in Hfri2.
-    assert (Hto2: graph_has_gen g2 to) by
-        (rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri2 to); exact Hto).
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' gen Hto2 Hneq Hfold).
-    eapply (forward_remset_item_gen_unmarked_pres from to g h rh rmst a g2 h2 rh2 rmst2 gen); eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' gen Hto Hneq Hfold Hunmk.
+  eapply (forward_remset_item_fold_graph_property (fun g0 => gen_unmarked g0 gen));
+    [| exact Hto | exact Hunmk | exact Hfold].
+  intros. eapply forward_remset_item_gen_unmarked_pres; eassumption.
 Qed.
 
 Lemma forward_remset_gh_gen_unmarked:
@@ -9783,17 +9785,11 @@ Lemma forward_remset_item_fold_firstn_gen_clear_pres:
     firstn_gen_clear g gen ->
     firstn_gen_clear g' gen.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' gen Hto Hle Hfold Hclear; simpl in Hfold.
-  - now inversion Hfold.
-  - destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    pose proof Hfri2 as Hfri2'. unfold forward_remset_item in Hfri2'. simpl in Hfri2'.
-    rewrite Hfri2' in Hfold. symmetry in Hfri2.
-    assert (Hto2: graph_has_gen g2 to) by
-        (rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri2 to); exact Hto).
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' gen Hto2 Hle Hfold).
-    eapply (forward_remset_item_firstn_gen_clear_pres from to g h rh rmst a g2 h2 rh2 rmst2 gen);
-      eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' gen Hto Hle Hfold Hclear.
+  eapply (forward_remset_item_fold_graph_property
+            (fun g0 => firstn_gen_clear g0 gen));
+    [| exact Hto | exact Hclear | exact Hfold].
+  intros. eapply forward_remset_item_firstn_gen_clear_pres; eassumption.
 Qed.
 
 Lemma forward_remset_gh_firstn_gen_clear:
@@ -9838,20 +9834,19 @@ Lemma forward_remset_item_fold_stcg_pres:
     safe_to_copy_gen g gen1 gen2 ->
     safe_to_copy_gen g' gen1 gen2.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' gen1 gen2 Hto Hgen Hneq Hfold Hsafe;
-    simpl in Hfold.
-  - now inversion Hfold.
-  - destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    pose proof Hfri2 as Hfri2'. unfold forward_remset_item in Hfri2'. simpl in Hfri2'.
-    rewrite Hfri2' in Hfold. symmetry in Hfri2.
-    assert (Hto2: graph_has_gen g2 to) by
-        (rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri2 to); exact Hto).
-    assert (Hgen2: graph_has_gen g2 gen2) by
-        (rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri2 gen2); exact Hgen).
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' gen1 gen2 Hto2 Hgen2 Hneq Hfold).
-    eapply (forward_remset_item_stcg_pres from to g h rh rmst a g2 h2 rh2 rmst2 gen1 gen2);
-      eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' gen1 gen2
+         Hto Hgen Hneq Hfold Hsafe.
+  enough (graph_has_gen g' gen2 /\ safe_to_copy_gen g' gen1 gen2)
+    as [_ H]; [exact H |].
+  eapply (forward_remset_item_fold_graph_property
+            (fun g0 => graph_has_gen g0 gen2 /\ safe_to_copy_gen g0 gen1 gen2));
+    [| exact Hto | split; assumption | exact Hfold].
+  intros item g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 Hto0 [Hgen0 Hsafe0] Hstep.
+  split.
+  - apply (proj1 (forward_remset_item_ghg from to g0 h0 rh0 rmst0 item
+                    g1 h1 rh1 rmst1 Hto0 Hstep gen2)); exact Hgen0.
+  - eapply (forward_remset_item_stcg_pres from to g0 h0 rh0 rmst0 item
+              g1 h1 rh1 rmst1 gen1 gen2); eassumption.
 Qed.
 
 Lemma forward_remset_gh_stcg:
@@ -9971,20 +9966,17 @@ Lemma forward_remset_item_fold_space_property:
       fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     Q nil rh'.
 Proof.
-  intros Q from to r.
-  induction r as [|item rest IH];
-    intros g h rh rmst g' h' rh' rmst' Hrange HQ HQstep Hfold.
-  - simpl in Hfold. inversion Hfold; subst. exact HQ.
-  - Opaque forward_remset_item.
-    simpl in Hfold.
-    Transparent forward_remset_item.
-    destruct (forward_remset_item from to (g, h, rh, rmst) item)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    symmetry in Hfri.
-    assert (Hrange2: 0 <= Z.of_nat to < Zlength rh2) by
-        (pose proof (fri_rh_Zlength_same from to g h rh rmst item
-                       g2 h2 rh2 rmst2 Hfri); lia).
-    eapply (IH g2 h2 rh2 rmst2 g' h' rh' rmst'); eauto.
+  intros Q from to r g h rh rmst g' h' rh' rmst' Hrange HQ HQstep Hfold.
+  enough (0 <= Z.of_nat to < Zlength rh' /\ Q nil rh') as [_ H]; [exact H |].
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun rest _ _ rh0 _ =>
+               0 <= Z.of_nat to < Zlength rh0 /\ Q rest rh0));
+    [| split; [exact Hrange | exact HQ] | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 [Hrange0 HQ0] Hstep.
+  split.
+  - pose proof (fri_rh_Zlength_same from to g0 h0 rh0 rmst0 item
+                  g1 h1 rh1 rmst1 Hstep); lia.
+  - eapply HQstep; eassumption.
 Qed.
 
 Lemma remset_item2forward_t_not_edge:
@@ -10503,33 +10495,23 @@ Lemma forward_remset_item_fold_interior_generation_order:
     (g', h', rh', rmst') = fold_left (forward_remset_item from (S from)) r (g, h, rh, rmst) ->
     remset_interior_generation_order rh'.
 Proof.
-  intros from r. induction r;
-    intros g h rh rmst g' h' rh' rmst' Hrange Horder Hbound Hfold.
-  - simpl in Hfold. inversion Hfold; subst. exact Horder.
-  - simpl in Hfold.
-    change (if negb (remset_item_in_gen a rmst g from)
-            then let (new_g, new_h) :=
-                   forward_graph_and_heap from (S from) 0 (remset_item2forward_t a rmst g) g h in
-                 (new_g, incr_remset_heap new_h (Z.pos (Pos.of_succ_nat from)),
-                  upd_remset_heap a rh (S from), upd_remset from (S from) g a rmst)
-            else (g, h, rh, rmst))
-      with (forward_remset_item from (S from) (g, h, rh, rmst) a) in Hfold.
-    destruct (forward_remset_item from (S from) (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    symmetry in Hfri.
-    assert (Horder2: remset_interior_generation_order rh2). {
-      eapply forward_remset_item_interior_generation_order; eauto.
-      intros v pos Heq. eapply Hbound. simpl. left. exact Heq.
-    }
-    assert (Hrange2: 0 <= Z.of_nat (S from) < Zlength rh2). {
-      pose proof (fri_rh_Zlength_same from (S from) g h rh rmst a g2 h2 rh2 rmst2 Hfri).
-      lia.
-    }
-    assert (Hbound2: remset_space_interior_generation_order_from from r). {
-      unfold remset_space_interior_generation_order_from in *. intros v pos Hin.
-      eapply (Hbound v pos). simpl. right. exact Hin.
-    }
-    eapply IHr; eauto.
+  intros from r g h rh rmst g' h' rh' rmst' Hrange Horder Hbound Hfold.
+  enough (remset_interior_generation_order rh' /\
+          remset_space_interior_generation_order_from from nil) as [H _];
+    [exact H |].
+  eapply (forward_remset_item_fold_space_property
+            (fun rest rh0 => remset_interior_generation_order rh0 /\
+               remset_space_interior_generation_order_from from rest)
+            from (S from));
+    [exact Hrange | split; [exact Horder | exact Hbound] | | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1
+         Hrange0 [Horder0 Hbound0] Hstep.
+  unfold remset_space_interior_generation_order_from in Hbound0.
+  split.
+  - eapply forward_remset_item_interior_generation_order; eauto.
+    intros v pos Heq. apply (Hbound0 v pos). simpl. left. exact Heq.
+  - unfold remset_space_interior_generation_order_from.
+    intros v pos Hin. apply (Hbound0 v pos). simpl. right. exact Hin.
 Qed.
 
 Lemma forward_remset_gh_interior_generation_order:
@@ -10722,22 +10704,13 @@ Lemma forward_remset_item_fold_gen_v_num_to:
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     (gen_v_num g to <= gen_v_num g' to)%nat.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' Hto Hfold.
-  - simpl in Hfold. inversion Hfold; subst. lia.
-  - simpl in Hfold.
-    destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    symmetry in Hfri2.
-    fold (forward_remset_item from to (g, h, rh, rmst) a) in Hfold.
-    rewrite <- Hfri2 in Hfold.
-    assert (Hto2: graph_has_gen g2 to) by
-        (rewrite <- (forward_remset_item_ghg from to g h rh rmst a g2 h2 rh2 rmst2
-                       Hto Hfri2 to); exact Hto).
-    pose proof (forward_remset_item_gen_v_num_to from to g h rh rmst a g2 h2 rh2 rmst2
-                  Hto Hfri2).
-    pose proof (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' Hto2 Hfold).
-    lia.
+  intros from to g h rh rmst r g' h' rh' rmst' Hto Hfold.
+  eapply (forward_remset_item_fold_graph_property
+            (fun g0 => (gen_v_num g to <= gen_v_num g0 to)%nat));
+    [| exact Hto | lia | exact Hfold].
+  intros item g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 Hto0 Hle Hstep.
+  transitivity (gen_v_num g0 to); [exact Hle |].
+  eapply forward_remset_item_gen_v_num_to; eassumption.
 Qed.
 
 Lemma forward_remset_gh_gen_v_num_to:

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -7751,6 +7751,17 @@ Definition remset_generation_compatible
   remset_interior_generation_order rh /\
   remset_lower_generations_empty from rh.
 
+Definition remembered_set_ok
+    (from : nat)
+    (g : LGraph)
+    (h : part_heap)
+    (outlier : outlier_t)
+    (rh : remset_heap)
+    (rmst : remset) : Prop :=
+  no_unrecorded_backward_edge_from from g rh /\
+  remset_compatible g outlier from rmst rh h /\
+  remset_generation_compatible from rmst rh.
+
 Definition forward_remset_condition g h from to : Prop :=
   enough_space_enhanced g h from to /\ graph_has_gen g from /\ graph_has_gen g to /\
     copy_compatible g /\ no_dangling_dst g /\ ti_size_spec h.

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -1920,9 +1920,8 @@ Lemma mutable_graph_update_graph_has_v:
     (graph_has_v g' v <-> graph_has_v g v).
 Proof.
   intros g it new g' v Hloc Hupd.
-  pose proof (mutable_graph_update_glabel _ _ _ _ Hloc Hupd) as Hglabel.
   unfold graph_has_v, graph_has_gen, gen_has_index, nth_gen.
-  rewrite Hglabel. reflexivity.
+  rewrite (mutable_graph_update_glabel _ _ _ _ Hloc Hupd). reflexivity.
 Qed.
 
 Lemma mutable_graph_update_nth_gen:
@@ -2139,9 +2138,8 @@ Lemma mutable_graph_update_graph_heap_compatible:
     graph_heap_compatible g' h.
 Proof.
   intros g it new g' h Hloc Hupd [Hgens [Hnull Hlen]].
-  pose proof (mutable_graph_update_glabel _ _ _ _ Hloc Hupd) as Hglabel.
   unfold graph_heap_compatible.
-  rewrite Hglabel.
+  rewrite (mutable_graph_update_glabel _ _ _ _ Hloc Hupd).
   split; [|split; assumption].
   eapply Forall_impl; [|exact Hgens].
   intros [[gen gi] sp] Hcomp.
@@ -4687,10 +4685,9 @@ Lemma mutable_graph_update_make_fields_vals_src:
     upd_Znth pos (make_fields_vals g src) (exterior2val g new).
 Proof.
   intros g src pos new g' Hloc Hupd.
-  destruct Hloc as [Hv [Hpos [Hmark Htag]]].
-  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos)).
-  { exact (conj Hv (conj Hpos (conj Hmark Htag))). }
-  pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc' Hupd) as Hsrc.
+  pose proof Hloc as Hloc_parts.
+  destruct Hloc_parts as [Hv [Hpos [Hmark Htag]]].
+  pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc Hupd) as Hsrc.
   unfold raw_vertex_field_update in Hsrc.
   destruct Hsrc as [Hfields [Hmark' [_ [_ Htag']]]].
   apply List_ext.list_eq_Znth.
@@ -4723,10 +4720,10 @@ Proof.
       rewrite Hrawnew. destruct new as [z | p | dstv]; simpl.
       * destruct (zlt (raw_tag (vlabel g src)) NO_SCAN_TAG); [reflexivity|lia].
       * reflexivity.
-      * rewrite (mutable_graph_update_dst_new g src pos dstv g' Hloc' Hupd).
+      * rewrite (mutable_graph_update_dst_new g src pos dstv g' Hloc Hupd).
         rewrite (mutable_graph_update_vertex_address
                    g (InteriorVertexPos src pos) (ExteriorVertex dstv) g' dstv
-                   Hloc' Hupd).
+                   Hloc Hupd).
         reflexivity.
     + rewrite upd_Znth_diff_strong; [|exact Hposmap|exact Hneq].
       rewrite Znth_map by (rewrite make_fields_eq_length; exact Hjoldraw).
@@ -4742,9 +4739,9 @@ Proof.
       { intro He. inversion He. apply Hneq. apply Z2Nat.inj; lia. }
       rewrite (mutable_graph_update_vertex_address
                  g (InteriorVertexPos src pos) new g'
-                 (dst g' (src, Z.to_nat j)) Hloc' Hupd).
+                 (dst g' (src, Z.to_nat j)) Hloc Hupd).
       rewrite (mutable_graph_update_dst_neq
-                 g src pos new g' (src, Z.to_nat j) Hedge Hloc' Hupd).
+                 g src pos new g' (src, Z.to_nat j) Hedge Hloc Hupd).
       reflexivity.
 Qed.
 

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -22,7 +22,7 @@ Require Import CertiGraph.graph.graph_model.
 Require Export CertiGraph.graph.graph_gen.
 Import ListNotations.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 Require CertiGraph.CertiGC.gc_stack.
 Import Ctypes compspecs Cop2 Clight.
 
@@ -172,7 +172,7 @@ Record raw_vertex_block : Type :=
     (* what's up with this? why can raw_f be None at all? *)
   }.
 
-Local Close Scope Z_scope.
+#[local] Close Scope Z_scope.
 
 Lemma raw_fields_not_nil: forall rvb, raw_fields rvb <> nil.
 Proof.
@@ -196,7 +196,7 @@ Proof.
   - exists r, raw_fields0. split; reflexivity.
 Qed.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
 Record generation_info: Type :=
   {
@@ -224,7 +224,7 @@ Record graph_info : Type :=
 
 Definition LGraph := LabeledGraph VType EType raw_vertex_block nat graph_info.
 
-Local Coercion pg_lg: LabeledGraph >-> PreGraph.
+#[local] Coercion pg_lg: LabeledGraph >-> PreGraph.
 
 Record space: Type :=
   {
@@ -406,7 +406,7 @@ Proof.
   intros. unfold vertex_size. pose proof raw_fields_range (vlabel g v). lia.
 Qed.
 
-Local Close Scope Z_scope.
+#[local] Close Scope Z_scope.
 
 Lemma seq_Permutation_cons: forall s i n,
     i < n -> exists l, Permutation (seq s n) (s + i :: l).
@@ -447,7 +447,7 @@ Proof.
   apply seq_Permutation_cons. assumption.
 Qed.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
 Definition vertex_size_accum g gen (s: Z) (n: nat) := s + vertex_size g (gen, n).
 
@@ -498,7 +498,7 @@ Definition generation_space_compatible (g: LGraph)
     previous_vertices_size g gen gi.(number_of_vertices) = sp.(used_space)
   end.
 
-Local Close Scope Z_scope.
+#[local] Close Scope Z_scope.
 
 Definition graph_heap_compatible (g: LGraph) (h: part_heap): Prop :=
   Forall (generation_space_compatible g)
@@ -946,7 +946,7 @@ Definition make_header (g: LGraph) (v: VType): Z:=
                             vb.(raw_tag) + (Z.shiftl vb.(raw_color) 8) +
                             (Z.shiftl (Zlength vb.(raw_fields)) 10).
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
 Lemma make_header_mark_iff: forall g v,
     make_header g v = 0 <-> raw_mark (vlabel g v) = true.
@@ -2164,7 +2164,7 @@ Proof.
   apply H. rewrite <- (filter_proj_In_iff exterior_proj_vertex_spec). assumption.
 Qed.
 
-Local Close Scope Z_scope.
+#[local] Close Scope Z_scope.
 
 Definition update_vertex (from to: nat) (g: LGraph) (v: VType) : VType :=
   if Nat.eq_dec (vgeneration v) from
@@ -2312,7 +2312,7 @@ Proof.
   - assumption.
 Qed.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
 Lemma vo_lt_gs: forall g v pos,
     0 <= pos < Zlength (raw_fields (vlabel g v)) ->
@@ -2476,7 +2476,7 @@ Proof.
   rewrite isptr_offset_val. apply graph_has_gen_start_isptr, (proj1 (H _ H1 Heqb)).
 Qed.
 
-Local Close Scope Z_scope.
+#[local] Close Scope Z_scope.
 
 Lemma cvmgil_length: forall l to,
     to < length l -> length (copy_v_mod_gen_info_list l to) = length l.
@@ -3006,7 +3006,7 @@ Lemma lcv_outlier_compatible: forall g outlier v to,
     outlier_compatible (lgraph_copy_v g v to) outlier.
 Proof. intros. apply lmc_outlier_compatible, lacv_outlier_compatible; assumption. Qed.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
 Lemma lacv_unmarked_gen_size: forall g v to from,
     from <> to -> graph_has_gen g to ->
@@ -5203,7 +5203,7 @@ Proof.
   - cut (two_p (Z.of_nat gen) > 0). 1: lia. apply two_p_gt_ZERO. lia.
 Qed.
 
-Local Close Scope Z_scope.
+#[local] Close Scope Z_scope.
 
 Lemma lcv_gen_v_num_to: forall g v to,
     graph_has_gen g to -> gen_v_num g to <= gen_v_num (lgraph_copy_v g v to) to.
@@ -6080,7 +6080,7 @@ Definition new_gen_relation (gen: nat) (g1 g2: LGraph): Prop :=
 Definition garbage_collect_condition (g: LGraph) (h : part_heap) : Prop :=
   graph_unmarked g /\ no_dangling_dst g /\ ti_size_spec h.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
 Lemma upd_heap_Zlength: forall (hp : part_heap) (sp : space) (i : Z),
     0 <= i < MAX_SPACES -> Zlength (upd_Znth i (spaces hp) sp) = MAX_SPACES.

--- a/CertiGC/GCGraph.v
+++ b/CertiGC/GCGraph.v
@@ -6131,6 +6131,16 @@ Definition new_gen_relation (gen: nat) (g1 g2: LGraph): Prop :=
 Definition garbage_collect_condition (g: LGraph) (h : part_heap) : Prop :=
   graph_unmarked g /\ no_dangling_dst g /\ ti_size_spec h.
 
+Definition full_gc
+    (g : LGraph)
+    (h : part_heap)
+    (rootpairs : list rootpair)
+    (roots : roots_t)
+    (outlier : outlier_t) : Prop :=
+  super_compatible g h rootpairs roots outlier /\
+  garbage_collect_condition g h /\
+  safe_to_copy_heap g h.
+
 #[local] Open Scope Z_scope.
 
 Definition add_new_space (hp: part_heap) (sp: space) i (Hs: 0 <= i < MAX_SPACES): part_heap :=

--- a/CertiGC/GC_Source/gc_stack.h
+++ b/CertiGC/GC_Source/gc_stack.h
@@ -188,7 +188,7 @@ value* extract_answer(struct thread_info *ti);
 void* export_heap(struct thread_info *ti, value root);
 
 /* mutable write barrier */
-void certicoq_modify(struct thread_info *ti, value *p_cell, value p_val);
+void mutable_update(struct thread_info *ti, value *p_cell, value p_val);
 
 void print_heapsize(struct thread_info *ti);
 

--- a/CertiGC/assumptions.v
+++ b/CertiGC/assumptions.v
@@ -1,4 +1,4 @@
-From CertiGraph.CertiGC Require Import 
+From CertiGraph.CertiGC Require Import
   verif_garbage_collect
   verif_create_heap
   verif_create_space
@@ -8,64 +8,52 @@ From CertiGraph.CertiGC Require Import
   verif_forward_roots
   verif_forward
   verif_make_tinfo
-   gc_correct.
+  verif_conversion
+  verif_is_ptr
+  verif_resume
+  verif_mutable_update
+  verif_Is_from
+  spatial_gcgraph
+  gc_correct.
 
-Definition collection := 
-(body_garbage_collect,
- body_create_heap,
- body_create_space,
- body_do_generation,
- body_do_scan,
- body_forward_remset,
- body_forward_roots,
- body_forward,
- body_make_tinfo,
- garbage_collect_spec_preconditions_imply_isomorphism).
- 
+(** VST proofs of the sixteen verified internal Clight function bodies. *)
+Definition verified_bodies :=
+  (body_garbage_collect,
+   body_create_heap,
+   body_create_space,
+   body_do_generation,
+   body_do_scan,
+   body_forward_remset,
+   body_forward_roots,
+   body_forward,
+   body_make_tinfo,
+   body_int_to_int_or_ptr,
+   body_int_or_ptr_to_int,
+   body_ptr_to_int_or_ptr,
+   body_int_or_ptr_to_ptr,
+   body_is_ptr,
+   body_resume,
+   body_mutable_update).
 
-Print Assumptions collection.
+(** Model-level and spatial correctness endpoints used when auditing the
+    collector and the mutable-update boundary. *)
+Definition model_endpoints :=
+  (garbage_collect_spec_preconditions_imply_isomorphism,
+   mutable_graph_update_sound,
+   mutable_update_garbage_collect_model_preconditions,
+   int_mutable_update_restores_garbage_collect_model_preconditions,
+   remset_rep_mutable_graph_update).
 
-(* Print Assumptions produces the following list:
- Part 1, standard extensionality axioms
+(** These results establish [extcall_properties] for legacy external-call
+    semantics.  They are not [semax_body] proofs of the corresponding
+    internal Clight functions in [Gprog]. *)
+Definition legacy_extcall_endpoints :=
+  (Is_from_extcall, test_iop__extcall).
 
-ClassicalDedekindReals.sig_not_dec :
-  forall P : Prop, {~ ~ P} + {~ P} 
-ClassicalDedekindReals.sig_forall_dec :
-  forall P : nat -> Prop,
-  (forall n : nat, {P n} + {~ P n}) ->
-  {n : nat | ~ P n} + {forall n : nat, P n}
-Axioms.prop_ext : ClassicalFacts.prop_extensionality
-FunctionalExtensionality.functional_extensionality_dep :
-  forall (A : Type) (B : A -> Type)
-    (f g : forall x : A, B x),
-  (forall x : A, f x = g x) -> f = g
-Eqdep.Eq_rect_eq.eq_rect_eq :
-  forall (U : Type) (p : U) (Q : U -> Type) 
-    (x : Q p) (h : p = p),
-  x = eq_rect p Q x p h
-Classical_Prop.classic : forall P : Prop, P \/ ~ P
-Ensembles.Extensionality_Ensembles :
-  forall (U : Type) (A B : Ensembles.Ensemble U),
-  Ensembles.Same_set A B -> A = B
+(** In particular, [Gprog] currently has no [body_test_int_or_ptr],
+    [body_Is_from], or [body_abort_with] theorem.  The legacy extcall results
+    above do not close those internal-function body-proof obligations. *)
+Definition audit_collection :=
+  (verified_bodies, model_endpoints, legacy_extcall_endpoints).
 
-Part 2, axiomatization of a malloc/free system, for use when the g.c.
-  needs to allocate a new generation from the operating system's virtual memory.
-
-library.mem_mgr : SeparationLogic.globals -> mpred.mpred
-library.malloc_token_valid_pointer :
-  forall (cs : compspecs.compspecs) (sh : shares.share)
-    (t : Ctypes.type) (p : Values.val),
-  BinInt.Z.le (expr.sizeof t) BinNums.Z0 ->
-  seplog.derives (library.malloc_token sh t p)
-    (expr.valid_pointer p)
-library.malloc_token_local_facts :
-  forall (cs : compspecs.compspecs) (sh : shares.share)
-    (t : Ctypes.type) (p : Values.val),
-  seplog.derives (library.malloc_token sh t p)
-    (seplog.prop
-       (field_at.malloc_compatible (expr.sizeof t) p))
-library.malloc_token :
-  compspecs.compspecs ->
-  shares.share -> Ctypes.type -> Values.val -> mpred.mpred
-
-*)
+Print Assumptions audit_collection.

--- a/CertiGC/assumptions.v
+++ b/CertiGC/assumptions.v
@@ -40,8 +40,7 @@ Definition verified_bodies :=
 Definition model_endpoints :=
   (garbage_collect_spec_preconditions_imply_isomorphism,
    mutable_graph_update_sound,
-   mutable_update_garbage_collect_model_preconditions,
-   int_mutable_update_restores_garbage_collect_model_preconditions,
+   mutable_update_gc_ready,
    remset_rep_mutable_graph_update).
 
 (** These results establish [extcall_properties] for legacy external-call

--- a/CertiGC/forward_lemmas.v
+++ b/CertiGC/forward_lemmas.v
@@ -94,15 +94,6 @@ Proof.
     + rewrite get_edges_In_iff, <- Heqf. now apply Znth_In; rewrite make_fields_eq_length.
 Qed.
 
-Lemma root_valid_int_or_ptr: forall g (roots: roots_t) root outlier,
-    In root roots ->
-    roots_compatible g outlier roots ->
-    graph_rep g * outlier_rep outlier |-- !! (valid_int_or_ptr (exterior2val g root)).
-Proof.
-  intros. apply extr_valid_int_or_ptr.
-  rewrite roots_iff_exterior_compatible, Forall_forall in H0. now apply H0.
-Qed.
-
 Lemma sapi_ptr_val: forall p m n,
     isptr p -> Int.min_signed <= n <= Int.max_signed ->
     (force_val
@@ -112,6 +103,21 @@ Proof.
   intros. rewrite sem_add_pi_ptr_special; [| easy | | easy].
   - simpl. rewrite offset_offset_val. f_equal. fold WORD_SIZE; rep_lia.
   - rewrite isptr_offset_val. assumption.
+Qed.
+
+Lemma sem_sub_pi_available_space_minus: forall s,
+    isptr (space_start s) ->
+    force_val
+      (sem_sub_pi int_or_ptr_type Signed
+        (offset_val (WORD_SIZE * available_space s) (space_start s))
+        (Vint (Int.repr 1))) =
+    offset_val (WORD_SIZE * (available_space s - 1)) (space_start s).
+Proof.
+  intros s Hptr. destruct (space_start s); try contradiction. simpl.
+  rewrite ptrofs_of_ints_unfold, ptrofs_mul_repr, Ptrofs.add_commut,
+    Ptrofs.sub_add_l.
+  rewrite ptrofs_sub_repr, Int.signed_repr by rep_lia.
+  rewrite Ptrofs.add_commut. do 3 f_equal. unfold WORD_SIZE. lia.
 Qed.
 
 Lemma sapil_ptr_val: forall p m n,

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -131,7 +131,7 @@ Proof.
     destruct H0 as [x [? _]]; now subst v.
 Qed.
 
-Lemma edge_label_same_resset: forall g gen,
+Lemma edge_label_same_reset: forall g gen,
     edge_label_same g -> edge_label_same (reset_graph gen g).
 Proof.
   unfold edge_label_same. intros g gen He e. simpl.
@@ -144,7 +144,7 @@ Proof.
   intros. destruct H as [? [? [? ?]]].
   now split; [|split; [|split]];
     [apply vertex_valid_reset | apply edge_valid_reset |
-      apply src_edge_reset | apply edge_label_same_resset ].
+      apply src_edge_reset | apply edge_label_same_reset ].
 Qed.
 
 (** Quasi-Isomorphism to Full-Isomorphism *)
@@ -9184,39 +9184,6 @@ Proof.
             g1 g_scan); eauto.
 Qed.
 
-Lemma no_dangling_dst_reset_from_no_edge2gen:
-  forall g gen,
-    no_dangling_dst g ->
-    no_edge2gen g gen ->
-    no_dangling_dst (reset_graph gen g).
-Proof.
-  unfold no_dangling_dst.
-  intros g gen Hndd Hnoedge v Hv e Hin.
-  rewrite graph_has_v_reset in Hv.
-  rewrite get_edges_reset in Hin.
-  simpl.
-  rewrite remove_ve_dst_unchanged.
-  rewrite graph_has_v_reset.
-  split.
-  - eapply Hndd; eauto.
-    tauto.
-  - intro Hdst_gen.
-    destruct Hv as [Hv Hsrc_ne].
-    pose proof (get_edges_fst g v e Hin) as Hfst.
-    assert (He: graph_has_e g e). {
-      unfold graph_has_e.
-      rewrite Hfst.
-      split; assumption.
-    }
-    destruct e as [[src_gen src_idx] e_idx].
-    destruct v as [v_gen v_idx].
-    simpl in *.
-    inversion Hfst; subst src_gen src_idx.
-    specialize (Hnoedge v_gen (not_eq_sym Hsrc_ne) v_idx e_idx He).
-    symmetry in Hdst_gen.
-    contradiction.
-Qed.
-
 Lemma do_generation_relation_no_dangling_dst_noedge_state:
   forall g h rh rmst g_rem h_rem rh' rmst' g' h' roots roots' i,
     sound_gc_graph g ->
@@ -9260,7 +9227,7 @@ Proof.
               i (S i) roots roots' g h rh rmst
               g_rem h_rem rh' rmst' g1 g2); eauto.
   }
-  subst g'. eapply no_dangling_dst_reset_from_no_edge2gen; eauto.
+  subst g'. eapply no_dangling_dst_reset; eauto.
 Qed.
 
 Lemma do_generation_relation_no_unrecorded_backward_edge_reset_state:

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -43,25 +43,25 @@ Definition sound_gc_graph (g: LGraph): Prop :=
 
 (** Reset is sound *)
 
-Lemma fold_left_remove_edge_vvalid: forall (g: PreGraph VType EType) l v,
+#[local] Lemma fold_left_remove_edge_vvalid: forall (g: PreGraph VType EType) l v,
     vvalid (fold_left pregraph_remove_edge l g) v <-> vvalid g v.
 Proof. now intros; revert g; induction l; [|intros; simpl; rewrite IHl]. Qed.
 
-Lemma lrvae_vvalid: forall g v1 v2,
+#[local] Lemma lrvae_vvalid: forall g v1 v2,
     vvalid (lgraph_remove_vertex_and_edges g v1) v2 <-> vvalid g v2 /\ v1 <> v2.
 Proof.
   intros. simpl. unfold pregraph_remove_vertex_and_edges.
   rewrite fold_left_remove_edge_vvalid, remove_vertex_vvalid. intuition.
 Qed.
 
-Lemma fold_left_lrvae_vvalid: forall g l v,
+#[local] Lemma fold_left_lrvae_vvalid: forall g l v,
     vvalid (fold_left lgraph_remove_vertex_and_edges l g) v <->
     vvalid g v /\ ~ In v l.
 Proof.
   intros; revert g v; induction l; intros; simpl; [|rewrite IHl, lrvae_vvalid]; intuition.
 Qed.
 
-Lemma vertex_valid_reset: forall g gen,
+#[local] Lemma vertex_valid_reset: forall g gen,
     vertex_valid g -> vertex_valid (reset_graph gen g).
 Proof.
   intros. unfold vertex_valid in *. intros. simpl. rewrite graph_has_v_reset.
@@ -71,7 +71,7 @@ Proof.
     rewrite nat_inc_list_In_iff. destruct H1. now red in H1.   - apply list_in_map_inv in H0. destruct H0 as [? [? _]]; now subst v.
 Qed.
 
-Lemma remove_ve_src_unchanged: forall g gen e,
+#[local] Lemma remove_ve_src_unchanged: forall g gen e,
     src (remove_nth_gen_ve g gen) e = src g e.
 Proof.
   intros. unfold remove_nth_gen_ve.
@@ -85,20 +85,20 @@ Proof.
   now induction l; intros; simpl; [|rewrite IHl].
 Qed.
 
-Lemma src_edge_reset: forall (g: LGraph) gen,
+#[local] Lemma src_edge_reset: forall (g: LGraph) gen,
     src_edge g -> src_edge (reset_graph gen g).
 Proof.
   intros. unfold src_edge in *. intros.
   simpl. rewrite remove_ve_src_unchanged. apply H.
 Qed.
 
-Lemma fold_left_remove_edge_evalid: forall (g: PreGraph VType EType) l e,
+#[local] Lemma fold_left_remove_edge_evalid: forall (g: PreGraph VType EType) l e,
     evalid (fold_left pregraph_remove_edge l g) e <-> evalid g e /\ ~ In e l.
 Proof.
   intros; revert g; induction l; intros; simpl; [|rewrite IHl, remove_edge_evalid]; intuition.
 Qed.
 
-Lemma lrvae_evalid: forall g v e,
+#[local] Lemma lrvae_evalid: forall g v e,
     evalid (lgraph_remove_vertex_and_edges g v) e <->
     evalid g e /\ ~ In e (get_edges g v).
 Proof.
@@ -106,7 +106,7 @@ Proof.
   rewrite fold_left_remove_edge_evalid. intuition.
 Qed.
 
-Lemma fold_left_lrvae_evalid: forall g l e,
+#[local] Lemma fold_left_lrvae_evalid: forall g l e,
     evalid (fold_left lgraph_remove_vertex_and_edges l g) e <->
     evalid g e /\ forall v, In v l -> ~ In e (get_edges g v).
 Proof.
@@ -117,7 +117,7 @@ Proof.
   - apply (H1 v); intuition.
 Qed.
 
-Lemma edge_valid_reset: forall g gen, edge_valid g -> edge_valid (reset_graph gen g).
+#[local] Lemma edge_valid_reset: forall g gen, edge_valid g -> edge_valid (reset_graph gen g).
 Proof.
   intros. unfold edge_valid in *. intros. rewrite graph_has_e_reset. simpl.
   unfold remove_nth_gen_ve. rewrite fold_left_lrvae_evalid, H. intuition.
@@ -131,7 +131,7 @@ Proof.
     destruct H0 as [x [? _]]; now subst v.
 Qed.
 
-Lemma edge_label_same_reset: forall g gen,
+#[local] Lemma edge_label_same_reset: forall g gen,
     edge_label_same g -> edge_label_same (reset_graph gen g).
 Proof.
   unfold edge_label_same. intros g gen He e. simpl.
@@ -156,7 +156,7 @@ Definition exterior_map (vmap: VType -> VType) (r: exterior_t): exterior_t :=
   | ExteriorVertex r => ExteriorVertex (vmap r)
   end.
 
-Lemma bijective_exterior_map: forall vmap1 vmap2,
+#[local] Lemma bijective_exterior_map: forall vmap1 vmap2,
     bijective vmap1 vmap2 -> bijective (exterior_map vmap1) (exterior_map vmap2).
 Proof.
   intros. destruct H. split; intros.
@@ -181,7 +181,7 @@ Proof.
   clear. induction roots; simpl; auto. rewrite <- IHroots. f_equal. destruct a; auto.
 Qed.
 
-Lemma map_exterior_map_bijective:
+#[local] Lemma map_exterior_map_bijective:
   forall (roots1 roots2 : roots_t) (vmap12 vmap21 : VType -> VType),
     roots2 = map (exterior_map vmap12) roots1 ->
     bijective vmap12 vmap21 -> roots1 = map (exterior_map vmap21) roots2.
@@ -212,7 +212,7 @@ Definition gen_edge_pair_list
            (g: LGraph) (l: list (VType * VType)): list (EType * EType) :=
   concat (map (gen_single_edge_pair_list g) l).
 
-Lemma get_edges_snd_NoDup: forall g v, NoDup (map snd (get_edges g v)).
+#[local] Lemma get_edges_snd_NoDup: forall g v, NoDup (map snd (get_edges g v)).
 Proof.
   intros. unfold get_edges. unfold make_fields.
   remember (raw_fields (vlabel g v)). remember O.
@@ -227,7 +227,7 @@ Proof.
   apply Nat2Z.inj_lt; assumption.
 Qed.
 
-Lemma get_edges_map_map: forall g v,
+#[local] Lemma get_edges_map_map: forall g v,
     get_edges g v = map (fun idx => (v, idx)) (map snd (get_edges g v)).
 Proof.
   intros. rewrite map_map. unfold get_edges, make_fields.
@@ -236,13 +236,13 @@ Proof.
     simpl; rewrite <- IHl; auto.
 Qed.
 
-Lemma get_edges_NoDup: forall g v, NoDup (get_edges g v).
+#[local] Lemma get_edges_NoDup: forall g v, NoDup (get_edges g v).
 Proof.
   intros. rewrite get_edges_map_map, <- combine_repeat_eq_map;
             apply NoDup_combine_r, get_edges_snd_NoDup.
 Qed.
 
-Lemma gsepl_DoubleNoDup: forall (v1 v2 : VType) (g : LGraph),
+#[local] Lemma gsepl_DoubleNoDup: forall (v1 v2 : VType) (g : LGraph),
     v1 <> v2 -> DoubleNoDup (gen_single_edge_pair_list g (v1, v2)).
 Proof.
   intros. simpl. pose proof (get_edges_NoDup g v1). remember (get_edges g v1).
@@ -268,7 +268,7 @@ Proof.
       apply NoDup_cons_2 in H0. contradiction.
 Qed.
 
-Lemma gsepl_InEither: forall x g a,
+#[local] Lemma gsepl_InEither: forall x g a,
     InEither x (gen_single_edge_pair_list g a) -> IsEither (fst x) a.
 Proof.
   intros. destruct a as [v1 v2]. red. simpl.
@@ -283,7 +283,7 @@ Proof.
   - apply IHl; auto.
 Qed.
 
-Lemma gepl_InEither: forall x g l,
+#[local] Lemma gepl_InEither: forall x g l,
     InEither x (gen_edge_pair_list g l) -> InEither (fst x) l.
 Proof.
   intros. induction l; simpl in *; unfold gen_edge_pair_list in H; simpl in H.
@@ -292,7 +292,7 @@ Proof.
   destruct H; [left; eapply gsepl_InEither; eauto | right; apply IHl; assumption].
 Qed.
 
-Lemma gepl_DoubleNoDup:
+#[local] Lemma gepl_DoubleNoDup:
   forall g l, DoubleNoDup l -> DoubleNoDup (gen_edge_pair_list g l).
 Proof.
   intros g l. revert g. induction l; intros.
@@ -305,7 +305,7 @@ Proof.
   simpl in H3. destruct H3; rewrite H3 in H4; contradiction.
 Qed.
 
-Lemma get_edges_inv: forall g v e,
+#[local] Lemma get_edges_inv: forall g v e,
     In e (get_edges g v) <->
     exists idx, e = (v, idx) /\ In idx (map snd (get_edges g v)).
 Proof.
@@ -315,11 +315,11 @@ Proof.
   - destruct H as [? [? ?]]. inversion H. subst. rewrite get_edges_In. assumption.
 Qed.
 
-Lemma In_snd_get_edges: forall g v idx,
+#[local] Lemma In_snd_get_edges: forall g v idx,
     In idx (map snd (get_edges g v)) -> In (v, idx) (get_edges g v).
 Proof. intros. rewrite get_edges_inv. exists idx. split; auto. Qed.
 
-Lemma vlabel_get_edges_snd: forall v1 v2 (g1 g2: LGraph),
+#[local] Lemma vlabel_get_edges_snd: forall v1 v2 (g1 g2: LGraph),
     vlabel g1 v1 = vlabel g2 v2 ->
     map snd (get_edges g1 v1) = map snd (get_edges g2 v2).
 Proof.
@@ -330,7 +330,7 @@ Proof.
   now destruct a; rewrite filter_proj_cons; simpl; rewrite IHl.
 Qed.
 
-Lemma gsepl_key: forall e g v,
+#[local] Lemma gsepl_key: forall e g v,
     In e (get_edges g (fst e)) ->
     In (e, (v, snd e)) (gen_single_edge_pair_list g (fst e, v)).
 Proof.
@@ -338,7 +338,7 @@ Proof.
   induction l; simpl in *; auto. now destruct H; [left; subst | right; apply IHl].
 Qed.
 
-Lemma gsepl_value: forall (e: EType) k (g1 g2: LGraph),
+#[local] Lemma gsepl_value: forall (e: EType) k (g1 g2: LGraph),
     In e (get_edges g2 (fst e)) -> vlabel g1 k = vlabel g2 (fst e) ->
     In (k, snd e, e) (gen_single_edge_pair_list g1 (k, fst e)).
 Proof.
@@ -349,7 +349,7 @@ Proof.
   now destruct H; [left; subst a | right; apply IHl].
 Qed.
 
-Lemma gepl_key: forall (g : LGraph) (vpl : list (VType * VType)) (e : EType) v,
+#[local] Lemma gepl_key: forall (g : LGraph) (vpl : list (VType * VType)) (e : EType) v,
     In e (get_edges g (fst e)) -> In (fst e, v) vpl ->
     In (e, (v, snd e)) (gen_edge_pair_list g vpl).
 Proof.
@@ -358,7 +358,7 @@ Proof.
   destruct H0; [left; subst a; apply gsepl_key | right; apply IHvpl]; auto.
 Qed.
 
-Lemma gepl_value: forall (e: EType) k (g1 g2: LGraph) vpl,
+#[local] Lemma gepl_value: forall (e: EType) k (g1 g2: LGraph) vpl,
     In e (get_edges g2 (fst e)) -> In (k, fst e) vpl ->
     vlabel g1 k = vlabel g2 (fst e) -> In (k, snd e, e) (gen_edge_pair_list g1 vpl).
 Proof.
@@ -373,7 +373,7 @@ Definition GenNoDup (l: list VType) (gen: nat): Prop :=
 Definition PairGenNoDup (l: list (VType * VType)) (from to: nat): Prop :=
   let (left_l, right_l) := split l in GenNoDup left_l from /\ GenNoDup right_l to.
 
-Lemma PairGenNoDup_DoubleNoDup: forall l from to,
+#[local] Lemma PairGenNoDup_DoubleNoDup: forall l from to,
     from <> to -> PairGenNoDup l from to -> DoubleNoDup l.
 Proof.
   intros. red in H0 |-* . destruct (split l) as [l1 l2]. destruct H0 as [[? ?] [? ?]].
@@ -499,7 +499,7 @@ Proof.
   destruct (lt_dec idx (number_of_vertices (nth_gen g gen))); [left | right]; auto.
 Defined.
 
-Lemma graph_has_v_dec: forall (g: LGraph) (v: VType),
+#[local] Lemma graph_has_v_dec: forall (g: LGraph) (v: VType),
     {graph_has_v g v} + {~ graph_has_v g v}.
 Proof.
   intros. destruct v as [vgen vidx]. destruct (graph_has_gen_dec g vgen).
@@ -508,7 +508,7 @@ Proof.
   - right; intro; apply n; destruct H; auto.
 Defined.
 
-Lemma vvalid_lcm: forall g v, vertex_valid g -> vvalid g v \/ ~ vvalid g v.
+#[local] Lemma vvalid_lcm: forall g v, vertex_valid g -> vvalid g v \/ ~ vvalid g v.
 Proof. intros. red in H. rewrite H. destruct (graph_has_v_dec g v); auto. Qed.
 
 Lemma reachable_map_reachable_sub_edges:
@@ -991,7 +991,7 @@ Proof.
       intro Hedge_in. apply Hnin. apply gepl_InEither in Hedge_in. assumption.
 Qed.
 
-Lemma new_gen_heap_new_gen_relation: forall g1 h1 g2 h2 gen,
+#[local] Lemma new_gen_heap_new_gen_relation: forall g1 h1 g2 h2 gen,
     new_gen_heap_relation gen g1 h1 g2 h2 -> new_gen_relation gen g1 g2.
 Proof.
   intros g1 h1 g2 h2 gen Hrel.
@@ -1002,7 +1002,7 @@ Proof.
     exists gi. split; assumption.
 Qed.
 
-Lemma ngr_vertex_valid: forall g1 g2 gen,
+#[local] Lemma ngr_vertex_valid: forall g1 g2 gen,
     vertex_valid g1 -> new_gen_relation gen g1 g2 -> vertex_valid g2.
 Proof.
   intros. red in H0. destruct (graph_has_gen_dec g1 gen).
@@ -1011,7 +1011,7 @@ Proof.
     rewrite H. now split; intros; [apply ang_graph_has_v | apply ang_graph_has_v_inv in H1].
 Qed.
 
-Lemma ngr_edge_valid: forall g1 g2 gen,
+#[local] Lemma ngr_edge_valid: forall g1 g2 gen,
     edge_valid g1 -> new_gen_relation gen g1 g2 -> edge_valid g2.
 Proof.
   intros. red in H0. destruct (graph_has_gen_dec g1 gen).
@@ -1021,7 +1021,7 @@ Proof.
     [apply ang_graph_has_v | | apply ang_graph_has_v_inv in H1|].
 Qed.
 
-Lemma ngr_src_edge: forall (g1 g2: LGraph) gen,
+#[local] Lemma ngr_src_edge: forall (g1 g2: LGraph) gen,
     src_edge g1 -> new_gen_relation gen g1 g2 -> src_edge g2.
 Proof.
   intros. red in H0. destruct (graph_has_gen_dec g1 gen).
@@ -1029,7 +1029,7 @@ Proof.
   - destruct H0 as [gen_i [? ?]]. subst g2. now unfold src_edge in *.
 Qed.
 
-Lemma ngr_edge_label_same: forall (g1 g2: LGraph) gen,
+#[local] Lemma ngr_edge_label_same: forall (g1 g2: LGraph) gen,
     edge_label_same g1 -> new_gen_relation gen g1 g2 -> edge_label_same g2.
 Proof.
   intros. red in H0. destruct (graph_has_gen_dec g1 gen).
@@ -1047,7 +1047,7 @@ Proof.
   - eapply ngr_edge_label_same; eauto.
 Qed.
 
-Lemma cvae_vvalid_iff: forall g v' l v0,
+#[local] Lemma cvae_vvalid_iff: forall g v' l v0,
     vvalid (fold_left (copy_v_add_edge v') l g) v0 <-> vvalid g v0.
 Proof.
   intros. split; intro.
@@ -1059,14 +1059,14 @@ Proof.
         reflexivity; assumption.
 Qed.
 
-Lemma pcv_vvalid_iff: forall g v v' new,
+#[local] Lemma pcv_vvalid_iff: forall g v v' new,
     vvalid (pregraph_copy_v g v new) v' <-> vvalid g v' \/ v' = new.
 Proof.
   intros. unfold pregraph_copy_v. rewrite cvae_vvalid_iff. simpl.
   unfold addValidFunc. reflexivity.
 Qed.
 
-Lemma lcv_graph_has_v_iff: forall (g : LGraph) (v : VType) (to : nat) (x : VType),
+#[local] Lemma lcv_graph_has_v_iff: forall (g : LGraph) (v : VType) (to : nat) (x : VType),
   graph_has_gen g to ->
   graph_has_v (lgraph_copy_v g v to) x <-> graph_has_v g x \/ x = new_copied_v g to.
 Proof.
@@ -1075,21 +1075,21 @@ Proof.
   - now destruct H0; [apply lcv_graph_has_v_old | subst x; apply lcv_graph_has_v_new].
 Qed.
 
-Lemma lcv_vertex_valid: forall g v to,
+#[local] Lemma lcv_vertex_valid: forall g v to,
     vertex_valid g -> graph_has_gen g to -> vertex_valid (lgraph_copy_v g v to).
 Proof.
   intros. unfold vertex_valid in *. intros. simpl.
   rewrite pcv_vvalid_iff, lcv_graph_has_v_iff; auto. now rewrite H.
 Qed.
 
-Lemma fr_O_vertex_valid: forall g g' from to p,
+#[local] Lemma fr_O_vertex_valid: forall g g' from to p,
     vertex_valid g -> graph_has_gen g to -> forward_relation from to 0 p g g' ->
     vertex_valid g'.
 Proof.
   intros. inversion H1; subst; try assumption; try now apply lcv_vertex_valid.
 Qed.
 
-Lemma lcv_get_edges_old: forall (g: LGraph) v v' to,
+#[local] Lemma lcv_get_edges_old: forall (g: LGraph) v v' to,
     graph_has_v g v' -> graph_has_gen g to ->
     get_edges (lgraph_copy_v g v to) v' = get_edges g v'.
 Proof.
@@ -1097,14 +1097,14 @@ Proof.
   now erewrite <- lcv_raw_fields by assumption.
 Qed.
 
-Lemma cvae_evalid_iff: forall g v l e,
+#[local] Lemma cvae_evalid_iff: forall g v l e,
     evalid (fold_left (copy_v_add_edge v) l g) e <-> evalid g e \/ In e (map fst l).
 Proof.
   intros. revert g. induction l; intros; simpl; [intuition|].
   rewrite IHl. unfold copy_v_add_edge. simpl. unfold addValidFunc. intuition.
 Qed.
 
-Lemma pcv_evalid_iff: forall g v new e,
+#[local] Lemma pcv_evalid_iff: forall g v new e,
     evalid (pregraph_copy_v g v new) e <->
     evalid g e \/ In e (map (fun x => (new, snd x)) (get_edges g v)).
 Proof.
@@ -1116,14 +1116,14 @@ Proof.
     apply Nat.min_id.
 Qed.
 
-Lemma lcv_lacv_get_edges: forall g v to new,
+#[local] Lemma lcv_lacv_get_edges: forall g v to new,
     get_edges (lgraph_copy_v g v to) new = get_edges (lgraph_add_copied_v g v to) new.
 Proof.
   intros. unfold lgraph_copy_v, get_edges, make_fields. rewrite <- lmc_raw_fields.
   reflexivity.
 Qed.
 
-Lemma lcv_edge_valid: forall g v to,
+#[local] Lemma lcv_edge_valid: forall g v to,
     edge_valid g -> graph_has_gen g to -> edge_valid (lgraph_copy_v g v to).
 Proof.
   intros. unfold edge_valid in *. intros. unfold graph_has_e in *. simpl.
@@ -1141,14 +1141,14 @@ Proof.
       assumption.
 Qed.
 
-Lemma fr_O_edge_valid: forall g1 g2 from to p,
+#[local] Lemma fr_O_edge_valid: forall g1 g2 from to p,
     edge_valid g1 -> graph_has_gen g1 to ->
     forward_relation from to O p g1 g2 -> edge_valid g2.
 Proof.
   intros. inversion H1; subst; try assumption; try now apply lcv_edge_valid.
 Qed.
 
-Lemma flcvae_src_old: forall g new (l: list (EType * VType)) e,
+#[local] Lemma flcvae_src_old: forall g new (l: list (EType * VType)) e,
     ~ In e (map fst l) -> src (fold_left (copy_v_add_edge new) l g) e = src g e.
 Proof.
   intros. revert g H. induction l; intros; simpl; trivial.
@@ -1158,7 +1158,7 @@ Proof.
   apply H. simpl. left; assumption.
 Qed.
 
-Lemma flcvae_src_new: forall g new (l: list (EType * VType)) e,
+#[local] Lemma flcvae_src_new: forall g new (l: list (EType * VType)) e,
     In e (map fst l) -> src (fold_left (copy_v_add_edge new) l g) e = new.
 Proof.
   intros. revert g. induction l. 1: simpl in H; exfalso; assumption.
@@ -1170,7 +1170,7 @@ Proof.
   - apply IHl; assumption.
 Qed.
 
-Lemma pcv_src_old: forall (g : LGraph) (old new : VType) (e : VType * nat),
+#[local] Lemma pcv_src_old: forall (g : LGraph) (old new : VType) (e : VType * nat),
     fst e <> new -> src (pregraph_copy_v g old new) e = src g e.
 Proof.
   intros. unfold pregraph_copy_v. rewrite flcvae_src_old. 1: now simpl.
@@ -1179,7 +1179,7 @@ Proof.
   - unfold EType. now rewrite length_combine, repeat_length, !length_map, Nat.min_id.
 Qed.
 
-Lemma pcv_src_new: forall (g : LGraph) (old new : VType) (n : nat),
+#[local] Lemma pcv_src_new: forall (g : LGraph) (old new : VType) (n : nat),
        In n (map snd (get_edges g old)) ->
        src (pregraph_copy_v g old new) (new, n) = new.
 Proof.
@@ -1193,7 +1193,7 @@ Proof.
   - unfold EType. now rewrite length_combine, repeat_length, !length_map, Nat.min_id.
 Qed.
 
-Lemma pcv_src_edge: forall (g: LGraph) v new,
+#[local] Lemma pcv_src_edge: forall (g: LGraph) v new,
     src_edge g -> src_edge (pregraph_copy_v g v new).
 Proof.
   intros. unfold src_edge in *. intros. unfold pregraph_copy_v.
@@ -1208,13 +1208,13 @@ Proof.
   - rewrite flcvae_src_old; auto. simpl. apply H.
 Qed.
 
-Lemma fr_O_src_edge: forall (g1 g2: LGraph) from to p,
+#[local] Lemma fr_O_src_edge: forall (g1 g2: LGraph) from to p,
     src_edge g1 -> forward_relation from to O p g1 g2 -> src_edge g2.
 Proof.
   intros. inversion H0; subst; try assumption; try (apply pcv_src_edge; assumption).
 Qed.
 
-Lemma fr_O_edge_label_same: forall (g1 g2: LGraph) from to p,
+#[local] Lemma fr_O_edge_label_same: forall (g1 g2: LGraph) from to p,
     edge_label_same g1 -> forward_relation from to O p g1 g2 -> edge_label_same g2.
 Proof. intros. inversion H0; subst; try assumption. Qed.
 
@@ -9790,7 +9790,7 @@ Proof.
       intros gen Hlt. lia.
 Qed.
 
-Lemma graph_has_e_iff_raw_internal:
+#[local] Lemma graph_has_e_iff_raw_internal:
   forall g v n,
     graph_has_v g v ->
     (graph_has_e g (v, n) <->

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -9863,3 +9863,500 @@ Proof.
   - eapply remset_compatible_remset_heap_covers_graph; eauto.
   - exact Hrel.
 Qed.
+
+Lemma mutable_update_remset_heap_and_heap_compatible:
+  forall (g: LGraph) (h: part_heap) (rh: remset_heap)
+         (x: val) (item: remset_space_item),
+    graph_heap_compatible g h ->
+    used_space (nth_space h O) < available_space (nth_space h O) ->
+    remset_heap_and_heap_compatible rh h ->
+    remset_heap_and_heap_compatible
+      (if isptr_dec x then upd_remset_heap item rh O else rh)
+      (if isptr_dec x then incr_remset_heap h 0 else h).
+Proof.
+  intros g h rh x item Hghc Hcapacity Hrhhc.
+  destruct (isptr_dec x).
+  - eapply upd_incr_remset_heap_rhhc; eauto.
+    apply graph_has_gen_O.
+  - exact Hrhhc.
+Qed.
+
+Lemma mutable_update_remset_generation_compatible:
+  forall (x: val) (it: interior_t) (rh: remset_heap) (rmst: remset),
+    0 <= Z.of_nat O < Zlength rh ->
+    remset_generation_compatible O rmst rh ->
+    remset_generation_compatible O rmst
+      (if isptr_dec x
+       then upd_remset_heap (RemSetInterior it) rh O
+       else rh).
+Proof.
+  intros x it rh rmst Hrange Hcompatible.
+  destruct (isptr_dec x).
+  2: exact Hcompatible.
+  destruct Hcompatible as [Hext [Horder _]].
+  split.
+  - unfold remset_ext_space_compatible in *.
+    intros v addr Hin.
+    eapply nth_remset_space_upd_remset_heap_old; eauto.
+  - split.
+    + eapply upd_remset_heap_interior_generation_order; eauto.
+      intros. apply Nat.le_0_l.
+    + unfold remset_lower_generations_empty.
+      intros gen Hlt. lia.
+Qed.
+
+Lemma graph_has_e_iff_raw_internal:
+  forall g v n,
+    graph_has_v g v ->
+    (graph_has_e g (v, n) <->
+     0 <= Z.of_nat n < Zlength (raw_fields (vlabel g v)) /\
+     Znth (Z.of_nat n) (raw_fields (vlabel g v)) = RawInternal).
+Proof.
+  intros g v n Hv. split.
+  - intro He. pose proof (graph_has_e_Znth g v n He) as [Hrange Hfield].
+    split; [exact Hrange|].
+    rewrite (Znth_make_fields g v (Z.of_nat n) Hrange) in Hfield.
+    destruct (Znth (Z.of_nat n) (raw_fields (vlabel g v)));
+      inversion Hfield; reflexivity.
+  - intros [Hrange Hraw]. split; [exact Hv|].
+    rewrite get_edges_In_iff.
+    assert (Hfield: Znth (Z.of_nat n) (make_fields g v) = FieldEdge (v, n)).
+    { rewrite (Znth_make_fields g v (Z.of_nat n) Hrange), Hraw, Nat2Z.id.
+      reflexivity. }
+    rewrite <- Hfield. apply Znth_In.
+    rewrite make_fields_eq_length. exact Hrange.
+Qed.
+
+Lemma mutable_graph_update_graph_has_e_neq:
+  forall g src pos new g' e,
+    e <> (src, Z.to_nat pos) ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    (graph_has_e g' e <-> graph_has_e g e).
+Proof.
+  intros g src pos new g' [v n] Hneq Hloc Hupd.
+  destruct Hloc as [Hv [Hpos [Hmark Htag]]].
+  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
+    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
+  destruct (V_EqDec v src) as [Heq | Hne].
+  - hnf in Heq. subst v.
+    assert (Hidx: Z.of_nat n <> pos).
+    { intro Heq. apply Hneq. f_equal. rewrite <- Heq, Nat2Z.id. reflexivity. }
+    pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc' Hupd) as Hsrc.
+    unfold raw_vertex_field_update in Hsrc. destruct Hsrc as [Hfields _].
+    rewrite (graph_has_e_iff_raw_internal g' src n).
+    2: rewrite (mutable_graph_update_graph_has_v g (InteriorVertexPos src pos)
+                  new g' src Hloc' Hupd); exact Hv.
+    rewrite (graph_has_e_iff_raw_internal g src n Hv).
+    rewrite Hfields, Zlength_upd_Znth.
+    rewrite upd_Znth_diff_strong; [reflexivity|exact Hpos|exact Hidx].
+  - unfold graph_has_e; simpl fst.
+    rewrite (mutable_graph_update_graph_has_v
+               g (InteriorVertexPos src pos) new g' v Hloc' Hupd).
+    unfold get_edges, make_fields.
+    rewrite (mutable_graph_update_vlabel_other
+               g src pos new g' v Hne Hloc' Hupd).
+    reflexivity.
+Qed.
+
+Lemma mutable_graph_update_graph_has_e_target:
+  forall g src pos new g',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    (graph_has_e g' (src, Z.to_nat pos) <->
+     exists dstv, new = ExteriorVertex dstv).
+Proof.
+  intros g src pos new g' Hloc Hupd.
+  destruct Hloc as [Hv [Hpos [Hmark Htag]]].
+  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
+    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
+  rewrite (graph_has_e_iff_raw_internal g' src (Z.to_nat pos)).
+  2: rewrite (mutable_graph_update_graph_has_v g (InteriorVertexPos src pos)
+                new g' src Hloc' Hupd); exact Hv.
+  rewrite Z2Nat.id by lia.
+  pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc' Hupd) as Hsrc.
+  unfold raw_vertex_field_update in Hsrc. destruct Hsrc as [Hfields _].
+  rewrite Hfields, Zlength_upd_Znth, upd_Znth_same by exact Hpos.
+  destruct new as [z | p | dstv]; simpl.
+  - split; [intros [_ H]; discriminate|intros [x H]; discriminate].
+  - split; [intros [_ H]; discriminate|intros [x H]; discriminate].
+  - split; [intros; now exists dstv|intros; split; [exact Hpos|reflexivity]].
+Qed.
+
+Lemma mutable_graph_update_evalid_neq:
+  forall g src pos new g' e,
+    e <> (src, Z.to_nat pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    (evalid g' e <-> evalid g e).
+Proof.
+  intros g src pos new g' e Hneq Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dstv].
+  - destruct Hupd as [rvb' [_ ->]].
+    simpl. unfold removeValidFunc. tauto.
+  - destruct Hupd as [rvb' [_ ->]].
+    simpl. unfold removeValidFunc. tauto.
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. reflexivity.
+    + destruct Hupd as [rvb' [_ ->]].
+      simpl. unfold addValidFunc. tauto.
+    + destruct Hupd as [rvb' [_ ->]].
+      simpl. unfold addValidFunc. tauto.
+Qed.
+
+Lemma mutable_graph_update_evalid_target:
+  forall g src pos new g',
+    sound_gc_graph g ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    (evalid g' (src, Z.to_nat pos) <->
+     exists dstv, new = ExteriorVertex dstv).
+Proof.
+  intros g src pos new g' Hsound Hloc Hupd.
+  destruct Hloc as [Hv [Hpos [Hmark Htag]]].
+  destruct Hsound as [Hvv [Hev [Hsrc Helabel]]].
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dstv].
+  - destruct Hupd as [rvb' [_ ->]].
+    simpl. unfold removeValidFunc. split; [tauto|intros [x H]; discriminate].
+  - destruct Hupd as [rvb' [_ ->]].
+    simpl. unfold removeValidFunc. split; [tauto|intros [x H]; discriminate].
+  - destruct (Znth pos (raw_fields (vlabel g src))) eqn:Hold.
+    + subst g'. split.
+      * intros. now exists dstv.
+      * intros _. apply Hev.
+        apply (proj2 (graph_has_e_iff_raw_internal g src (Z.to_nat pos) Hv)).
+        rewrite Z2Nat.id by lia. split; assumption.
+    + destruct Hupd as [rvb' [_ ->]].
+      split; [intros; now exists dstv|intros; apply add_edge_evalid].
+    + destruct Hupd as [rvb' [_ ->]].
+      split; [intros; now exists dstv|intros; apply add_edge_evalid].
+Qed.
+
+Lemma mutable_graph_update_vvalid:
+  forall g it new g' v,
+    mutable_graph_update g it new g' ->
+    (vvalid g' v <-> vvalid g v).
+Proof.
+  intros g [src pos] new g' v Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dstv].
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct Hupd as [rvb' [_ ->]]. reflexivity.
+  - destruct (Znth pos (raw_fields (vlabel g src))).
+    + subst g'. reflexivity.
+    + destruct Hupd as [rvb' [_ ->]]. reflexivity.
+    + destruct Hupd as [rvb' [_ ->]]. reflexivity.
+Qed.
+
+Lemma mutable_graph_update_src_edge:
+  forall (g: LGraph) it new g',
+    src_edge g -> mutable_graph_update g it new g' -> src_edge g'.
+Proof.
+  intros g [srcv pos] new g' Hsrc Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dstv].
+  - destruct Hupd as [rvb' [_ ->]]. exact Hsrc.
+  - destruct Hupd as [rvb' [_ ->]]. exact Hsrc.
+  - destruct (Znth pos (raw_fields (vlabel g srcv))).
+    + subst g'. exact Hsrc.
+    + destruct Hupd as [rvb' [_ ->]]. intros e.
+      simpl. unfold updateEdgeFunc. if_tac.
+      * hnf in H. subst e. reflexivity.
+      * apply Hsrc.
+    + destruct Hupd as [rvb' [_ ->]]. intros e.
+      simpl. unfold updateEdgeFunc. if_tac.
+      * hnf in H. subst e. reflexivity.
+      * apply Hsrc.
+Qed.
+
+Lemma mutable_graph_update_edge_label_same:
+  forall (g: LGraph) it new g',
+    edge_label_same g ->
+    mutable_graph_update g it new g' ->
+    edge_label_same g'.
+Proof.
+  intros g [srcv pos] new g' Hlabel Hupd.
+  unfold mutable_graph_update, internal_write_at in Hupd.
+  destruct new as [z | p | dstv].
+  - destruct Hupd as [rvb' [_ ->]]. exact Hlabel.
+  - destruct Hupd as [rvb' [_ ->]]. exact Hlabel.
+  - destruct (Znth pos (raw_fields (vlabel g srcv))).
+    + subst g'. exact Hlabel.
+    + destruct Hupd as [rvb' [_ ->]]. intros e.
+      simpl. unfold update_elabel. if_tac.
+      * hnf in H. subst e. reflexivity.
+      * apply Hlabel.
+    + destruct Hupd as [rvb' [_ ->]]. intros e.
+      simpl. unfold update_elabel. if_tac.
+      * hnf in H. subst e. reflexivity.
+      * apply Hlabel.
+Qed.
+
+Theorem mutable_graph_update_sound:
+  forall g src pos new g' outlier,
+    sound_gc_graph g ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    sound_gc_graph g'.
+Proof.
+  intros g src pos new g' outlier Hsound Hloc Hext Hupd.
+  destruct Hsound as [Hvv [Hev [Hsrc Hlabel]]].
+  assert (Hsound': sound_gc_graph g).
+  { exact (conj Hvv (conj Hev (conj Hsrc Hlabel))). }
+  split; [|split; [|split]].
+  - intro v.
+    rewrite (mutable_graph_update_vvalid g (InteriorVertexPos src pos) new g' v Hupd).
+    rewrite (mutable_graph_update_graph_has_v g (InteriorVertexPos src pos)
+               new g' v Hloc Hupd).
+    apply Hvv.
+  - intro e. destruct (E_EqDec e (src, Z.to_nat pos)) as [Heq | Hneq].
+    + hnf in Heq. subst e.
+      rewrite (mutable_graph_update_evalid_target g src pos new g' Hsound' Hloc Hupd).
+      rewrite (mutable_graph_update_graph_has_e_target g src pos new g' Hloc Hupd).
+      reflexivity.
+    + rewrite (mutable_graph_update_evalid_neq g src pos new g' e Hneq Hupd).
+      rewrite (mutable_graph_update_graph_has_e_neq g src pos new g' e Hneq Hloc Hupd).
+      apply Hev.
+  - eapply mutable_graph_update_src_edge; eassumption.
+  - eapply mutable_graph_update_edge_label_same; eassumption.
+Qed.
+
+Theorem mutable_graph_update_outlier_compatible:
+  forall g src pos new g' outlier,
+    outlier_compatible g outlier ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    outlier_compatible g' outlier.
+Proof.
+  intros g src pos new g' outlier Hold Hloc Hext Hupd.
+  intros v Hv' p Hin.
+  assert (Hv: graph_has_v g v).
+  { rewrite <- (mutable_graph_update_graph_has_v g (InteriorVertexPos src pos)
+                   new g' v Hloc Hupd). exact Hv'. }
+  destruct (V_EqDec v src) as [Heq | Hneq].
+  - hnf in Heq. subst v.
+    pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc Hupd) as Hsrc.
+    unfold raw_vertex_field_update in Hsrc. destruct Hsrc as [Hfields _].
+    rewrite <- (filter_proj_In_iff raw_proj_outlier_spec) in Hin.
+    rewrite Hfields in Hin. apply In_upd_Znth in Hin. destruct Hin as [Hnew | Holdin].
+    + destruct new as [z | q | dstv]; inversion Hnew; subst. exact Hext.
+    + apply (Hold src Hv).
+      rewrite <- (filter_proj_In_iff raw_proj_outlier_spec). exact Holdin.
+  - apply (Hold v Hv).
+    rewrite (mutable_graph_update_vlabel_other g src pos new g' v Hneq Hloc Hupd) in Hin.
+    exact Hin.
+Qed.
+
+Theorem mutable_graph_update_no_unrecorded_backward_edge:
+  forall g src pos new g' outlier rh,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    0 <= Z.of_nat O < Zlength rh ->
+    no_unrecorded_backward_edge g rh ->
+    no_unrecorded_backward_edge g'
+      (if isptr_dec (exterior2val g new)
+       then upd_remset_heap (RemSetInterior (InteriorVertexPos src pos)) rh O
+       else rh).
+Proof.
+  intros g src pos new g' outlier rh Hloc Hext Hupd Hrange Hold.
+  destruct Hloc as [Hv [Hpos [Hmark Htag]]].
+  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
+    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
+  unfold no_unrecorded_backward_edge, no_unrecorded_backward_edge_from in *.
+  intros e He' Hback.
+  destruct (E_EqDec e (src, Z.to_nat pos)) as [Heq | Hneq].
+  - hnf in Heq. subst e.
+    apply (mutable_graph_update_graph_has_e_target g src pos new g' Hloc' Hupd) in He'.
+    destruct He' as [dstv Hnew]. subst new.
+    destruct (isptr_dec (exterior2val g (ExteriorVertex dstv))) as [Hptr | Hnptr].
+    2: exfalso; apply Hnptr; simpl; apply graph_has_v_addr_isptr; exact Hext.
+    exists O. split.
+    + split; lia.
+    + unfold remset_heap_records_edge. simpl fst. simpl snd.
+      rewrite Z2Nat.id by lia.
+      apply nth_remset_space_upd_remset_heap_new. exact Hrange.
+  - assert (He: graph_has_e g e).
+    { apply (proj1 (mutable_graph_update_graph_has_e_neq
+                      g src pos new g' e Hneq Hloc' Hupd)). exact He'. }
+    pose proof (mutable_graph_update_dst_neq
+                  g src pos new g' e Hneq Hloc' Hupd) as Hdst.
+    rewrite Hdst in Hback.
+    specialize (Hold e He Hback).
+    destruct Hold as [k [Hbounds Hrecord]].
+    assert (Hbounds': (O <= k <= vgeneration (dst g' e))%nat).
+    { rewrite Hdst. exact Hbounds. }
+    exists k. split; [exact Hbounds'|].
+    destruct (isptr_dec (exterior2val g new)) as [Hptr | Hnptr].
+    + unfold remset_heap_records_edge in *.
+      eapply nth_remset_space_upd_remset_heap_old; eauto.
+    + exact Hrecord.
+Qed.
+
+Lemma mutable_graph_update_raw_mark_tag:
+  forall g src pos new g' v,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    raw_mark (vlabel g' v) = raw_mark (vlabel g v) /\
+    raw_tag (vlabel g' v) = raw_tag (vlabel g v).
+Proof.
+  intros g src pos new g' v Hloc Hupd.
+  destruct (V_EqDec v src) as [Heq | Hneq].
+  - hnf in Heq. subst v.
+    pose proof (mutable_graph_update_vlabel_src g src pos new g' Hloc Hupd) as Hsrc.
+    unfold raw_vertex_field_update in Hsrc. tauto.
+  - rewrite (mutable_graph_update_vlabel_other
+               g src pos new g' v Hneq Hloc Hupd).
+    split; reflexivity.
+Qed.
+
+Lemma mutable_graph_update_remset_ext_compatible:
+  forall g it new g' outlier re,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    remset_ext_compatible g outlier re ->
+    remset_ext_compatible g' outlier re.
+Proof.
+  intros g it new g' outlier re Hloc Hupd Hold.
+  destruct re as [p addr | v addr]; simpl in *.
+  - exact Hold.
+  - rewrite (mutable_graph_update_graph_has_v g it new g' v Hloc Hupd).
+    exact Hold.
+Qed.
+
+Lemma mutable_graph_update_remset_graph_outlier_compatible:
+  forall g it new g' outlier rmst,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    remset_graph_outlier_compatible g outlier rmst ->
+    remset_graph_outlier_compatible g' outlier rmst.
+Proof.
+  intros g it new g' outlier rmst Hloc Hupd Hold.
+  unfold remset_graph_outlier_compatible in *.
+  eapply Forall_impl; [|exact Hold].
+  intros re Hre.
+  eapply mutable_graph_update_remset_ext_compatible; eauto.
+Qed.
+
+Lemma mutable_graph_update_remset_item_compatible:
+  forall g src pos new g' from rmst item,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    remset_item_compatible g from rmst item ->
+    remset_item_compatible g' from rmst item.
+Proof.
+  intros g src pos new g' from rmst item Hloc Hupd Hold.
+  destruct item as [addr | [v n]]; simpl in *; [exact Hold|].
+  destruct Hold as [Hv [Hn Hscan]].
+  split.
+  - rewrite (mutable_graph_update_graph_has_v
+               g (InteriorVertexPos src pos) new g' v Hloc Hupd).
+    exact Hv.
+  - split.
+    + rewrite (mutable_graph_update_raw_fields_length
+                 g (InteriorVertexPos src pos) new g' v Hloc Hupd).
+      exact Hn.
+    + intros Hgen. specialize (Hscan Hgen). destruct Hscan as [Hmark Htag].
+      pose proof (mutable_graph_update_raw_mark_tag
+                    g src pos new g' v Hloc Hupd) as [Hmark' Htag'].
+      rewrite Hmark', Htag'. split; assumption.
+Qed.
+
+Lemma mutable_graph_update_new_remset_item_compatible:
+  forall g src pos new g' from rmst,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    remset_item_compatible g' from rmst
+      (RemSetInterior (InteriorVertexPos src pos)).
+Proof.
+  intros g src pos new g' from rmst Hloc Hupd.
+  destruct Hloc as [Hv [Hpos [Hmark Htag]]].
+  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
+    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
+  simpl. split.
+  - rewrite (mutable_graph_update_graph_has_v
+               g (InteriorVertexPos src pos) new g' src Hloc' Hupd).
+    exact Hv.
+  - split.
+    + rewrite (mutable_graph_update_raw_fields_length
+                 g (InteriorVertexPos src pos) new g' src Hloc' Hupd).
+      exact Hpos.
+    + intros _.
+      pose proof (mutable_graph_update_raw_mark_tag
+                    g src pos new g' src Hloc' Hupd) as [Hmark' Htag'].
+      rewrite Hmark', Htag'. split; assumption.
+Qed.
+
+Lemma mutable_graph_update_remset_space_compatible:
+  forall g src pos new g' from rmst items,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    remset_and_remset_space_compatible g from rmst items ->
+    remset_and_remset_space_compatible g' from rmst items.
+Proof.
+  intros g src pos new g' from rmst items Hloc Hupd Hold.
+  unfold remset_and_remset_space_compatible in *.
+  eapply Forall_impl; [|exact Hold].
+  intros item Hitem.
+  eapply mutable_graph_update_remset_item_compatible; eauto.
+Qed.
+
+Lemma mutable_update_remset_and_remset_heap_compatible:
+  forall g src pos new g' from rmst rh x,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    0 <= Z.of_nat O < Zlength rh ->
+    remset_and_remset_heap_compatible g from rmst rh ->
+    remset_and_remset_heap_compatible g' from rmst
+      (if isptr_dec x
+       then upd_remset_heap
+              (RemSetInterior (InteriorVertexPos src pos)) rh O
+       else rh).
+Proof.
+  intros g src pos new g' from rmst rh x Hloc Hupd Hrange Hold.
+  destruct (isptr_dec x) as [Hptr | Hnptr].
+  2: {
+    unfold remset_and_remset_heap_compatible in *.
+    eapply Forall_impl; [|exact Hold].
+    intros items Hitems.
+    eapply mutable_graph_update_remset_space_compatible; eauto.
+  }
+  unfold remset_and_remset_heap_compatible in *.
+  rewrite Forall_forall in *. intros items Hin.
+  apply upd_remset_heap_In in Hin. destruct Hin as [Hin | ->].
+  - eapply mutable_graph_update_remset_space_compatible; eauto.
+  - constructor.
+    + eapply mutable_graph_update_new_remset_item_compatible; eauto.
+    + eapply mutable_graph_update_remset_space_compatible; eauto.
+      apply Hold. apply Znth_In. exact Hrange.
+Qed.
+
+Theorem mutable_update_remset_compatible:
+  forall g src pos new g' outlier from rmst rh h,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    graph_heap_compatible g h ->
+    used_space (nth_space h O) < available_space (nth_space h O) ->
+    remset_compatible g outlier from rmst rh h ->
+    remset_compatible g' outlier from rmst
+      (if isptr_dec (exterior2val g new)
+       then upd_remset_heap
+              (RemSetInterior (InteriorVertexPos src pos)) rh O
+       else rh)
+      (if isptr_dec (exterior2val g new)
+       then incr_remset_heap h 0
+       else h).
+Proof.
+  intros g src pos new g' outlier from rmst rh h
+         Hloc Hupd Hghc Hcapacity [Hrgoc [Hrrhc Hrhhc]].
+  assert (Hrange: 0 <= Z.of_nat O < Zlength rh).
+  { eapply gen_range_remset_heap; eauto. apply graph_has_gen_O. }
+  split.
+  - eapply mutable_graph_update_remset_graph_outlier_compatible; eauto.
+  - split.
+    + eapply mutable_update_remset_and_remset_heap_compatible; eauto.
+    + eapply mutable_update_remset_heap_and_heap_compatible; eauto.
+Qed.

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -2308,8 +2308,6 @@ Proof.
          Hdd_l Hiso Hpartial_new.
   pose proof Hsound_base as Hsound_base0.
   pose proof Hsound_g as Hsound_g0.
-  assert (Hsound_lcv: sound_gc_graph (lgraph_copy_v g v to)) by
-      (apply lcv_sound; auto).
   destruct Hiso as [Hcopy Hspec].
   destruct (split l) as [from_l to_l] eqn:Hsplit.
   destruct Hspec as [Hfrom [Hto [Hlabel Hpartial]]].
@@ -3074,8 +3072,7 @@ Proof.
               Hevalid Hsrcgen Hdstgen)
     as [Hdst_eq [Hdst_valid_base Hdst_base_gen]].
   assert (Holdvalid: old_vertices_valid base g). {
-    pose proof Hsemi as Hsemi0.
-    destruct Hsemi0 as [_ Hspec].
+    destruct Hsemi as [_ Hspec].
     destruct (split l) as [from_l to_l].
     destruct Hspec as [_ [_ [_ Hpartial]]].
     exact (proj1 Hpartial).
@@ -3167,9 +3164,8 @@ Proof.
   intros base g from to l e Hneq Hsound_base Hndd_base Hsemi
          Hevalid Hsrcgen Hdstgen.
   destruct Hsound_base as [Hvv_base [Hev_base _]].
-  pose proof Hsemi as Hsemi0.
   assert (Hdd: DoubleNoDup l) by
-      (eapply remset_semi_iso_DoubleNoDup; [exact Hneq | exact Hsemi0]).
+      (eapply remset_semi_iso_DoubleNoDup; [exact Hneq | exact Hsemi]).
   destruct Hsemi as [_ Hspec].
   destruct (split l) as [from_l to_l] eqn:Hsplit.
   destruct Hspec as [[_ Hfrom] [[_ [Hto_valid Hto_gen]] [_ Hpartial]]].
@@ -3272,11 +3268,7 @@ Lemma fr_O_remset_semi_iso:
 Proof.
   intros from to p base g1 g2 l1 Hneq Hsound_base Hsound_g1 Hto Hsemi
          Hcompat Hndd_base Hndd_g1 Hspecial Hclosed Hfr.
-  pose proof Hsound_base as Hsound_base0.
-  pose proof Hsound_g1 as Hsound_g1_0.
   assert (Hdd: DoubleNoDup l1) by (eapply remset_semi_iso_DoubleNoDup; eauto).
-  assert (Hbij: bijective (roots_map l1) (roots_map l1)) by
-      (now apply roots_map_bijective).
   assert (Hvv_base: vertex_valid base) by (destruct Hsound_base as [Hvv _]; exact Hvv).
   assert (Hvv_g1: vertex_valid g1) by (destruct Hsound_g1 as [Hvv _]; exact Hvv).
   destruct p; simpl in Hcompat, Hfr.
@@ -5217,10 +5209,8 @@ Proof.
              Hneq Hsemi Hevalid_base Hsrcgen Hdst_base Hgenv).
   }
   assert (Hgv: graph_has_v g v). {
-    pose proof Hsound_base as Hsound_base0.
-    pose proof Hsound_g as Hsound_g0.
-    destruct Hsound_base0 as [Hvv_base [Hev_base _]].
-    destruct Hsound_g0 as [Hvv_g _].
+    destruct Hsound_base as [Hvv_base [Hev_base _]].
+    destruct Hsound_g as [Hvv_g _].
     assert (Hge_base: graph_has_e base e) by
         (apply (proj1 (Hev_base _)); exact Hevalid_base).
     assert (Hdst_has_base: graph_has_v base (dst base e)) by
@@ -5285,10 +5275,8 @@ Proof.
             remset_partial_graph_pending base g l from (item :: pending)) by
       (eapply gc_graph_remset_semi_iso_parts_partial; exact Hsemi).
   assert (Hgv: graph_has_v g v). {
-    pose proof Hsound_base as Hsound_base0.
-    pose proof Hsound_g as Hsound_g0.
-    destruct Hsound_base0 as [Hvv_base [Hev_base _]].
-    destruct Hsound_g0 as [Hvv_g _].
+    destruct Hsound_base as [Hvv_base [Hev_base _]].
+    destruct Hsound_g as [Hvv_g _].
     assert (Hge_base: graph_has_e base e) by
         (apply (proj1 (Hev_base _)); exact Hevalid_base).
     assert (Hdst_has_base: graph_has_v base (dst base e)) by
@@ -5591,8 +5579,7 @@ Proof.
       eapply lcv_pending_remset_semi_iso; eauto.
     }
     assert (Hsrc_not_new: fst e <> new_copied_v g to). {
-      pose proof Hsound_g as Hsound_g0.
-      destruct Hsound_g0 as [_ [Hev_g _]].
+      destruct Hsound_g as [_ [Hev_g _]].
       assert (Hge_g: graph_has_e g e) by
           (apply (proj1 (Hev_g _)); exact Hevalid_g).
       destruct Hge_g as [Hsrc_has _].
@@ -7988,14 +7975,12 @@ Proof.
       eapply svwl_graph_has_v in Hv; eauto.
       now rewrite Hvv3.
     - rewrite Hvv3 in Hv.
-      pose proof Hscan as Hscan_loop'.
-      destruct Hscan_loop' as [n' [Hsvwl_loop' _]].
+      destruct Hscan as [n' [Hsvwl_loop' _]].
       apply svwl_graph_has_v_inv with (v := v0) in Hsvwl_loop'; auto.
       destruct Hsvwl_loop' as [Hv2 | [Hgen_to _]].
       2: (rewrite Hgen_to in Hgen; exfalso; apply Hneq; symmetry; exact Hgen).
-      pose proof Hfrr as Hfrr_inv.
-      apply frr_graph_has_v_inv with (v := v0) in Hfrr_inv; auto.
-      destruct Hfrr_inv as [Hv1 | [Hgen_to _]].
+      apply frr_graph_has_v_inv with (v := v0) in Hfrr; auto.
+      destruct Hfrr as [Hv1 | [Hgen_to _]].
       2: (rewrite Hgen_to in Hgen; exfalso; apply Hneq; symmetry; exact Hgen).
       now rewrite Hvv1.
   }

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -1268,20 +1268,10 @@ Lemma forward_remset_item_fold_P_holds:
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     P g'.
 Proof.
-  intros P from to r. induction r; intros g h rh rmst g' h' rh' rmst' HP HPg Hto Hfold.
-  - inversion Hfold; subst. assumption.
-  - destruct (forward_remset_item from to (g, h, rh, rmst) a)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    change (fold_left (forward_remset_item from to) (a :: r) (g, h, rh, rmst))
-      with (fold_left (forward_remset_item from to) r
-              (forward_remset_item from to (g, h, rh, rmst) a)) in Hfold.
-    rewrite Hfri in Hfold.
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst').
-    + exact HP.
-    + eapply forward_remset_item_P_holds; eauto.
-    + apply (proj1 (forward_remset_item_ghg from to g h rh rmst a
-                      g2 h2 rh2 rmst2 Hto (eq_sym Hfri) to)); exact Hto.
-    + exact Hfold.
+  intros P from to r g h rh rmst g' h' rh' rmst' HP HPg Hto Hfold.
+  eapply (forward_remset_item_fold_graph_property P);
+    [| exact Hto | exact HPg | exact Hfold].
+  intros. eapply forward_remset_item_P_holds; eassumption.
 Qed.
 
 Lemma forward_remset_gh_P_holds:
@@ -8233,18 +8223,13 @@ Lemma forward_remset_item_fold_rh_Zlength_same:
       fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     Zlength rh = Zlength rh'.
 Proof.
-  intros from to r. induction r as [|item rest IH];
-    intros g h rh rmst g' h' rh' rmst' Hfold.
-  - simpl in Hfold. inversion Hfold. reflexivity.
-  - Opaque forward_remset_item.
-    simpl in Hfold.
-    Transparent forward_remset_item.
-    destruct (forward_remset_item from to (g, h, rh, rmst) item)
-      as [[[g2 h2] rh2] rmst2] eqn:Hfri.
-    symmetry in Hfri.
-    transitivity (Zlength rh2).
-    + eapply fri_rh_Zlength_same; exact Hfri.
-    + eapply IH; exact Hfold.
+  intros from to r g h rh rmst g' h' rh' rmst' Hfold.
+  eapply (forward_remset_item_fold_suffix_invariant
+            (fun _ _ _ rh0 _ => Zlength rh = Zlength rh0));
+    [| reflexivity | exact Hfold].
+  intros item rest g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 Hlen Hstep.
+  transitivity (Zlength rh0); [exact Hlen |].
+  eapply fri_rh_Zlength_same; exact Hstep.
 Qed.
 
 Lemma forward_remset_gh_rh_Zlength_same:

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -1307,44 +1307,6 @@ Proof.
   intros. eapply fr_O_sound; eauto.
 Qed.
 
-Lemma forward_remset_item_step_state_with_tail:
-  forall from to g h rh rmst item rest g' h' rh' rmst',
-    from <> to ->
-    graph_has_gen g to ->
-    copy_compatible g ->
-    remset_nodup rmst ->
-    remset_graph_compatible g rmst ->
-    remset_item_compatible g from rmst item ->
-    remset_and_remset_space_compatible g from rmst rest ->
-    (g', h', rh', rmst') = forward_remset_item from to (g, h, rh, rmst) item ->
-    graph_has_gen g' to /\
-    copy_compatible g' /\
-    remset_nodup rmst' /\
-    remset_graph_compatible g' rmst' /\
-    remset_and_remset_space_compatible g' from rmst' rest.
-Proof.
-  intros from to g h rh rmst item rest g' h' rh' rmst'
-         Hneq Hto Hcc Hrnd Hrgc Hric Hrest Hfri.
-  split.
-  - rewrite <- (forward_remset_item_ghg from to g h rh rmst item
-                  g' h' rh' rmst' Hto Hfri to).
-    exact Hto.
-  - split.
-    + exact (fri_copy_compatible from to g h rh rmst item g' h' rh' rmst'
-               Hneq Hto Hcc Hfri).
-    + split.
-      * exact (fri_remset_nodup from to g h rh rmst item g' h' rh' rmst'
-                 Hrnd Hfri).
-      * split.
-        -- exact (fri_remset_graph_compatible from to g h rh rmst item
-                    g' h' rh' rmst' Hto Hcc Hrnd Hrgc Hric Hfri).
-        -- unfold remset_and_remset_space_compatible in Hrest |- *.
-           rewrite Forall_forall in Hrest |- *.
-           intros tail_item Hin_tail.
-           specialize (Hrest _ Hin_tail).
-           eapply fri_remset_item_compatible with (rmst := rmst) (item := item);
-             eassumption.
-Qed.
 
 (** Semi-Isomorphism **)
 
@@ -5143,7 +5105,7 @@ Proof.
         -- destruct (forward_remset_item from to (g, h, rh, rmst) (RemSetExterior item_addr))
              as [[[g2 h2] rh2] rmst2] eqn:Hfri.
            symmetry in Hfri.
-           destruct (forward_remset_item_step_state_with_tail
+           destruct (forward_remset_item_step_facts
                        from to g h rh rmst (RemSetExterior item_addr) rest
                        g2 h2 rh2 rmst2 Hneq Hto Hcc Hrnd Hrgc Hric_item
                        Hrrsc_tail Hfri)
@@ -5163,7 +5125,7 @@ Proof.
       * destruct (forward_remset_item from to (g, h, rh, rmst) (RemSetInterior intr))
           as [[[g2 h2] rh2] rmst2] eqn:Hfri.
         symmetry in Hfri.
-        destruct (forward_remset_item_step_state_with_tail
+        destruct (forward_remset_item_step_facts
                     from to g h rh rmst (RemSetInterior intr) rest
                     g2 h2 rh2 rmst2 Hneq Hto Hcc Hrnd Hrgc Hric_item
                     Hrrsc_tail Hfri)
@@ -5769,7 +5731,7 @@ Proof.
     assert (Hsound2: sound_gc_graph g2) by
         (eapply forward_remset_item_P_holds; eauto;
          intros; eapply fr_O_sound; eauto).
-    destruct (forward_remset_item_step_state_with_tail
+    destruct (forward_remset_item_step_facts
                 from to g h rh rmst item r g2 h2 rh2 rmst2
                 Hneq Hto Hcc Hrnd Hrgc Hric_item Hrrsc_tail Hfri)
       as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
@@ -7215,7 +7177,7 @@ Proof.
         as [Hnotin Heff].
       eapply remset_item_effective_root_in_effective_roots_from_space_cons;
         eauto.
-    + destruct (forward_remset_item_step_state_with_tail
+    + destruct (forward_remset_item_step_facts
                   from to g h rh rmst item rest g2 h2 rh2 rmst2
                   Hneq Hto Hcc Hrnd Hrgc Hric_item Hrrsc_tail Hfri)
         as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
@@ -8411,7 +8373,7 @@ Proof.
     assert (Hrange2: 0 <= Z.of_nat to < Zlength rh2) by
         (pose proof (fri_rh_Zlength_same from to g h rh rmst item
                        g2 h2 rh2 rmst2 Hfri); lia).
-    destruct (forward_remset_item_step_state_with_tail
+    destruct (forward_remset_item_step_facts
                 from to g h rh rmst item rest g2 h2 rh2 rmst2
                 Hneq Hto Hcc Hrnd Hrgc Hitem Hrrsc_tail Hfri)
       as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
@@ -8465,7 +8427,7 @@ Proof.
     symmetry in Hfri.
     hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc.
     destruct Hrrsc as [Hitem Hrrsc_tail].
-    destruct (forward_remset_item_step_state_with_tail
+    destruct (forward_remset_item_step_facts
                 from to g h rh rmst item rest g2 h2 rh2 rmst2
                 Hneq Hto Hcc Hrnd Hrgc Hitem Hrrsc_tail Hfri)
       as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].
@@ -8648,7 +8610,7 @@ Proof.
     assert (Hsound2: sound_gc_graph g2) by
         (eapply forward_remset_item_P_holds;
          [intros; eapply fr_O_sound; eauto | exact Hsound | exact Hto | exact Hfri]).
-    destruct (forward_remset_item_step_state_with_tail
+    destruct (forward_remset_item_step_facts
                 from to g h rh rmst item rest g2 h2 rh2 rmst2
                 Hneq Hto Hcc Hrnd Hrgc Hric Hrrsc_tail Hfri)
       as [Hto2 [Hcc2 [Hrnd2 [Hrgc2 Hrrsc2]]]].

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -1327,6 +1327,19 @@ Definition gc_graph_pending_remset_semi_iso
     (fun g1 g2 l from => remset_partial_graph_pending g1 g2 l from pending)
     g1 g2 from to l.
 
+#[local] Lemma gc_graph_remset_semi_iso_parts_impl:
+  forall Partial1 Partial2 g1 g2 from to l,
+    gc_graph_remset_semi_iso_parts Partial1 g1 g2 from to l ->
+    (Partial1 g1 g2 l from -> Partial2 g1 g2 l from) ->
+    gc_graph_remset_semi_iso_parts Partial2 g1 g2 from to l.
+Proof.
+  unfold gc_graph_remset_semi_iso_parts.
+  intros Partial1 Partial2 g1 g2 from to l [Hcopy Hspec] Himpl.
+  split; [exact Hcopy |].
+  destruct (split l) as [from_l to_l].
+  intuition.
+Qed.
+
 Lemma gc_graph_remset_semi_iso_parts_partial:
   forall Partial g1 g2 from to l,
     gc_graph_remset_semi_iso_parts Partial g1 g2 from to l ->
@@ -1770,17 +1783,10 @@ Lemma pending_remset_semi_iso_nil:
     gc_graph_pending_remset_semi_iso g1 g2 from to nil l ->
     gc_graph_remset_semi_iso g1 g2 from to l.
 Proof.
-  intros g1 g2 from to l [Hcopy Hspec].
-  split; [exact Hcopy |].
-  destruct (split l) as [from_l to_l] eqn:Hsplit.
-  destruct Hspec as [Hfrom [Hto [Hlabel Hpartial]]].
-  split; [exact Hfrom |]. split; [exact Hto |].
-  split; [exact Hlabel |].
-  unfold remset_partial_graph_pending in Hpartial.
-  unfold remset_partial_graph.
-  destruct Hpartial as [Hold [Hedges Hunmarked]].
-  split; [exact Hold |]. split; [|exact Hunmarked].
-  now apply old_nonfrom_edges_mapped_pending_nil.
+  intros g1 g2 from to l Hiso.
+  eapply gc_graph_remset_semi_iso_parts_impl; [exact Hiso |].
+  unfold remset_partial_graph_pending, remset_partial_graph.
+  intuition eauto using old_nonfrom_edges_mapped_pending_nil.
 Qed.
 
 Lemma remset_semi_iso_pending:
@@ -1788,17 +1794,10 @@ Lemma remset_semi_iso_pending:
     gc_graph_remset_semi_iso g1 g2 from to l ->
     gc_graph_pending_remset_semi_iso g1 g2 from to pending l.
 Proof.
-  intros g1 g2 from to l pending [Hcopy Hspec].
-  split; [exact Hcopy |].
-  destruct (split l) as [from_l to_l] eqn:Hsplit.
-  destruct Hspec as [Hfrom [Hto [Hlabel Hpartial]]].
-  split; [exact Hfrom |]. split; [exact Hto |].
-  split; [exact Hlabel |].
-  unfold remset_partial_graph in Hpartial.
-  unfold remset_partial_graph_pending.
-  destruct Hpartial as [Hold [Hedges Hunmarked]].
-  split; [exact Hold |]. split; [|exact Hunmarked].
-  now apply old_nonfrom_edges_mapped_pending_intro.
+  intros g1 g2 from to l pending Hiso.
+  eapply gc_graph_remset_semi_iso_parts_impl; [exact Hiso |].
+  unfold remset_partial_graph, remset_partial_graph_pending.
+  intuition eauto using old_nonfrom_edges_mapped_pending_intro.
 Qed.
 
 Lemma pending_remset_semi_iso_lift_partial:
@@ -1808,13 +1807,8 @@ Lemma pending_remset_semi_iso_lift_partial:
     gc_graph_pending_remset_semi_iso g1 g2 from to pending1 l ->
     gc_graph_pending_remset_semi_iso g1 g2 from to pending2 l.
 Proof.
-  intros g1 g2 from to pending1 pending2 l Hlift [Hcopy Hspec].
-  split; [exact Hcopy |].
-  destruct (split l) as [from_l to_l] eqn:Hsplit.
-  destruct Hspec as [Hfrom [Hto [Hlabel Hpartial]]].
-  split; [exact Hfrom |]. split; [exact Hto |].
-  split; [exact Hlabel |].
-  now apply Hlift.
+  intros g1 g2 from to pending1 pending2 l Hlift Hiso.
+  eapply gc_graph_remset_semi_iso_parts_impl; [exact Hiso | exact Hlift].
 Qed.
 
 Lemma pending_remset_semi_iso_cons_drop:

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -10337,7 +10337,7 @@ Proof.
   - exact Hsafe.
 Qed.
 
-Theorem mutable_update_garbage_collect_model_preconditions:
+Theorem mutable_update_gc_ready:
   forall g src pos new g' h rootpairs roots outlier rmst rh,
     mutable_location_compatible g (InteriorVertexPos src pos) ->
     exterior_compatible g outlier new ->

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -1233,11 +1233,8 @@ Lemma new_gen_heap_sound: forall g1 h1 g2 h2 gen,
     sound_gc_graph g1 -> new_gen_heap_relation gen g1 h1 g2 h2 -> sound_gc_graph g2.
 Proof.
   intros g1 h1 g2 h2 gen Hsound Hrel.
-  eapply (ngr_sound g1 g2 gen); eauto. unfold new_gen_relation, new_gen_heap_relation in *.
-  destruct (graph_has_gen_dec g1 gen).
-  - destruct Hrel as [Hg _]. symmetry. assumption.
-  - destruct Hrel as [gi [sp [i [Hs [_ [Hnum [_ [_ [_ [Hg _]]]]]]]]]].
-    exists gi. split; assumption.
+  eapply (ngr_sound g1 g2 gen); eauto.
+  eapply new_gen_heap_new_gen_relation; exact Hrel.
 Qed.
 
 Lemma forward_remset_item_P_holds:

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -1818,78 +1818,6 @@ Proof.
   now apply Hlift.
 Qed.
 
-Lemma remset_partial_graph_pending_nil:
-  forall g1 g2 l from,
-    remset_partial_graph_pending g1 g2 l from nil ->
-    remset_partial_graph g1 g2 l from.
-Proof.
-  unfold remset_partial_graph_pending, remset_partial_graph.
-  intros g1 g2 l from [Hold [Hedges Hunmarked]].
-  split; [exact Hold |].
-  split; [|exact Hunmarked].
-  now apply old_nonfrom_edges_mapped_pending_nil.
-Qed.
-
-Lemma remset_partial_graph_pending_intro:
-  forall g1 g2 l from pending,
-    remset_partial_graph g1 g2 l from ->
-    remset_partial_graph_pending g1 g2 l from pending.
-Proof.
-  unfold remset_partial_graph_pending, remset_partial_graph.
-  intros g1 g2 l from pending [Hold [Hedges Hunmarked]].
-  split; [exact Hold |].
-  split; [|exact Hunmarked].
-  now apply old_nonfrom_edges_mapped_pending_intro.
-Qed.
-
-Lemma remset_partial_graph_pending_cons_drop:
-  forall g1 g2 l from item pending,
-    (forall e, ~ remset_item_records_edge item e) ->
-    remset_partial_graph_pending g1 g2 l from (item :: pending) ->
-    remset_partial_graph_pending g1 g2 l from pending.
-Proof.
-  intros g1 g2 l from item pending Hnone Hpartial.
-  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
-  intros Hedges. eapply old_nonfrom_edges_mapped_pending_cons_drop; eauto.
-Qed.
-
-Lemma remset_partial_graph_pending_cons_drop_old_nonfrom:
-  forall g1 g2 l from item pending,
-    (forall e, vgeneration (fst e) <> from -> ~ remset_item_records_edge item e) ->
-    remset_partial_graph_pending g1 g2 l from (item :: pending) ->
-    remset_partial_graph_pending g1 g2 l from pending.
-Proof.
-  intros g1 g2 l from item pending Hnone Hpartial.
-  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
-  intros Hedges. eapply old_nonfrom_edges_mapped_pending_cons_drop_old_nonfrom; eauto.
-Qed.
-
-Lemma remset_partial_graph_pending_consume_item_not_to:
-  forall (g1 g2: LGraph) (l: list (VType * VType)) from item
-         (pending: remset_space) e,
-    remset_item_records_edge item e ->
-    vgeneration (dst g2 e) <> from ->
-    remset_partial_graph_pending g1 g2 l from (item :: pending) ->
-    remset_partial_graph_pending g1 g2 l from pending.
-Proof.
-  intros g1 g2 l from item pending e Hitem Hdst_not Hpartial.
-  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
-  intros Hedges. eapply old_nonfrom_edges_mapped_pending_consume_item_not_to; eauto.
-Qed.
-
-Lemma remset_partial_graph_pending_consume_item_no_current_edge:
-  forall (g1 g2: LGraph) (l: list (VType * VType)) from item
-         (pending: remset_space),
-    (forall e, remset_item_records_edge item e -> ~ evalid g2 e) ->
-    remset_partial_graph_pending g1 g2 l from (item :: pending) ->
-    remset_partial_graph_pending g1 g2 l from pending.
-Proof.
-  intros g1 g2 l from item pending Hno_current Hpartial.
-  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
-  intros Hedges.
-  eapply old_nonfrom_edges_mapped_pending_consume_item_no_current_edge; eauto.
-Qed.
-
 Lemma pending_remset_semi_iso_nil:
   forall g1 g2 from to l,
     gc_graph_pending_remset_semi_iso g1 g2 from to nil l ->
@@ -1901,7 +1829,11 @@ Proof.
   destruct Hspec as [Hfrom [Hto [Hlabel Hpartial]]].
   split; [exact Hfrom |]. split; [exact Hto |].
   split; [exact Hlabel |].
-  now apply remset_partial_graph_pending_nil.
+  unfold remset_partial_graph_pending in Hpartial.
+  unfold remset_partial_graph.
+  destruct Hpartial as [Hold [Hedges Hunmarked]].
+  split; [exact Hold |]. split; [|exact Hunmarked].
+  now apply old_nonfrom_edges_mapped_pending_nil.
 Qed.
 
 Lemma remset_semi_iso_pending:
@@ -1915,7 +1847,11 @@ Proof.
   destruct Hspec as [Hfrom [Hto [Hlabel Hpartial]]].
   split; [exact Hfrom |]. split; [exact Hto |].
   split; [exact Hlabel |].
-  now apply remset_partial_graph_pending_intro.
+  unfold remset_partial_graph in Hpartial.
+  unfold remset_partial_graph_pending.
+  destruct Hpartial as [Hold [Hedges Hunmarked]].
+  split; [exact Hold |]. split; [|exact Hunmarked].
+  now apply old_nonfrom_edges_mapped_pending_intro.
 Qed.
 
 Lemma pending_remset_semi_iso_lift_partial:
@@ -1942,7 +1878,9 @@ Lemma pending_remset_semi_iso_cons_drop:
 Proof.
   intros g1 g2 from to item pending l Hnone Hiso.
   eapply pending_remset_semi_iso_lift_partial; [|exact Hiso].
-  intros Hpartial. eapply remset_partial_graph_pending_cons_drop; eauto.
+  intros Hpartial.
+  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
+  intros Hedges. eapply old_nonfrom_edges_mapped_pending_cons_drop; eauto.
 Qed.
 
 Lemma pending_remset_semi_iso_cons_drop_old_nonfrom:
@@ -1954,7 +1892,9 @@ Proof.
   intros g1 g2 from to item pending l Hnone Hiso.
   eapply pending_remset_semi_iso_lift_partial; [|exact Hiso].
   intros Hpartial.
-  eapply remset_partial_graph_pending_cons_drop_old_nonfrom; eauto.
+  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
+  intros Hedges.
+  eapply old_nonfrom_edges_mapped_pending_cons_drop_old_nonfrom; eauto.
 Qed.
 
 Lemma pending_remset_semi_iso_consume_item_not_to:
@@ -1968,7 +1908,9 @@ Proof.
   intros g1 g2 from to item pending l e Hitem Hdst_not Hiso.
   eapply pending_remset_semi_iso_lift_partial; [|exact Hiso].
   intros Hpartial.
-  eapply remset_partial_graph_pending_consume_item_not_to; eauto.
+  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
+  intros Hedges.
+  eapply old_nonfrom_edges_mapped_pending_consume_item_not_to; eauto.
 Qed.
 
 Lemma pending_remset_semi_iso_consume_item_no_current_edge:
@@ -1981,7 +1923,9 @@ Proof.
   intros g1 g2 from to item pending l Hno_current Hiso.
   eapply pending_remset_semi_iso_lift_partial; [|exact Hiso].
   intros Hpartial.
-  eapply remset_partial_graph_pending_consume_item_no_current_edge; eauto.
+  eapply remset_partial_graph_pending_lift_edges; [|exact Hpartial].
+  intros Hedges.
+  eapply old_nonfrom_edges_mapped_pending_consume_item_no_current_edge; eauto.
 Qed.
 
 Lemma pending_remset_semi_iso_refl:
@@ -2118,15 +2062,10 @@ Lemma forward_remset_item_graph_has_v_pres:
     graph_has_v g' v.
 Proof.
   intros from to g h rh rmst item g' h' rh' rmst' v Hto Hv Hfri.
-  unfold forward_remset_item in Hfri.
-  destruct (negb (remset_item_in_gen item rmst g from)).
-  - destruct (forward_graph_and_heap from to O (remset_item2forward_t item rmst g) g h)
-      as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap from to O (remset_item2forward_t item rmst g) g h
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. inversion Hfri; subst.
-    eapply fr_graph_has_v; eauto.
-  - inversion Hfri; subst. exact Hv.
+  eapply (forward_remset_item_P_holds
+            (fun g0 => graph_has_v g0 v)); eauto.
+  intros g1 g2 p Hv1 Hto1 Hfr.
+  eapply fr_graph_has_v; eauto.
 Qed.
 
 Lemma forward_remset_item_fold_raw_mark_true_pres:
@@ -3493,26 +3432,6 @@ Proof.
         now rewrite make_fields_eq_length.
 Qed.
 
-Lemma fr_O_no_unmarked_old_nonfrom_dst:
-  forall base from to p g g',
-    from <> to ->
-    forward_relation from to O (forward_p2forward_t p g) g g' ->
-    no_unmarked_old_nonfrom_dst base g from ->
-    no_unmarked_old_nonfrom_dst base g' from.
-Proof.
-  intros base from to p g g' Hneq Hfr Hclosed.
-  destruct p; simpl in Hfr.
-  - destruct extr; simpl in Hfr; inversion Hfr; subst; auto.
-    eapply no_unmarked_old_nonfrom_dst_lcv; eauto.
-  - destruct intr as [v i]. simpl in Hfr.
-    destruct (Znth i (make_fields g v)); simpl in Hfr; inversion Hfr; subst; auto;
-      try solve [
-        eapply no_unmarked_old_nonfrom_dst_lgd;
-        eapply no_unmarked_old_nonfrom_dst_lcv; eauto
-      ];
-      eapply no_unmarked_old_nonfrom_dst_lgd; eauto.
-Qed.
-
 Lemma fr_O_no_unmarked_old_nonfrom_dst_t:
   forall base from to p g g',
     from <> to ->
@@ -3581,7 +3500,7 @@ Proof.
       now apply roots_graph_compatible_inv in Hroots.
     + eapply fr_O_no_dangling_dst' with (p := FwdPntExtr r); eauto.
     + eapply fr_copy_compatible; eauto.
-    + eapply fr_O_no_unmarked_old_nonfrom_dst with (p := FwdPntExtr r); eauto.
+    + eapply fr_O_no_unmarked_old_nonfrom_dst_t; eauto.
     + exists (l3 ++ l2). rewrite <- app_assoc. split; auto. subst roots2. f_equal.
       inversion Hupd as [Hupd_exterior]. clear Hupd. rewrite Hupd_exterior.
       unfold exterior_map. destruct r; auto.
@@ -3647,8 +3566,7 @@ Proof.
                     g2 g0 H2 H16 v H20 NOSCAN).
       exact H12.
     + eapply (fr_copy_compatible O from); eauto.
-    + eapply fr_O_no_unmarked_old_nonfrom_dst with
-        (p := FwdPntIntr (InteriorVertexPos v (Z.of_nat a))); eauto.
+    + eapply fr_O_no_unmarked_old_nonfrom_dst_t; eauto.
 Qed.
 
 Lemma svfl_no_unmarked_old_nonfrom_dst:
@@ -6068,7 +5986,7 @@ Proof.
   apply IHHfrr.
   - rewrite <- (fr_graph_has_gen 0 from to (exterior2forward r) g1 g2 Hto H to).
     exact Hto.
-  - eapply fr_O_no_unmarked_old_nonfrom_dst with (p := FwdPntExtr r); eauto.
+  - eapply fr_O_no_unmarked_old_nonfrom_dst_t; eauto.
 Qed.
 
 Lemma forward_remset_gh_frr_remset_semi_iso:
@@ -9902,9 +9820,8 @@ Lemma mutable_graph_update_graph_has_e_neq:
     (graph_has_e g' e <-> graph_has_e g e).
 Proof.
   intros g src pos new g' [v n] Hneq Hloc Hupd.
+  pose proof Hloc as Hloc'.
   destruct Hloc as [Hv [Hpos [Hmark Htag]]].
-  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
-    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
   destruct (V_EqDec v src) as [Heq | Hne].
   - hnf in Heq. subst v.
     assert (Hidx: Z.of_nat n <> pos).
@@ -9934,9 +9851,8 @@ Lemma mutable_graph_update_graph_has_e_target:
      exists dstv, new = ExteriorVertex dstv).
 Proof.
   intros g src pos new g' Hloc Hupd.
+  pose proof Hloc as Hloc'.
   destruct Hloc as [Hv [Hpos [Hmark Htag]]].
-  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
-    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
   rewrite (graph_has_e_iff_raw_internal g' src (Z.to_nat pos)).
   2: rewrite (mutable_graph_update_graph_has_v g (InteriorVertexPos src pos)
                 new g' src Hloc' Hupd); exact Hv.
@@ -10069,9 +9985,8 @@ Theorem mutable_graph_update_sound:
     sound_gc_graph g'.
 Proof.
   intros g src pos new g' outlier Hsound Hloc Hext Hupd.
+  pose proof Hsound as Hsound'.
   destruct Hsound as [Hvv [Hev [Hsrc Hlabel]]].
-  assert (Hsound': sound_gc_graph g).
-  { exact (conj Hvv (conj Hev (conj Hsrc Hlabel))). }
   split; [|split; [|split]].
   - intro v.
     rewrite (mutable_graph_update_vvalid g (InteriorVertexPos src pos) new g' v Hupd).
@@ -10130,9 +10045,8 @@ Theorem mutable_graph_update_no_unrecorded_backward_edge:
        else rh).
 Proof.
   intros g src pos new g' outlier rh Hloc Hext Hupd Hrange Hold.
+  pose proof Hloc as Hloc'.
   destruct Hloc as [Hv [Hpos [Hmark Htag]]].
-  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
-    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
   unfold no_unrecorded_backward_edge, no_unrecorded_backward_edge_from in *.
   intros e He' Hback.
   destruct (E_EqDec e (src, Z.to_nat pos)) as [Heq | Hneq].
@@ -10240,9 +10154,8 @@ Lemma mutable_graph_update_new_remset_item_compatible:
       (RemSetInterior (InteriorVertexPos src pos)).
 Proof.
   intros g src pos new g' from rmst Hloc Hupd.
+  pose proof Hloc as Hloc'.
   destruct Hloc as [Hv [Hpos [Hmark Htag]]].
-  assert (Hloc': mutable_location_compatible g (InteriorVertexPos src pos))
-    by exact (conj Hv (conj Hpos (conj Hmark Htag))).
   simpl. split.
   - rewrite (mutable_graph_update_graph_has_v
                g (InteriorVertexPos src pos) new g' src Hloc' Hupd).

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -10360,3 +10360,228 @@ Proof.
     + eapply mutable_update_remset_and_remset_heap_compatible; eauto.
     + eapply mutable_update_remset_heap_and_heap_compatible; eauto.
 Qed.
+
+Lemma mutable_graph_update_exterior2val_all:
+  forall g it new g' ext,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    exterior2val g' ext = exterior2val g ext.
+Proof.
+  intros g it new g' ext Hloc Hupd.
+  destruct ext; simpl; try reflexivity.
+  eapply mutable_graph_update_vertex_address; eassumption.
+Qed.
+
+Lemma mutable_graph_update_rootpairs_compatible:
+  forall g it new g' rootpairs roots,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    rootpairs_compatible g rootpairs roots ->
+    rootpairs_compatible g' rootpairs roots.
+Proof.
+  intros g it new g' rootpairs roots Hloc Hupd Hcompatible.
+  unfold rootpairs_compatible in *.
+  rewrite <- Hcompatible. clear Hcompatible rootpairs.
+  induction roots as [|ext roots IH]; simpl; [reflexivity|].
+  rewrite (mutable_graph_update_exterior2val_all
+             g it new g' ext Hloc Hupd), IH.
+  reflexivity.
+Qed.
+
+Lemma mutable_graph_update_roots_compatible:
+  forall g it new g' outlier roots,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    roots_compatible g outlier roots ->
+    roots_compatible g' outlier roots.
+Proof.
+  intros g it new g' outlier roots Hloc Hupd [Houtlier Hgraph].
+  split; [exact Houtlier|].
+  unfold roots_graph_compatible in *.
+  eapply Forall_impl; [|exact Hgraph].
+  intros v Hv.
+  rewrite (mutable_graph_update_graph_has_v g it new g' v Hloc Hupd).
+  exact Hv.
+Qed.
+
+Lemma mutable_graph_update_graph_unmarked:
+  forall g src pos new g',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    graph_unmarked g ->
+    graph_unmarked g'.
+Proof.
+  intros g src pos new g' Hloc Hupd Hunmarked v Hv'.
+  pose proof (mutable_graph_update_raw_mark_tag
+                g src pos new g' v Hloc Hupd) as [Hmark _].
+  rewrite Hmark. apply Hunmarked.
+  rewrite <- (mutable_graph_update_graph_has_v
+                 g (InteriorVertexPos src pos) new g' v Hloc Hupd).
+  exact Hv'.
+Qed.
+
+Lemma mutable_graph_update_no_dangling_dst:
+  forall g src pos new g' outlier,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    no_dangling_dst g ->
+    no_dangling_dst g'.
+Proof.
+  intros g src pos new g' outlier Hloc Hext Hupd Hno v Hv' e Hin'.
+  assert (Hfst': fst e = v) by (eapply get_edges_fst; exact Hin').
+  assert (He': graph_has_e g' e).
+  { unfold graph_has_e. rewrite Hfst'. split; assumption. }
+  destruct (E_EqDec e (src, Z.to_nat pos)) as [Heq | Hneq].
+  - hnf in Heq. subst e.
+    apply (mutable_graph_update_graph_has_e_target
+             g src pos new g' Hloc Hupd) in He'.
+    destruct He' as [dstv Hnew]. subst new.
+    rewrite (mutable_graph_update_dst_new g src pos dstv g' Hloc Hupd).
+    rewrite (mutable_graph_update_graph_has_v
+               g (InteriorVertexPos src pos) (ExteriorVertex dstv)
+               g' dstv Hloc Hupd).
+    exact Hext.
+  - assert (He: graph_has_e g e).
+    { apply (proj1 (mutable_graph_update_graph_has_e_neq
+                      g src pos new g' e Hneq Hloc Hupd)). exact He'. }
+    destruct He as [Hsrc Hin].
+    specialize (Hno _ Hsrc _ Hin).
+    rewrite (mutable_graph_update_dst_neq
+               g src pos new g' e Hneq Hloc Hupd).
+    rewrite (mutable_graph_update_graph_has_v
+               g (InteriorVertexPos src pos) new g'
+               (dst g e) Hloc Hupd).
+    exact Hno.
+Qed.
+
+Theorem mutable_update_super_compatible:
+  forall g src pos new g' h rootpairs roots outlier,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    super_compatible g h rootpairs roots outlier ->
+    super_compatible g'
+      (if isptr_dec (exterior2val g new)
+       then incr_remset_heap h 0
+       else h)
+      rootpairs roots outlier.
+Proof.
+  intros g src pos new g' h rootpairs roots outlier
+         Hloc Hext Hupd [Hghc [Hrootpairs [Hroots Houtlier]]].
+  split; [|split; [|split]].
+  - destruct (isptr_dec (exterior2val g new)).
+    + apply incr_remset_heap_ghc.
+      eapply mutable_graph_update_graph_heap_compatible; eauto.
+    + eapply mutable_graph_update_graph_heap_compatible; eauto.
+  - eapply mutable_graph_update_rootpairs_compatible; eauto.
+  - eapply mutable_graph_update_roots_compatible; eauto.
+  - eapply mutable_graph_update_outlier_compatible; eauto.
+Qed.
+
+Theorem mutable_update_garbage_collect_condition:
+  forall g src pos new g' outlier h,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    garbage_collect_condition g h ->
+    garbage_collect_condition g'
+      (if isptr_dec (exterior2val g new)
+       then incr_remset_heap h 0
+       else h).
+Proof.
+  intros g src pos new g' outlier h Hloc Hext Hupd
+         [Hunmarked [Hno_dangling Hsize]].
+  split; [|split].
+  - eapply mutable_graph_update_graph_unmarked; eauto.
+  - eapply mutable_graph_update_no_dangling_dst; eauto.
+  - destruct (isptr_dec (exterior2val g new)).
+    + eapply weak_heap_relation_size_spec; eauto.
+      apply incr_remset_heap_whr.
+    + exact Hsize.
+Qed.
+
+Lemma incr_remset_heap_rest_gen_size_above_nursery:
+  forall h n,
+    rest_gen_size (incr_remset_heap h 0) (S n) =
+    rest_gen_size h (S n).
+Proof.
+  intros h n. unfold rest_gen_size.
+  rewrite !nth_space_Znth.
+  rewrite (irh_Znth_spaces_not_eq h (Z.of_nat (S n)) 0) by lia.
+  reflexivity.
+Qed.
+
+Theorem mutable_update_safe_to_copy_heap:
+  forall g src pos new g' h,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    safe_to_copy_heap g h ->
+    safe_to_copy_heap g'
+      (if isptr_dec (exterior2val g new)
+       then incr_remset_heap h 0
+       else h).
+Proof.
+  intros g src pos new g' h Hloc Hupd Hsafe.
+  unfold safe_to_copy_heap in *. intros n Hgen'.
+  assert (Hgen: graph_has_gen g (S n)).
+  { unfold graph_has_gen in *.
+    rewrite (mutable_graph_update_glabel
+               g (InteriorVertexPos src pos) new g' Hloc Hupd) in Hgen'.
+    exact Hgen'. }
+  specialize (Hsafe n Hgen).
+  destruct (isptr_dec (exterior2val g new)).
+  - unfold safe_to_copy_gen_heap in *.
+    unfold total_size.
+    rewrite irh_total_space.
+    rewrite incr_remset_heap_rest_gen_size_above_nursery.
+    exact Hsafe.
+  - exact Hsafe.
+Qed.
+
+Theorem mutable_update_garbage_collect_model_preconditions:
+  forall g src pos new g' h rootpairs roots outlier rmst rh,
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    used_space (nth_space h O) < available_space (nth_space h O) ->
+    super_compatible g h rootpairs roots outlier ->
+    garbage_collect_condition g h ->
+    no_unrecorded_backward_edge g rh ->
+    safe_to_copy_heap g h ->
+    remset_compatible g outlier O rmst rh h ->
+    remset_generation_compatible O rmst rh ->
+    let x := exterior2val g new in
+    let h' := if isptr_dec x then incr_remset_heap h 0 else h in
+    let rh' :=
+      if isptr_dec x
+      then upd_remset_heap
+             (RemSetInterior (InteriorVertexPos src pos)) rh O
+      else rh in
+    super_compatible g' h' rootpairs roots outlier /\
+    garbage_collect_condition g' h' /\
+    no_unrecorded_backward_edge g' rh' /\
+    safe_to_copy_heap g' h' /\
+    remset_compatible g' outlier O rmst rh' h' /\
+    remset_generation_compatible O rmst rh'.
+Proof.
+  intros g src pos new g' h rootpairs roots outlier rmst rh
+         Hloc Hext Hupd Hcapacity Hsuper Hgcc Hunrecorded Hsafe Hremset Hremgen.
+  simpl.
+  assert (Hghc: graph_heap_compatible g h) by exact (proj1 Hsuper).
+  assert (Hrhhc: remset_heap_and_heap_compatible rh h).
+  { exact (proj2 (proj2 Hremset)). }
+  assert (Hrange: 0 <= Z.of_nat O < Zlength rh).
+  { eapply gen_range_remset_heap; eauto. apply graph_has_gen_O. }
+  split.
+  - eapply mutable_update_super_compatible; eauto.
+  - split.
+    + eapply mutable_update_garbage_collect_condition; eauto.
+    + split.
+      * eapply mutable_graph_update_no_unrecorded_backward_edge; eauto.
+      * split.
+        -- eapply mutable_update_safe_to_copy_heap; eauto.
+        -- split.
+           ++ eapply mutable_update_remset_compatible; eauto.
+           ++ eapply mutable_update_remset_generation_compatible; eauto.
+Qed.

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -1254,9 +1254,7 @@ Proof.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [new_g new_h] eqn:Hfgh.
     inversion Hfri; subst. eapply HP; eauto.
-    pose proof (fr_forward_graph_and_heap
-                  from to 0 (remset_item2forward_t item rmst g) g h) as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr. exact Hfr.
+    eapply fr_forward_graph_and_heap_eq. symmetry. exact Hfgh.
   - inversion Hfri; subst. assumption.
 Qed.
 
@@ -4973,9 +4971,7 @@ Proof.
     as [new_g new_h] eqn:Hfgh.
   inversion Hfri; subst; clear Hfri.
   rewrite remset_item2forward_p_eq.
-  pose proof fr_forward_graph_and_heap
-       from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-  rewrite Hfgh in Hfr. simpl in Hfr. exact Hfr.
+  eapply fr_forward_graph_and_heap_eq. symmetry. exact Hfgh.
 Qed.
 
 Lemma forward_remset_item_effective_root_marked:
@@ -5248,9 +5244,9 @@ Proof.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hnotin.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [new_g new_h] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap
-         from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq
+                  from to 0 (remset_item2forward_t item rmst g) g h
+                  new_g new_h (eq_sym Hfgh)) as Hfr.
     inversion Hfri; subst; clear Hfri.
     destruct Hmarked_or_current as [Hmark_g | Hdst_current].
     + eapply fr_O_raw_mark_true_pres; eauto.
@@ -5317,9 +5313,9 @@ Proof.
     destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hnotin.
     - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
         as [new_g new_h] eqn:Hfgh.
-      pose proof fr_forward_graph_and_heap
-           from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-      rewrite Hfgh in Hfr. simpl in Hfr.
+      pose proof (fr_forward_graph_and_heap_eq
+                    from to 0 (remset_item2forward_t item rmst g) g h
+                    new_g new_h (eq_sym Hfgh)) as Hfr.
       inversion Hfri; subst; clear Hfri.
       eapply fr_O_raw_mark_false_inv; eauto.
     - inversion Hfri; subst; clear Hfri. exact Hmark_new.
@@ -7039,9 +7035,9 @@ Proof.
   destruct (negb (remset_item_in_gen item rmst g from)) eqn:Hitem.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq
+                  from to 0 (remset_item2forward_t item rmst g) g h
+                  newg newh (eq_sym Hfgh)) as Hfr.
     inversion Hfri; subst g2 h2 rh2 rmst2; clear Hfri.
     destruct item as [addr | [isrc ipos]]; simpl in Hfr.
     + destruct (find_remset_ext addr rmst) as [rext |] eqn:Hfind; simpl in Hfr.
@@ -7510,10 +7506,9 @@ Proof.
     destruct (forward_graph_and_heap from to O
                 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
-    pose proof (fr_forward_graph_and_heap
-                  from to O (remset_item2forward_t item rmst g) g h)
-      as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq
+                  from to O (remset_item2forward_t item rmst g) g h
+                  newg newh (eq_sym Hfgh)) as Hfr.
     inversion Hfri; subst g' h' rh' rmst'; clear Hfri.
     eapply fr_O_from_edge_inv; eauto.
     intros e0 Hedge.

--- a/CertiGC/gc_correct.v
+++ b/CertiGC/gc_correct.v
@@ -26,9 +26,9 @@ Require Import CertiGraph.graph.reachable_ind.
 Require Import CertiGraph.CertiGC.GCGraph.
 Import ListNotations.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
-Local Coercion pg_lg: LabeledGraph >-> PreGraph.
+#[local] Coercion pg_lg: LabeledGraph >-> PreGraph.
 
 Definition vertex_valid (g: LGraph): Prop := forall v, vvalid g v <-> graph_has_v g v.
 

--- a/CertiGC/gc_spec.v
+++ b/CertiGC/gc_spec.v
@@ -524,41 +524,6 @@ Definition ext_mutable_update_spec :=
          data_at sh int_or_ptr_type (exterior2val g v) p;
          heap_remset_rep g (ti_heap t_info').(pt_heap) rh').
 
-(* Maybe exterior_t could be renamed into root_t *)
-
-Lemma upd_rvb_range: forall rvb pos rf,
-    0 < Zlength (upd_Znth pos (raw_fields rvb) rf) < two_p (WORD_SIZE * 8 - 10).
-Proof.
-  intros rvb pos rf. pose proof raw_fields_range rvb. rewrite Zlength_upd_Znth. assumption.
-Qed.
-
-(*
-
-Definition upd_rvb (rvb: raw_vertex_block) (pos: Z) (rf: raw_field) : raw_vertex_block :=
-  Build_raw_vertex_block
-    (raw_mark rvb) (copied_vertex rvb) (upd_Znth pos (raw_fields rvb) rf)
-    (raw_color rvb) (raw_tag rvb) (raw_tag_range rvb)
-    (raw_color_range rvb) (upd_rvb_range rvb pos rf) (tag_no_scan rvb).
-
-Definition mtb_upd_graph (g: LGraph) (it: interior_t) (v: exterior_t) : LGraph :=
-  match it with
-  | InteriorVertexPos v pos =>
-      match Znth pos (raw_fields (vlabel g v)) with
-      | RawInternal => match v with
-                       | ExteriorUnboxed z =>
-                       | ExteriorOutlier p =>
-                       | ExteriorVertex vtx =>
-                       end
-      | RawUnboxed _
-      | RawOutlier _ => match v with
-                       | ExteriorUnboxed z =>
-                       | ExteriorOutlier p =>
-                       | ExteriorVertex vtx =>
-                       end
-  end
-
-*)
-
 Definition int_mutable_update_spec :=
   DECLARE _mutable_update
     WITH ti: val, v: exterior_t, t_info: thread_info, sh: share, g: LGraph,
@@ -586,11 +551,6 @@ Definition int_mutable_update_spec :=
          outlier_rep outlier;
          before_gc_thread_info_rep sh t_info' ti;
          heap_remset_rep g' (ti_heap t_info').(pt_heap) rh').
-
-(* Change before_gc_thread_info_rep *)
-(* Define a new heap_management to hide details in
-   before_gc_thread_info_rep *)
-(* combine heap and remset_heap *)
 
 Definition garbage_collect_spec :=
   DECLARE _garbage_collect
@@ -636,32 +596,6 @@ Definition garbage_collect_spec :=
          heap_remset_rep g' (ti_heap t_info').(pt_heap) rh';
          remset_rep sh g' rmst';
          before_gc_thread_info_rep sh t_info' ti).
-
-(*
-Definition reset_heap_spec :=
-   (* THIS IS A PLACEHOLDER AND NOT CORRECT *)
-  DECLARE _reset_heap
-  WITH h: val
-  PRE [tptr heap_type]
-    PROP ()
-    PARAMS (h)
-    GLOBALS ()
-    SEP ()
-  POST [tvoid]
-  PROP () RETURN () SEP ().
-
-Definition free_heap_spec :=
-   (* THIS IS A PLACEHOLDER AND NOT CORRECT *)
-  DECLARE _free_heap
-  WITH h: heap, p: val, rsh: share, gv: globals
-  PRE [tptr heap_type]
-    PROP (readable_share rsh) PARAMS (p) GLOBALS (gv)
-    SEP (heap_rep Ews h p; ti_token_rep h p;
-         mem_mgr gv; all_string_constants rsh gv)
-  POST [tvoid]
-  PROP () RETURN ()
-  SEP (mem_mgr gv; all_string_constants rsh gv).
-*)
 
 Definition Gprog: funspecs :=
   ltac:(with_library prog

--- a/CertiGC/gc_spec.v
+++ b/CertiGC/gc_spec.v
@@ -459,6 +459,24 @@ Definition make_tinfo_spec :=
          malloc_token Ews (tarray int_or_ptr_type NURSERY_SIZE) p;
          data_at_ Ews (tarray int_or_ptr_type NURSERY_SIZE) p).
 
+Definition headroom (ti : thread_info) : Z :=
+  let nursery := heap_head (pt_heap (ti_heap ti)) in
+  available_space nursery - used_space nursery.
+
+Definition info_recordable (ti : thread_info) : Prop :=
+  1 <= headroom ti.
+
+Lemma info_recordable_iff_used_lt_available:
+  forall ti,
+    info_recordable ti <->
+    used_space (heap_head (pt_heap (ti_heap ti))) <
+    available_space (heap_head (pt_heap (ti_heap ti))).
+Proof.
+  intros ti.
+  unfold info_recordable, headroom.
+  lia.
+Qed.
+
 Definition resume_spec :=
   DECLARE _resume
   WITH rsh: share, sh: share, gv: globals, ti: val,
@@ -474,9 +492,7 @@ Definition resume_spec :=
          graph_rep g;
          thread_info_rep sh t_info ti)
   POST [tvoid]
-    PROP (Ptrofs.unsigned (ti_nalloc t_info) <=
-           available_space (heap_head (ti_heap t_info).(pt_heap))
-          - used_space (heap_head (ti_heap t_info).(pt_heap)))
+    PROP (Ptrofs.unsigned (ti_nalloc t_info) <= headroom t_info)
     RETURN ()
     SEP (all_string_constants rsh gv;
          graph_rep g;
@@ -493,17 +509,13 @@ Definition decr_info_nursery (ti: thread_info) (x: val): thread_info :=
 Definition mtb_upd_remset_heap (x: val) (item: remset_space_item) (rh: remset_heap) : remset_heap :=
   if isptr_dec x then upd_remset_heap item rh O else rh.
 
-Definition info_recordable (ti: thread_info): Prop :=
-  let nursery := heap_head (ti_heap ti).(pt_heap) in
-  used_space nursery < available_space nursery.
-
 Definition ext_mutable_update_spec :=
   DECLARE _mutable_update
     WITH ti: val, p: val, v: exterior_t, t_info: thread_info, sh: share,
          g: LGraph, outlier: outlier_t, rh: remset_heap
   PRE [tptr thread_info_type, tptr int_or_ptr_type, int_or_ptr_type]
   PROP (writable_share sh;
-        info_recordable t_info;
+        1 <= headroom t_info;
         outlier_compatible g outlier;
         exterior_compatible g outlier v)
     PARAMS (ti; p; exterior2val g v)
@@ -530,7 +542,7 @@ Definition int_mutable_update_spec :=
          it: interior_t, outlier: outlier_t, rh: remset_heap
   PRE [tptr thread_info_type, tptr int_or_ptr_type, int_or_ptr_type]
   PROP (writable_share sh;
-        info_recordable t_info;
+        1 <= headroom t_info;
         graph_heap_compatible g (ti_heap t_info).(pt_heap);
         remset_heap_and_heap_compatible rh (ti_heap t_info).(pt_heap);
         mutable_location_compatible g it;
@@ -585,9 +597,7 @@ Definition garbage_collect_spec :=
           garbage_collect_condition g' (ti_heap t_info').(pt_heap);
           safe_to_copy_heap g' (ti_heap t_info').(pt_heap);
           frame_shells_eq (ti_frames t_info) (ti_frames t_info');
-          Ptrofs.unsigned (ti_nalloc t_info) <=
-                 available_space (heap_head (ti_heap t_info').(pt_heap))
-                    - used_space (heap_head (ti_heap t_info').(pt_heap)))
+          Ptrofs.unsigned (ti_nalloc t_info) <= headroom t_info')
     RETURN ()
     SEP (mem_mgr gv;
          all_string_constants rsh gv;

--- a/CertiGC/gc_spec.v
+++ b/CertiGC/gc_spec.v
@@ -564,6 +564,17 @@ Definition int_mutable_update_spec :=
          before_gc_thread_info_rep sh t_info' ti;
          heap_remset_rep g' (ti_heap t_info').(pt_heap) rh').
 
+Definition gc_sep (rsh sh : share) (gv : globals) (ti : val)
+    (g : LGraph) (t_info : thread_info) (outlier : outlier_t)
+    (rh : remset_heap) (rmst : remset) : mpred :=
+  mem_mgr gv *
+  all_string_constants rsh gv *
+  outlier_rep outlier *
+  graph_rep g *
+  heap_remset_rep g (pt_heap (ti_heap t_info)) rh *
+  remset_rep sh g rmst *
+  before_gc_thread_info_rep sh t_info ti.
+
 Definition garbage_collect_spec :=
   DECLARE _garbage_collect
   WITH rsh: share, sh: share, gv: globals, ti: val,
@@ -574,18 +585,11 @@ Definition garbage_collect_spec :=
     PROP (readable_share rsh; writable_share sh;
           full_gc g (ti_heap t_info).(pt_heap)
             (frames2rootpairs (ti_frames t_info)) roots outlier;
-          no_unrecorded_backward_edge g rh;
-          remset_compatible g outlier O rmst rh (ti_heap t_info).(pt_heap);
-          remset_generation_compatible O rmst rh)
+          remembered_set_ok O g (ti_heap t_info).(pt_heap)
+            outlier rh rmst)
     PARAMS (ti)
     GLOBALS (gv)
-    SEP (mem_mgr gv;
-         all_string_constants rsh gv;
-         outlier_rep outlier;
-         graph_rep g;
-         heap_remset_rep g (ti_heap t_info).(pt_heap) rh;
-         remset_rep sh g rmst;
-         before_gc_thread_info_rep sh t_info ti)
+    SEP (gc_sep rsh sh gv ti g t_info outlier rh rmst)
   POST [tvoid]
     EX g': LGraph, EX t_info': thread_info, EX roots': roots_t,
     EX rh': remset_heap, EX rmst': remset,
@@ -597,13 +601,7 @@ Definition garbage_collect_spec :=
           frame_shells_eq (ti_frames t_info) (ti_frames t_info');
           Ptrofs.unsigned (ti_nalloc t_info) <= headroom t_info')
     RETURN ()
-    SEP (mem_mgr gv;
-         all_string_constants rsh gv;
-         outlier_rep outlier;
-         graph_rep g';
-         heap_remset_rep g' (ti_heap t_info').(pt_heap) rh';
-         remset_rep sh g' rmst';
-         before_gc_thread_info_rep sh t_info' ti).
+    SEP (gc_sep rsh sh gv ti g' t_info' outlier rh' rmst').
 
 Definition Gprog: funspecs :=
   ltac:(with_library prog

--- a/CertiGC/gc_spec.v
+++ b/CertiGC/gc_spec.v
@@ -482,16 +482,20 @@ Definition resume_spec :=
          graph_rep g;
          before_gc_thread_info_rep sh t_info ti).
 
-(* TODO *)
 Definition decr_info_nursery (ti: thread_info) (x: val): thread_info :=
-  if isptr_dec x then ti else ti.
-    (* Build_thread_info (ti_heap_p ti) (incr_remset_heap (ti_heap ti).(pt_heap) 0) *)
-    (*   (ti_args ti) (arg_size ti) (ti_frames ti) (ti_nalloc ti). *)
+  if isptr_dec x then
+    Build_thread_info
+      (ti_heap_p ti)
+      (build_compatible_heap (incr_remset_heap (ti_heap ti).(pt_heap) 0))
+      (ti_args ti) (arg_size ti) (ti_frames ti) (ti_nalloc ti)
+  else ti.
 
 Definition mtb_upd_remset_heap (x: val) (item: remset_space_item) (rh: remset_heap) : remset_heap :=
   if isptr_dec x then upd_remset_heap item rh O else rh.
 
-Definition info_recordable (ti: thread_info): Prop := True.
+Definition info_recordable (ti: thread_info): Prop :=
+  let nursery := heap_head (ti_heap ti).(pt_heap) in
+  used_space nursery < available_space nursery.
 
 Definition ext_mutable_update_spec :=
   DECLARE _mutable_update
@@ -562,9 +566,10 @@ Definition int_mutable_update_spec :=
   PRE [tptr thread_info_type, tptr int_or_ptr_type, int_or_ptr_type]
   PROP (writable_share sh;
         info_recordable t_info;
-        outlier_compatible g outlier;
-        exterior_compatible g outlier v;
-        interior_compatible g O it)
+        graph_heap_compatible g (ti_heap t_info).(pt_heap);
+        remset_heap_and_heap_compatible rh (ti_heap t_info).(pt_heap);
+        mutable_location_compatible g it;
+        exterior_compatible g outlier v)
     PARAMS (ti; interior_address it g; exterior2val g v)
     GLOBALS ()
     SEP (graph_rep g;
@@ -573,9 +578,9 @@ Definition int_mutable_update_spec :=
          heap_remset_rep g (ti_heap t_info).(pt_heap) rh)
   POST [tvoid]
     EX g': LGraph, EX t_info': thread_info, EX rh': remset_heap,
-    PROP (t_info' = decr_info_nursery t_info (exterior2val g v);
-          rh' = mtb_upd_remset_heap (exterior2val g v) (RemSetInterior it) rh
-          (* relation or function about g and g' *))
+    PROP (mutable_graph_update g it v g';
+          t_info' = decr_info_nursery t_info (exterior2val g v);
+          rh' = mtb_upd_remset_heap (exterior2val g v) (RemSetInterior it) rh)
     RETURN ()
     SEP (graph_rep g';
          outlier_rep outlier;
@@ -677,4 +682,5 @@ Definition Gprog: funspecs :=
                       create_heap_spec;
                       make_tinfo_spec;
                       resume_spec;
+                      int_mutable_update_spec;
                       garbage_collect_spec]).

--- a/CertiGC/gc_spec.v
+++ b/CertiGC/gc_spec.v
@@ -572,10 +572,9 @@ Definition garbage_collect_spec :=
        rh: remset_heap, rmst: remset
   PRE [tptr thread_info_type]
     PROP (readable_share rsh; writable_share sh;
-          super_compatible g (ti_heap t_info).(pt_heap) (frames2rootpairs (ti_frames t_info)) roots outlier;
-          garbage_collect_condition g (ti_heap t_info).(pt_heap);
+          full_gc g (ti_heap t_info).(pt_heap)
+            (frames2rootpairs (ti_frames t_info)) roots outlier;
           no_unrecorded_backward_edge g rh;
-          safe_to_copy_heap g (ti_heap t_info).(pt_heap);
           remset_compatible g outlier O rmst rh (ti_heap t_info).(pt_heap);
           remset_generation_compatible O rmst rh)
     PARAMS (ti)
@@ -590,12 +589,11 @@ Definition garbage_collect_spec :=
   POST [tvoid]
     EX g': LGraph, EX t_info': thread_info, EX roots': roots_t,
     EX rh': remset_heap, EX rmst': remset,
-    PROP (super_compatible g' (ti_heap t_info').(pt_heap) (frames2rootpairs (ti_frames t_info')) roots' outlier;
+    PROP (full_gc g' (ti_heap t_info').(pt_heap)
+            (frames2rootpairs (ti_frames t_info')) roots' outlier;
           garbage_collect_relation roots roots'
             g (ti_heap t_info).(pt_heap) rh rmst
             g' (ti_heap t_info').(pt_heap) rh' rmst';
-          garbage_collect_condition g' (ti_heap t_info').(pt_heap);
-          safe_to_copy_heap g' (ti_heap t_info').(pt_heap);
           frame_shells_eq (ti_frames t_info) (ti_frames t_info');
           Ptrofs.unsigned (ti_nalloc t_info) <= headroom t_info')
     RETURN ()

--- a/CertiGC/mutable_update_design.md
+++ b/CertiGC/mutable_update_design.md
@@ -1,0 +1,235 @@
+# `mutable_update` design decisions
+
+This note records the decisions made before implementing the unfinished
+`mutable_update` specification and proof.  It is intentionally a design note,
+not a substitute for the Coq definitions.
+
+## Scope
+
+- Verify writes to cells inside `graph_rep` only.  The exterior-cell spec is
+  out of scope for now.
+- A source field may belong to any generation, including generation 0.  The
+  write-barrier contract must not require `vgeneration src <> 0`.
+- The source must still be a real, writable, scannable graph field.  Define a
+  mutation-specific compatibility predicate equivalent to
+  `interior_compatible` without its generation inequality.  In particular it
+  retains source-vertex validity, field bounds, `raw_mark = false`, and
+  `raw_tag < NO_SCAN_TAG`.
+- The new value remains an `exterior_t` and must satisfy the existing
+  `exterior_compatible` condition.
+
+## Public and concrete layers
+
+Keep `it : interior_t` as the public logical location because it is already
+shared by `interior_address`, `FwdPntIntr`, and `RemSetInterior`.  Since
+`InteriorVertexPos` is the only constructor, it contains exactly the same
+information as a pair `(src, pos)`.
+
+Use two layers:
+
+```coq
+internal_write_at :
+  LGraph -> VType -> Z -> exterior_t -> LGraph -> Prop
+
+mutable_graph_update :
+  LGraph -> interior_t -> exterior_t -> LGraph -> Prop
+```
+
+The public relation just matches `InteriorVertexPos src pos` and delegates to
+`internal_write_at g src pos`.
+
+Both relations are concrete graph-transition definitions.  They must not
+depend on `sound_gc_graph` or on anything from `gc_correct.v`.
+
+## Concrete graph transition
+
+For a valid position, let:
+
+```coq
+e := (src, Z.to_nat pos)
+```
+
+The relation distinguishes the following cases in order to reuse existing
+graph operations and proofs:
+
+1. The old raw field is `RawInternal` and the new value is
+   `ExteriorVertex dst`: use `labeledgraph_gen_dst g e dst` directly.  This
+   preserves direct reuse of the existing `lgd_*` algebraic, compatibility,
+   and spatial ramification lemmas.
+2. The old raw field is not `RawInternal` and the new value is
+   `ExteriorVertex dst`: update the source raw field to `RawInternal`, use
+   `labeledgraph_add_edge` for `e`, and use `labeledgraph_vgen` for the source
+   label.
+3. The new value is `ExteriorUnboxed z` or `ExteriorOutlier p`: update the
+   source raw field accordingly, remove `e` (removal is harmless if it was not
+   valid), and use `labeledgraph_vgen` for the source label.
+
+Introduce a concrete relation such as `raw_vertex_field_update` to state that
+the new `raw_vertex_block` has
+
+```coq
+raw_fields rvb' = upd_Znth pos (raw_fields rvb) new_raw_field
+```
+
+and that its mark, copied vertex, color, and tag are unchanged.  This avoids
+putting dependent proof fields from `raw_vertex_block` into the public spec.
+
+The generic graph library already supplies `labeledgraph_vgen`,
+`labeledgraph_add_edge`, `pregraph_remove_edge`, and
+`labeledgraph_gen_dst`.  Only a thin labeled-graph removal wrapper and the
+CertiGC-specific synchronization between `raw_fields` and edges are missing.
+
+## Separation from graph correctness
+
+The transition definition operates on the actual `LGraph` components and the
+generic `vvalid`/`evalid` update operations.  It does not assume that
+`vvalid = graph_has_v` or `evalid = graph_has_e`.
+
+Preservation is a later theorem in `gc_correct.v`, of the form:
+
+```coq
+sound_gc_graph g ->
+mutable_graph_update g it new g' ->
+(* compatibility of the location and new value *) ->
+sound_gc_graph g'.
+```
+
+Pure transition definitions belong in `GCGraph.v`; spatial update lemmas
+belong in `spatial_gcgraph.v`; soundness preservation belongs in
+`gc_correct.v`; `gc_spec.v` should only refer to the public relation.
+
+## Required derived facts
+
+- The transition is deterministic on compatible inputs.
+- Vertices, generations, addresses, headers, and all unrelated fields and
+  edges are unchanged.
+- `sound_gc_graph`, graph/heap compatibility, outlier compatibility, and the
+  relevant spatial representations are preserved under their proper
+  hypotheses.
+- When a write creates a new old-to-young internal edge, recording
+  `RemSetInterior it` in remset generation 0 supplies witness `k = 0` for the
+  current indexed `no_unrecorded_backward_edge` invariant.
+
+## Mutator/collector pointer handoff
+
+The C program intentionally maintains two phase-specific views of the nursery
+allocation/remset boundary:
+
+- while the mutator is running, `ti->alloc` and `ti->limit` are authoritative;
+- at entry to `garbage_collect` (and `garbage_collect_all`), those values are
+  published to `h->spaces[0].next` and `h->spaces[0].limit`;
+- while the collector is running, the space descriptor is authoritative;
+- `resume` copies the resulting nursery pointers back to `thread_info`.
+
+Consequently, mutator-phase `before_gc_thread_info_rep` must not require the
+possibly stale nursery descriptor's `next` or `limit` fields to equal the
+active abstract boundary.  Keep the `thread_info` fields exact, keep
+`total_space` exact, and hide both nursery descriptor fields (the representation
+already hides `next`; `limit` should be hidden in the same way).  The abstract
+`available_space` continues to describe the authoritative mutator boundary and
+the split between unused space and the remembered set.
+
+The collector-entry stores establish the full exact heap descriptor before any
+collector operation consumes it.  Correctness of this handoff is a spatial
+representation fact, not a change to the C collector algorithm.
+
+## Authoritative remset state
+
+For this work, keep the existing `heap` and `thread_info` record definitions
+unchanged.  In particular, do not remove `heap.rs_heap`, because doing so would
+cause broad, unrelated changes to existing proofs.
+
+Treat the separately supplied `rh : remset_heap` as the sole authoritative
+description of remembered-set contents.  It is the state used by
+`heap_remset_rep`, the remset correctness invariants, and the collector
+relations.  The `rs_heap` stored inside `thread_info.ti_heap` is only a
+dependent-record compatibility witness for `pt_heap`; this work does not
+require it to equal the external `rh` or preserve the same entries.
+
+This interpretation agrees with the existing garbage-collector proof, which
+constructs a new thread-info heap with `build_compatible_heap h` while tracking
+the actual remembered set separately as `rh`.
+
+Consequently, the pointer-valued branch of `mutable_update` should:
+
+1. update the authoritative nursery boundary with
+   `incr_remset_heap ... 0` in `pt_heap`;
+2. rebuild the enclosing `heap` with `build_compatible_heap` (or an equivalent
+   compatibility-only constructor), leaving the rest of the thread-info shell
+   unchanged; and
+3. update the authoritative external remembered set with
+   `upd_remset_heap (RemSetInterior it) rh 0`.
+
+The nonpointer branch leaves both the thread info and external `rh` unchanged.
+
+## Funspec boundary
+
+The mutable-update funspec describes a well-formed CertiGC runtime state, so
+its PRE includes
+
+```coq
+graph_heap_compatible g (pt_heap (ti_heap t_info))
+```
+
+This is a justified representation-level condition rather than an optional
+global correctness property: the graph objects occupy the generation spaces
+described by the heap, and their used/available regions must agree.  Keeping
+this condition also permits direct reuse of the existing graph/heap spatial
+lemmas.
+
+The PRE also unconditionally requires a recordable nursery,
+
+```coq
+used_space nursery < available_space nursery
+```
+
+because the C assertion precedes the pointer test, and it requires the
+authoritative external remset to match the heap layout:
+
+```coq
+remset_heap_and_heap_compatible rh (pt_heap (ti_heap t_info))
+```
+
+Together with the previously settled writable-share, mutation-location, and
+new-value compatibility conditions, these are the operational and
+representation-level premises of the base funspec.
+
+The POST records only the actual deterministic effects:
+
+- `mutable_graph_update g it new g'`;
+- the pointer-conditional thread-info/nursery-boundary transition; and
+- the pointer-conditional update of external `rh` with
+  `RemSetInterior it` in generation 0.
+
+Do not place `sound_gc_graph`, `no_unrecorded_backward_edge`, full
+`remset_compatible`, `remset_generation_compatible`, or similar global GC
+properties directly in the VST PRE/POST.  Prove them as ordinary conditional
+preservation theorems from the transition relation and whatever old invariant
+the caller has.  In particular, the mutable-update funspec does not need to
+carry `rmst` or `remset_rep`.  Since `mutable_update` has no loop, keeping these
+pure arguments outside the VST body proof should remain straightforward and
+gives the funspec the weaker, more reusable interface.
+
+### Deferred cleanup (explicitly out of scope)
+
+There is a longer-term modeling cleanup available: remove the redundant
+internal `rs_heap`, or redesign the abstract state so that the part heap,
+remembered set, and their compatibility proof have exactly one authoritative
+owner.  That refactor would change widely used record types and require
+substantial reproving.  It is deliberately **not part of the current
+`mutable_update` task** and must not be mixed into this implementation.
+
+## Still open
+
+The specification semantics are settled.  The following are implementation
+and proof tasks, not remaining design choices:
+
+- implement the settled capacity condition replacing
+  `info_recordable := True`;
+- implementation of the settled mutator/collector handoff representation and
+  the localized repairs to `verif_resume.v` and `verif_garbage_collect.v`;
+- implementation of the settled abstract `thread_info` transition currently
+  stubbed by `decr_info_nursery`;
+- implement the graph transition, spatial update lemmas, and conditional
+  preservation theorems;
+- registration of the final funspec and the VST body proof.

--- a/CertiGC/mutable_update_design.md
+++ b/CertiGC/mutable_update_design.md
@@ -109,6 +109,32 @@ belong in `spatial_gcgraph.v`; soundness preservation belongs in
 - When a write creates a new old-to-young internal edge, recording
   `RemSetInterior it` in remset generation 0 supplies witness `k = 0` for the
   current indexed `no_unrecorded_backward_edge` invariant.
+- Prove component preservation lemmas sufficient to re-establish every
+  model-level `PROP` premise of `garbage_collect_spec`, including
+  `super_compatible`, `garbage_collect_condition`, `safe_to_copy_heap`, and
+  the remset invariants, for the pointer-conditional updated graph, heap, and
+  authoritative remset.
+- Package those component lemmas into a collector-entry closure theorem: the
+  old `garbage_collect_spec` model-level `PROP` premises together with the
+  operational premises and transition of `mutable_update` imply the
+  corresponding `PROP` premises for the updated state.  This theorem is an
+  external bridge between the weak mutator funspec and the collector boundary;
+  it does not strengthen or change either settled specification.
+- At the spec-facing layer, provide a thin corollary that instantiates the
+  abstract conditional heap/remset transition with the actual POST equations
+  for `decr_info_nursery` and `mtb_upd_remset_heap`; the definition of
+  `decr_info_nursery` also leaves `ti_frames` unchanged.
+- Prove that `remset_rep sh g rmst` can be rewritten for the updated graph by
+  address preservation.  The share premises, `mem_mgr`, and string constants
+  are unchanged environmental resources carried across the call (with the
+  spatial resources framed), rather than effects derived from the graph
+  transition.
+
+`sound_gc_graph` remains a separately preserved global semantic property.  It
+is intentionally not included in the collector-entry closure theorem for the
+model-level state premises of `garbage_collect_spec`.  The readable/writable
+share premises are unchanged caller facts, and `decr_info_nursery`
+definitionally preserves the frames used to instantiate `rootpairs`.
 
 ## Mutator/collector pointer handoff
 
@@ -219,17 +245,13 @@ owner.  That refactor would change widely used record types and require
 substantial reproving.  It is deliberately **not part of the current
 `mutable_update` task** and must not be mixed into this implementation.
 
-## Still open
+## Implementation status
 
-The specification semantics are settled.  The following are implementation
-and proof tasks, not remaining design choices:
-
-- implement the settled capacity condition replacing
-  `info_recordable := True`;
-- implementation of the settled mutator/collector handoff representation and
-  the localized repairs to `verif_resume.v` and `verif_garbage_collect.v`;
-- implementation of the settled abstract `thread_info` transition currently
-  stubbed by `decr_info_nursery`;
-- implement the graph transition, spatial update lemmas, and conditional
-  preservation theorems;
-- registration of the final funspec and the VST body proof.
+The settled capacity condition, mutator/collector handoff representation,
+abstract `thread_info` transition, concrete graph transition, spatial update
+lemmas, conditional preservation theorems, final funspec, and VST body proof
+have been implemented.  The collector-premise component lemmas, the
+`remset_rep` address-preservation rewrite, and the collector-entry closure
+theorem, including its spec-facing `thread_info` corollary, have also been
+proved.  These proofs complete the agreed scope without changing the settled
+definitions or moving the global invariants into the base funspec.

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -1410,10 +1410,7 @@ Lemma graph_generation_vertex_update_ramif:
 Proof.
   intros g g' v Hglabel Hvertex Hgen.
   unfold graph_rep.
-  assert (Hlength:
-    length (g_gen (glabel g')) = length (g_gen (glabel g))).
-  { now rewrite Hglabel. }
-  rewrite Hlength.
+  rewrite Hglabel.
   apply iter_sepcon_ramif_pred_1.
   remember (nat_inc_list (length (g_gen (glabel g)))) as generations.
   assert (Hin: In (vgeneration v) generations).
@@ -1515,15 +1512,13 @@ Lemma graph_rep_mutable_update_ramif:
        graph_rep g').
 Proof.
   intros g src pos new g' Hloc Hupd.
-  destruct Hloc as [Hsrc [Hpos [Hmark Htag]]].
-  assert (Hloc': mutable_location_compatible
-                   g (InteriorVertexPos src pos)) by
-    (exact (conj Hsrc (conj Hpos (conj Hmark Htag)))).
+  pose proof Hloc as Hloc_parts.
+  destruct Hloc_parts as [Hsrc [Hpos [Hmark Htag]]].
   apply graph_rep_vertex_field_update_ramif.
   - eapply mutable_graph_update_glabel; eassumption.
   - intros sh v Hneq.
     exact (mutable_graph_update_vertex_rep_other
-             g src pos new g' sh v Hneq Hloc' Hupd).
+             g src pos new g' sh v Hneq Hloc Hupd).
   - exact Hsrc.
   - rewrite fields_eq_length. exact Hpos.
   - eapply mutable_graph_update_vertex_address; eassumption.

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -1763,54 +1763,6 @@ Proof.
   reflexivity.
 Qed.
 
-#[local] Lemma lmc_generation_rep_not_eq: forall (g : LGraph) (v new_v : VType) (x : nat),
-    x <> vgeneration v ->
-    generation_rep g x = generation_rep (lgraph_mark_copied g v new_v) x.
-Proof.
-  intros. unfold generation_rep. unfold nth_sh, nth_gen. simpl.
-  remember (nat_inc_list (number_of_vertices (nth x (g_gen (glabel g)) null_info))).
-  apply iter_sepcon_func_strong. intros. destruct x0 as [n m].
-  apply list_in_map_inv in H0. destruct H0 as [x0 [? ?]]. inversion H0. subst n x0.
-  clear H0. remember (generation_sh (nth x (g_gen (glabel g)) null_info)) as sh.
-  rewrite lmc_vertex_rep_not_eq. 1: reflexivity. intro. destruct v. simpl in *.
-  inversion H0. subst. contradiction.
-Qed.
-
-#[local] Lemma graph_gen_lmc_ramif: forall g v new_v,
-    graph_has_gen g (vgeneration v) ->
-    graph_rep g |-- generation_rep g (vgeneration v) *
-    (generation_rep (lgraph_mark_copied g v new_v) (vgeneration v) -*
-                    graph_rep (lgraph_mark_copied g v new_v)).
-Proof.
-  intros. unfold graph_rep. simpl. apply iter_sepcon_ramif_pred_1.
-  red in H. rewrite <- nat_inc_list_In_iff in H. apply In_Permutation_cons in H.
-  destruct H as [f ?]. exists f. split. 1: assumption. intros.
-  assert (NoDup (vgeneration v :: f)) by
-      (apply (Permutation_NoDup H), nat_inc_list_NoDup). apply NoDup_cons_2 in H1.
-  rewrite <- lmc_generation_rep_not_eq. 1: reflexivity. intro. subst. contradiction.
-Qed.
-
-#[local] Lemma gen_vertex_lmc_ramif: forall g gen index new_v,
-    gen_has_index g gen index ->
-    generation_rep g gen |-- vertex_rep (nth_sh g gen) g (gen, index) *
-    (vertex_rep (nth_sh g gen) (lgraph_mark_copied g (gen, index) new_v)
-                (gen, index) -*
-                generation_rep (lgraph_mark_copied g (gen, index) new_v) gen).
-Proof.
-  intros. unfold generation_rep. unfold nth_gen. simpl. apply iter_sepcon_ramif_pred_1.
-  change (nth gen (g_gen (glabel g)) null_info) with (nth_gen g gen).
-  remember (map (fun x : nat => (gen, x))
-                (nat_inc_list (number_of_vertices (nth_gen g gen)))).
-  assert (In (gen, index) l) by
-      (subst l; apply in_map; rewrite nat_inc_list_In_iff; assumption).
-  apply In_Permutation_cons in H0. destruct H0 as [f ?]. exists f. split.
-  1: assumption. intros. unfold nth_sh, nth_gen. simpl. rewrite lmc_vertex_rep_not_eq.
-  1: reflexivity. assert (NoDup l). {
-    subst l. apply FinFun.Injective_map_NoDup. 2: apply nat_inc_list_NoDup.
-    red. intros. inversion H2. reflexivity. }
-  apply (Permutation_NoDup H0), NoDup_cons_2 in H2. intro. subst. contradiction.
-Qed.
-
 Lemma graph_vertex_lmc_ramif: forall g v new_v,
     graph_has_v g v ->
     graph_rep g |-- vertex_rep (nth_sh g (vgeneration v)) g v *
@@ -1818,9 +1770,11 @@ Lemma graph_vertex_lmc_ramif: forall g v new_v,
                 (lgraph_mark_copied g v new_v) v -*
                 graph_rep (lgraph_mark_copied g v new_v)).
 Proof.
-  intros. destruct H. sep_apply (graph_gen_lmc_ramif g v new_v H).
-  destruct v as [gen index]. simpl vgeneration in *. simpl vindex in *.
-  sep_apply (gen_vertex_lmc_ramif g gen index new_v H0). cancel. apply wand_frame_ver.
+  intros g v new_v Hv.
+  apply graph_vertex_update_ramif.
+  - reflexivity.
+  - intros sh v' Hneq. symmetry. now apply lmc_vertex_rep_not_eq.
+  - exact Hv.
 Qed.
 
 #[local] Lemma lgd_vertex_rep_eq_in_diff_vert: forall sh g v' v v1 e n,
@@ -1838,77 +1792,6 @@ Proof.
     try reflexivity; assumption.
 Qed.
 
-#[local] Lemma lgd_gen_rep_eq_in_diff_gen: forall (g : LGraph) (v v' : VType) (x : nat) e n,
-    0 <= n < Zlength (make_fields g v) ->
-    Znth n (make_fields g v) = FieldEdge e ->
-    x <> vgeneration v ->
-     generation_rep g x = generation_rep (labeledgraph_gen_dst g e v') x.
-Proof.
-  intros. unfold generation_rep.
-  unfold nth_sh, nth_gen. simpl.
-  remember (nat_inc_list (number_of_vertices
-                            (nth x (g_gen (glabel g)) null_info))).
-  apply iter_sepcon_func_strong. intros v1 H2.
-  apply list_in_map_inv in H2.
-  destruct H2 as [x1 [? ?]].
-  remember (generation_sh (nth x (g_gen (glabel g)) null_info)) as sh.
-  assert (v1 <> v). {
-    intro. unfold vgeneration in H1.
-    rewrite H4 in H2. rewrite H2 in H1. unfold not in H1.
-    simpl in H1. lia. }
-  apply (lgd_vertex_rep_eq_in_diff_vert sh g v' v v1 e n); assumption.
-Qed.
-
-#[local] Lemma graph_gen_lgd_ramif: forall g v v' e n,
-    0 <= n < Zlength (make_fields g v) ->
-    Znth n (make_fields g v) = FieldEdge e ->
-    graph_has_gen g (vgeneration v) ->
-    graph_rep g |-- generation_rep g (vgeneration v) *
-    (generation_rep (labeledgraph_gen_dst g e v') (vgeneration v) -*
-                    graph_rep (labeledgraph_gen_dst g e v')).
-Proof.
-  intros. unfold graph_rep. simpl.
-  apply iter_sepcon_ramif_pred_1.
-  red in H1. rewrite <- nat_inc_list_In_iff in H1.
-  apply In_Permutation_cons in H1.
-  destruct H1 as [f ?]. exists f. split. 1: assumption. intros.
-  assert (NoDup (vgeneration v :: f)) by
-      (apply (Permutation_NoDup H1), nat_inc_list_NoDup).
-  apply NoDup_cons_2 in H3.
-  assert (x <> vgeneration v) by
-      (unfold not; intro; subst; contradiction).
-  apply (lgd_gen_rep_eq_in_diff_gen g v v' x e n); assumption.
-Qed.
-
-#[local] Lemma gen_vertex_lgd_ramif: forall g gen index new_v v n e,
-    gen_has_index g gen index ->
-0 <= n < Zlength (make_fields g v) ->
-       Znth n (make_fields g v) = FieldEdge e ->
-       v = (gen, index) ->
-    generation_rep g gen |-- vertex_rep (nth_sh g gen) g (gen, index) *
-    (vertex_rep (nth_sh g gen) (labeledgraph_gen_dst g e new_v)
-                (gen, index) -*
-                generation_rep (labeledgraph_gen_dst g e new_v) gen).
-Proof.
-  intros. unfold generation_rep. unfold nth_gen.
-  simpl. apply iter_sepcon_ramif_pred_1.
-  change (nth gen (g_gen (glabel g)) null_info) with (nth_gen g gen).
-  remember (map (fun x : nat => (gen, x))
-                (nat_inc_list (number_of_vertices (nth_gen g gen)))).
-  assert (In (gen, index) l) by
-      (subst l; apply in_map; rewrite nat_inc_list_In_iff; assumption).
-  apply In_Permutation_cons in H3. destruct H3 as [f ?]. exists f. split.
-  1: assumption. intros. unfold nth_sh, nth_gen. simpl.
-  remember (generation_sh (nth gen (g_gen (glabel g)) null_info)) as sh.
-  rewrite (lgd_vertex_rep_eq_in_diff_vert sh g new_v v x e n);
-    try reflexivity; try assumption.
-  assert (NoDup l). {
-    subst l. apply FinFun.Injective_map_NoDup. 2: apply nat_inc_list_NoDup.
-    red. intros. inversion H5. reflexivity. }
-  apply (Permutation_NoDup H3), NoDup_cons_2 in H5. intro.
-  rewrite H2 in H6. rewrite H6 in H4. intuition.
-Qed.
-
 Lemma graph_vertex_lgd_ramif: forall g v e v' n,
     0 <= n < Zlength (make_fields g v) ->
     Znth n (make_fields g v) = FieldEdge e ->
@@ -1918,13 +1801,12 @@ Lemma graph_vertex_lgd_ramif: forall g v e v' n,
                 (labeledgraph_gen_dst g e v') v -*
                 graph_rep (labeledgraph_gen_dst g e v')).
 Proof.
-  intros. destruct H1. sep_apply (graph_gen_lgd_ramif g v v' e n);
-                         try assumption.
-  destruct v as [gen index] eqn:?. simpl vgeneration in *.
-  simpl vindex in *. rewrite <- Heqv0 in H, H0.
-  sep_apply (gen_vertex_lgd_ramif g gen index v' v n e);
-    try assumption.
-  cancel. apply wand_frame_ver.
+  intros g v e v' n Hn He Hv.
+  apply graph_vertex_update_ramif.
+  - reflexivity.
+  - intros sh v1 Hneq.
+    now apply (lgd_vertex_rep_eq_in_diff_vert sh g v' v v1 e n).
+  - exact Hv.
 Qed.
 
 Definition space_struct_rep (sh: share) (heap_p: val) (h: part_heap) (gen: nat) :=

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -28,7 +28,7 @@ Definition vertex_field_hole
   SingletonHole.array_with_hole
     sh int_or_ptr_type pos (Zlength lst_fields) lst_fields p.
 
-Lemma vertex_at_field_hole_intro: forall sh p header lst_fields pos,
+#[local] Lemma vertex_at_field_hole_intro: forall sh p header lst_fields pos,
     0 <= pos < Zlength lst_fields ->
     vertex_at sh p header lst_fields |--
       data_at sh int_or_ptr_type (Znth pos lst_fields)
@@ -45,7 +45,7 @@ Proof.
   cancel.
 Qed.
 
-Lemma vertex_at_field_hole_elim: forall sh p header lst_fields pos new,
+#[local] Lemma vertex_at_field_hole_elim: forall sh p header lst_fields pos new,
     data_at sh int_or_ptr_type new
       (field_address
          (tarray int_or_ptr_type (Zlength lst_fields))
@@ -142,7 +142,7 @@ Definition heap_unused_rep (hp: part_heap): mpred := iter_sepcon hp.(spaces) spa
 Definition heap_remset_rep (g: LGraph) (h: part_heap) (rh : remset_heap) : mpred :=
   iter_sepcon (combine (spaces h) rh) (space_remset_rep g).
 
-Lemma remset_item_val_vertex_address_eq: forall g g' item,
+#[local] Lemma remset_item_val_vertex_address_eq: forall g g' item,
     (forall v, vertex_address g v = vertex_address g' v) ->
     remset_item_val g item = remset_item_val g' item.
 Proof.
@@ -150,7 +150,7 @@ Proof.
   now rewrite Haddr.
 Qed.
 
-Lemma space_remset_rep_vertex_address_eq: forall g g' sp rs,
+#[local] Lemma space_remset_rep_vertex_address_eq: forall g g' sp rs,
     (forall v, vertex_address g v = vertex_address g' v) ->
     space_remset_rep g (sp, rs) = space_remset_rep g' (sp, rs).
 Proof.
@@ -234,7 +234,7 @@ Proof. intros. destruct ext; simpl; reflexivity. Qed.
 Definition remset_rep (sh: share) (g: LGraph) (rmst: remset) : mpred :=
   iter_sepcon rmst (remset_ext_rep sh g).
 
-Lemma remset_ext_rep_vertex_address_eq: forall sh g g' ext,
+#[local] Lemma remset_ext_rep_vertex_address_eq: forall sh g g' ext,
     (forall v, vertex_address g v = vertex_address g' v) ->
     remset_ext_rep sh g ext = remset_ext_rep sh g' ext.
 Proof.
@@ -518,7 +518,7 @@ Proof.
   unfold WORD_SIZE. simpl sizeof. rewrite Z.max_r; auto.
 Qed.
 
-Lemma iter_sepcon_vertex_rep_ptrofs: forall g gen b i sh num,
+#[local] Lemma iter_sepcon_vertex_rep_ptrofs: forall g gen b i sh num,
     Vptr b i = gen_start g gen ->
     iter_sepcon (map (fun x : nat => (gen, x)) (nat_inc_list num)) (vertex_rep sh g)
                 |-- !! (WORD_SIZE * previous_vertices_size g gen num +
@@ -783,7 +783,7 @@ Proof.
   - first [now exists (Z.div Int.modulus 2) | now exists (Z.div Int64.modulus 2)].
 Qed.
 
-Lemma even_divided_odd_false: forall n z,
+#[local] Lemma even_divided_odd_false: forall n z,
     Z.even n = true -> (n | z) -> Z.odd z = false.
 Proof.
   intros. rewrite Zodd_mod. destruct (Zaux.Zeven_ex n) as [p ?].
@@ -792,7 +792,7 @@ Proof.
   rewrite Z_mod_mult; reflexivity.
 Qed.
 
-Lemma four_divided_tenth_pl_false: forall n i,
+#[local] Lemma four_divided_tenth_pl_false: forall n i,
     (4 | n) -> (n | Ptrofs.unsigned i) -> Ptrofs.testbit i 1 = false.
 Proof.
   intros. unfold Ptrofs.testbit. inversion H. inversion H0. rewrite H2. subst.
@@ -943,7 +943,7 @@ Qed.
 Definition generation_data_at_ g t_info gen :=
   data_at_ (nth_sh g gen) (tarray int_or_ptr_type (available_size t_info gen)) (gen_start g gen).
 
-Lemma gr_hrgda_data_at_: forall g h gen,
+#[local] Lemma gr_hrgda_data_at_: forall g h gen,
     graph_has_gen g gen ->
     graph_heap_compatible g h ->
     generation_rep g gen *
@@ -1017,7 +1017,7 @@ Qed.
 Definition total_gen_data_at_ g h gen :=
   data_at_ (nth_sh g gen) (tarray int_or_ptr_type (total_size h gen)) (gen_start g gen).
 
-Lemma gr_hrgda_srr_data_at_: forall g h rh gen,
+#[local] Lemma gr_hrgda_srr_data_at_: forall g h rh gen,
     graph_has_gen g gen ->
     graph_heap_compatible g h ->
     generation_rep g gen * heap_rest_gen_data_at_ g h gen *
@@ -1594,7 +1594,7 @@ Proof.
   rewrite data_at__eq, (data_at_singleton_array_eq _ _ (default_val tp)); reflexivity.
 Qed.
 
-Lemma field_compatible_int_or_ptr_integer_iff: forall p,
+#[local] Lemma field_compatible_int_or_ptr_integer_iff: forall p,
     field_compatible int_or_ptr_type [] p <->
     field_compatible (if Archi.ptr64 then tulong else tuint) [] p.
 Proof.
@@ -1613,7 +1613,7 @@ Proof.
           field_compatible_int_or_ptr_integer_iff. reflexivity.
 Qed.
 
-Lemma lacv_generation_rep_not_eq: forall g v to n,
+#[local] Lemma lacv_generation_rep_not_eq: forall g v to n,
     n <> to -> graph_has_gen g to -> no_dangling_dst g -> copy_compatible g ->
     generation_rep (lgraph_add_copied_v g v to) n = generation_rep g n.
 Proof.
@@ -1632,7 +1632,7 @@ Proof.
   - apply lacv_make_fields_vals_old; assumption.
 Qed.
 
-Lemma lacv_icgr_not_eq: forall l g v to,
+#[local] Lemma lacv_icgr_not_eq: forall l g v to,
     ~ In to l -> graph_has_gen g to -> no_dangling_dst g -> copy_compatible g ->
     iter_sepcon l (generation_rep (lgraph_add_copied_v g v to)) =
     iter_sepcon l (generation_rep g).
@@ -1643,7 +1643,7 @@ Proof.
   - intro. apply H. right. assumption.
 Qed.
 
-Lemma lacv_generation_rep_eq: forall g v to,
+#[local] Lemma lacv_generation_rep_eq: forall g v to,
     graph_has_v g v -> graph_has_gen g to -> no_dangling_dst g -> copy_compatible g ->
     generation_rep (lgraph_add_copied_v g v to) to =
     vertex_at (nth_sh g to) (vertex_address g (new_copied_v g to))
@@ -1755,7 +1755,7 @@ Proof.
     + rewrite Zlength_cons. rep_lia.
 Qed.
 
-Lemma lmc_vertex_rep_not_eq: forall sh g v new_v x,
+#[local] Lemma lmc_vertex_rep_not_eq: forall sh g v new_v x,
     x <> v -> vertex_rep sh (lgraph_mark_copied g v new_v) x = vertex_rep sh g x.
 Proof.
   intros. unfold vertex_rep. rewrite lmc_vertex_address, lmc_make_fields_vals_not_eq.
@@ -1763,7 +1763,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma lmc_generation_rep_not_eq: forall (g : LGraph) (v new_v : VType) (x : nat),
+#[local] Lemma lmc_generation_rep_not_eq: forall (g : LGraph) (v new_v : VType) (x : nat),
     x <> vgeneration v ->
     generation_rep g x = generation_rep (lgraph_mark_copied g v new_v) x.
 Proof.
@@ -1776,7 +1776,7 @@ Proof.
   inversion H0. subst. contradiction.
 Qed.
 
-Lemma graph_gen_lmc_ramif: forall g v new_v,
+#[local] Lemma graph_gen_lmc_ramif: forall g v new_v,
     graph_has_gen g (vgeneration v) ->
     graph_rep g |-- generation_rep g (vgeneration v) *
     (generation_rep (lgraph_mark_copied g v new_v) (vgeneration v) -*
@@ -1790,7 +1790,7 @@ Proof.
   rewrite <- lmc_generation_rep_not_eq. 1: reflexivity. intro. subst. contradiction.
 Qed.
 
-Lemma gen_vertex_lmc_ramif: forall g gen index new_v,
+#[local] Lemma gen_vertex_lmc_ramif: forall g gen index new_v,
     gen_has_index g gen index ->
     generation_rep g gen |-- vertex_rep (nth_sh g gen) g (gen, index) *
     (vertex_rep (nth_sh g gen) (lgraph_mark_copied g (gen, index) new_v)
@@ -1823,7 +1823,7 @@ Proof.
   sep_apply (gen_vertex_lmc_ramif g gen index new_v H0). cancel. apply wand_frame_ver.
 Qed.
 
-Lemma lgd_vertex_rep_eq_in_diff_vert: forall sh g v' v v1 e n,
+#[local] Lemma lgd_vertex_rep_eq_in_diff_vert: forall sh g v' v v1 e n,
     0 <= n < Zlength (make_fields g v) ->
     Znth n (make_fields g v) = FieldEdge e ->
     v1 <> v ->
@@ -1838,7 +1838,7 @@ Proof.
     try reflexivity; assumption.
 Qed.
 
-Lemma lgd_gen_rep_eq_in_diff_gen: forall (g : LGraph) (v v' : VType) (x : nat) e n,
+#[local] Lemma lgd_gen_rep_eq_in_diff_gen: forall (g : LGraph) (v v' : VType) (x : nat) e n,
     0 <= n < Zlength (make_fields g v) ->
     Znth n (make_fields g v) = FieldEdge e ->
     x <> vgeneration v ->
@@ -1859,7 +1859,7 @@ Proof.
   apply (lgd_vertex_rep_eq_in_diff_vert sh g v' v v1 e n); assumption.
 Qed.
 
-Lemma graph_gen_lgd_ramif: forall g v v' e n,
+#[local] Lemma graph_gen_lgd_ramif: forall g v v' e n,
     0 <= n < Zlength (make_fields g v) ->
     Znth n (make_fields g v) = FieldEdge e ->
     graph_has_gen g (vgeneration v) ->
@@ -1880,7 +1880,7 @@ Proof.
   apply (lgd_gen_rep_eq_in_diff_gen g v v' x e n); assumption.
 Qed.
 
-Lemma gen_vertex_lgd_ramif: forall g gen index new_v v n e,
+#[local] Lemma gen_vertex_lgd_ramif: forall g gen index new_v v n e,
     gen_has_index g gen index ->
 0 <= n < Zlength (make_fields g v) ->
        Znth n (make_fields g v) = FieldEdge e ->
@@ -2098,14 +2098,14 @@ Proof.
   apply wand_frame_intro.
 Qed.
 
-Lemma vertex_rep_reset: forall g i j x sh,
+#[local] Lemma vertex_rep_reset: forall g i j x sh,
     vertex_rep sh (reset_graph j g) (i, x) = vertex_rep sh g (i, x).
 Proof.
   intros. unfold vertex_rep.
   rewrite vertex_address_reset, make_header_reset, make_fields_reset. reflexivity.
 Qed.
 
-Lemma generation_rep_reset_diff: forall (g: LGraph) i j,
+#[local] Lemma generation_rep_reset_diff: forall (g: LGraph) i j,
     i <> j -> generation_rep (reset_graph j g) i = generation_rep g i.
 Proof.
   intros. unfold generation_rep. rewrite <- !iter_sepcon_map.
@@ -2113,7 +2113,7 @@ Proof.
   apply iter_sepcon_func; intros. apply vertex_rep_reset.
 Qed.
 
-Lemma generation_rep_reset_same: forall (g: LGraph) i,
+#[local] Lemma generation_rep_reset_same: forall (g: LGraph) i,
     graph_has_gen g i -> generation_rep (reset_graph i g) i = emp.
 Proof.
   intros. unfold generation_rep. rewrite <- !iter_sepcon_map.
@@ -2218,7 +2218,7 @@ Proof.
   rewrite if_true by assumption. rewrite emp_sepcon. reflexivity.
 Qed.
 
-Lemma vertex_rep_add: forall (g : LGraph) (gi : generation_info) v sh,
+#[local] Lemma vertex_rep_add: forall (g : LGraph) (gi : generation_info) v sh,
     graph_has_v g v -> copy_compatible g -> no_dangling_dst g ->
     vertex_rep sh g v = vertex_rep sh (lgraph_add_new_gen g gi) v.
 Proof.
@@ -2416,7 +2416,7 @@ Proof.
     + simpl. destruct (Val.eq _ _); [constructor; reflexivity | contradiction].
 Qed.
 
-Lemma fr_remset_ext_rep_eq: forall from to depth p sh g1 g2 rext,
+#[local] Lemma fr_remset_ext_rep_eq: forall from to depth p sh g1 g2 rext,
     graph_has_gen g1 to ->
     remset_ext_compatible' g1 rext ->
     forward_relation from to depth p g1 g2 ->

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -344,20 +344,6 @@ Definition roots_rep (sh: share) (roots: list rootpair) : mpred :=
 
 Definition frames_rep (sh: share) (frs: list frame) := frames_shell_rep sh frs * roots_rep sh (frames2rootpairs frs).
 
- Lemma data_at_tarray_field_compatible0:
- forall sh t s r,
- data_at sh (tarray t (Zlength s)) s r =
-!! field_compatible0 (tarray t (Zlength s)) [] r
- && data_at sh (tarray t (Zlength s)) s r.
-Proof.
- intros.
-apply pred_ext. apply andp_right; auto.
-unfold data_at, field_at. apply andp_left1.
-apply prop_derives. unfold field_compatible, field_compatible0.
-intuition.
-apply andp_left2; auto.
-Qed.
-
 Lemma frames_shell_rep_update:
  forall (sh: share) (frs: list frame) (rootvals: list val),
   Zlength rootvals = Zlength (frames2rootpairs frs) ->
@@ -1509,23 +1495,6 @@ Proof.
   rewrite (mutable_graph_update_make_fields_vals_other
              g src pos new g' v Hneq Hloc Hupd).
   reflexivity.
-Qed.
-
-Lemma mutable_graph_update_graph_vertex_ramif:
-  forall g src pos new g',
-    mutable_location_compatible g (InteriorVertexPos src pos) ->
-    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
-    graph_has_v g src ->
-    graph_rep g |-- vertex_rep (nth_sh g (vgeneration src)) g src *
-      (vertex_rep (nth_sh g (vgeneration src)) g' src -* graph_rep g').
-Proof.
-  intros g src pos new g' Hloc Hupd Hsrc.
-  apply graph_vertex_update_ramif.
-  - eapply mutable_graph_update_glabel; eassumption.
-  - intros sh v Hneq.
-    exact (mutable_graph_update_vertex_rep_other
-             g src pos new g' sh v Hneq Hloc Hupd).
-  - exact Hsrc.
 Qed.
 
 Lemma graph_rep_mutable_update_ramif:

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -2,6 +2,7 @@ Require Import VST.veric.compcert_rmaps.
 Require Import VST.msl.shares.
 Require Import VST.msl.wand_frame.
 Require Import VST.concurrency.conclib.
+Require Import VST.floyd.field_at_wand.
 Require Import CertiGraph.lib.List_ext.
 Require Import CertiGraph.msl_ext.log_normalize.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
@@ -20,8 +21,98 @@ Definition vertex_at (sh: share) (p: val) (header: Z) (lst_fields: list val) :=
                   (Z2val header) (offset_val (- WORD_SIZE) p) *
           data_at sh (tarray int_or_ptr_type (Zlength lst_fields)) lst_fields p).
 
+Definition vertex_field_hole
+    (sh: share) (p: val) (header: Z) (lst_fields: list val) (pos: Z): mpred :=
+  data_at sh (if Archi.ptr64 then tulong else tuint)
+          (Z2val header) (offset_val (- WORD_SIZE) p) *
+  SingletonHole.array_with_hole
+    sh int_or_ptr_type pos (Zlength lst_fields) lst_fields p.
+
+Lemma vertex_at_field_hole_intro: forall sh p header lst_fields pos,
+    0 <= pos < Zlength lst_fields ->
+    vertex_at sh p header lst_fields |--
+      data_at sh int_or_ptr_type (Znth pos lst_fields)
+        (field_address
+           (tarray int_or_ptr_type (Zlength lst_fields))
+           [ArraySubsc pos] p) *
+      vertex_field_hole sh p header lst_fields pos.
+Proof.
+  intros sh p header lst_fields pos Hpos.
+  unfold vertex_at, vertex_field_hole.
+  sep_apply
+    (SingletonHole.array_with_hole_intro
+       sh int_or_ptr_type pos (Zlength lst_fields) lst_fields p Hpos).
+  cancel.
+Qed.
+
+Lemma vertex_at_field_hole_elim: forall sh p header lst_fields pos new,
+    data_at sh int_or_ptr_type new
+      (field_address
+         (tarray int_or_ptr_type (Zlength lst_fields))
+         [ArraySubsc pos] p) *
+    vertex_field_hole sh p header lst_fields pos |--
+      vertex_at sh p header (upd_Znth pos lst_fields new).
+Proof.
+  intros sh p header lst_fields pos new.
+  unfold vertex_field_hole, vertex_at.
+  rewrite Zlength_upd_Znth.
+  sep_apply
+    (SingletonHole.array_with_hole_elim
+       sh int_or_ptr_type pos (Zlength lst_fields) new lst_fields p).
+  cancel.
+Qed.
+
+Opaque vertex_field_hole.
+
+Lemma vertex_at_field_update_ramif:
+  forall sh p header lst_fields pos new,
+    0 <= pos < Zlength lst_fields ->
+    vertex_at sh p header lst_fields |--
+      data_at sh int_or_ptr_type (Znth pos lst_fields)
+        (field_address
+           (tarray int_or_ptr_type (Zlength lst_fields))
+           [ArraySubsc pos] p) *
+      (data_at sh int_or_ptr_type new
+         (field_address
+            (tarray int_or_ptr_type (Zlength lst_fields))
+            [ArraySubsc pos] p) -*
+       vertex_at sh p header (upd_Znth pos lst_fields new)).
+Proof.
+  intros sh p header lst_fields pos new Hpos.
+  sep_apply (vertex_at_field_hole_intro sh p header lst_fields pos Hpos).
+  apply sepcon_derives; [apply derives_refl |].
+  apply wand_sepcon_adjoint.
+  rewrite sepcon_comm.
+  apply vertex_at_field_hole_elim.
+Qed.
+
+Transparent vertex_field_hole.
+
 Definition vertex_rep (sh: share) (g: LGraph) (v: VType): mpred :=
   vertex_at sh (vertex_address g v) (make_header g v) (make_fields_vals g v).
+
+Lemma vertex_rep_field_update_ramif:
+  forall sh g g' v pos new,
+    0 <= pos < Zlength (make_fields_vals g v) ->
+    vertex_address g' v = vertex_address g v ->
+    make_header g' v = make_header g v ->
+    make_fields_vals g' v =
+      upd_Znth pos (make_fields_vals g v) new ->
+    vertex_rep sh g v |--
+      data_at sh int_or_ptr_type (Znth pos (make_fields_vals g v))
+        (field_address
+           (tarray int_or_ptr_type (Zlength (make_fields_vals g v)))
+           [ArraySubsc pos] (vertex_address g v)) *
+      (data_at sh int_or_ptr_type new
+         (field_address
+            (tarray int_or_ptr_type (Zlength (make_fields_vals g v)))
+            [ArraySubsc pos] (vertex_address g v)) -*
+       vertex_rep sh g' v).
+Proof.
+  intros sh g g' v pos new Hpos Haddr Hheader Hfields.
+  unfold vertex_rep. rewrite Haddr, Hheader, Hfields.
+  apply vertex_at_field_update_ramif; exact Hpos.
+Qed.
 
 Definition generation_rep (g: LGraph) (gen: nat): mpred :=
   iter_sepcon (map (fun x => (gen, x))
@@ -50,6 +141,33 @@ Definition heap_unused_rep (hp: part_heap): mpred := iter_sepcon hp.(spaces) spa
 
 Definition heap_remset_rep (g: LGraph) (h: part_heap) (rh : remset_heap) : mpred :=
   iter_sepcon (combine (spaces h) rh) (space_remset_rep g).
+
+Lemma remset_item_val_vertex_address_eq: forall g g' item,
+    (forall v, vertex_address g v = vertex_address g' v) ->
+    remset_item_val g item = remset_item_val g' item.
+Proof.
+  intros g g' [p | [v pos]] Haddr; simpl; auto.
+  now rewrite Haddr.
+Qed.
+
+Lemma space_remset_rep_vertex_address_eq: forall g g' sp rs,
+    (forall v, vertex_address g v = vertex_address g' v) ->
+    space_remset_rep g (sp, rs) = space_remset_rep g' (sp, rs).
+Proof.
+  intros g g' sp rs Haddr. unfold space_remset_rep.
+  destruct (Val.eq (space_start sp) nullval); [reflexivity |].
+  f_equal. apply map_ext. intros.
+  now apply remset_item_val_vertex_address_eq.
+Qed.
+
+Lemma heap_remset_rep_vertex_address_eq: forall g g' h rh,
+    (forall v, vertex_address g v = vertex_address g' v) ->
+    heap_remset_rep g h rh = heap_remset_rep g' h rh.
+Proof.
+  intros g g' h rh Haddr. unfold heap_remset_rep.
+  apply iter_sepcon_func_strong. intros [sp rs] Hin.
+  now apply space_remset_rep_vertex_address_eq.
+Qed.
 
 Definition heap_remset_rep_except (g: LGraph) (h: part_heap)
            (rh : remset_heap) (gen: nat) : mpred :=
@@ -1224,6 +1342,220 @@ Proof.
   simpl. cancel. apply wand_frame_ver.
 Qed.
 
+Lemma generation_rep_vertex_update_eq_in_diff_gen:
+  forall g g' v gen,
+    glabel g' = glabel g ->
+    (forall sh v', v' <> v -> vertex_rep sh g v' = vertex_rep sh g' v') ->
+    gen <> vgeneration v ->
+    generation_rep g gen = generation_rep g' gen.
+Proof.
+  intros g g' v gen Hglabel Hvertex Hgen.
+  unfold generation_rep.
+  assert (Hnth: nth_gen g' gen = nth_gen g gen).
+  { unfold nth_gen. now rewrite Hglabel. }
+  assert (Hsh: nth_sh g' gen = nth_sh g gen).
+  { unfold nth_sh. now rewrite Hnth. }
+  rewrite Hnth, Hsh.
+  apply iter_sepcon_func_strong. intros v' Hin.
+  apply list_in_map_inv in Hin. destruct Hin as [index [? _]]. subst v'.
+  apply Hvertex. intro Heq. subst v.
+  simpl in Hgen. contradiction.
+Qed.
+
+Lemma generation_vertex_update_ramif:
+  forall g g' gen index,
+    glabel g' = glabel g ->
+    (forall sh v', v' <> (gen, index) ->
+       vertex_rep sh g v' = vertex_rep sh g' v') ->
+    gen_has_index g gen index ->
+    generation_rep g gen |--
+      vertex_rep (nth_sh g gen) g (gen, index) *
+      (vertex_rep (nth_sh g gen) g' (gen, index) -*
+       generation_rep g' gen).
+Proof.
+  intros g g' gen index Hglabel Hvertex Hindex.
+  unfold generation_rep.
+  assert (Hnth: nth_gen g' gen = nth_gen g gen).
+  { unfold nth_gen. now rewrite Hglabel. }
+  assert (Hsh: nth_sh g' gen = nth_sh g gen).
+  { unfold nth_sh. now rewrite Hnth. }
+  rewrite Hnth, Hsh.
+  apply iter_sepcon_ramif_pred_1.
+  remember
+    (map (fun x : nat => (gen, x))
+         (nat_inc_list (number_of_vertices (nth_gen g gen)))) as vertices.
+  assert (Hin: In (gen, index) vertices).
+  { subst vertices. apply in_map. rewrite nat_inc_list_In_iff. exact Hindex. }
+  apply In_Permutation_cons in Hin. destruct Hin as [rest Hperm].
+  exists rest. split; [exact Hperm |].
+  intros v' Hin'. apply Hvertex.
+  assert (Hnodup: NoDup vertices).
+  { subst vertices. apply FinFun.Injective_map_NoDup.
+    - intros x y Heq. now inversion Heq.
+    - apply nat_inc_list_NoDup. }
+  apply (Permutation_NoDup Hperm), NoDup_cons_2 in Hnodup.
+  intro Heq. subst v'. contradiction.
+Qed.
+
+Lemma graph_generation_vertex_update_ramif:
+  forall g g' v,
+    glabel g' = glabel g ->
+    (forall sh v', v' <> v -> vertex_rep sh g v' = vertex_rep sh g' v') ->
+    graph_has_gen g (vgeneration v) ->
+    graph_rep g |-- generation_rep g (vgeneration v) *
+      (generation_rep g' (vgeneration v) -* graph_rep g').
+Proof.
+  intros g g' v Hglabel Hvertex Hgen.
+  unfold graph_rep.
+  assert (Hlength:
+    length (g_gen (glabel g')) = length (g_gen (glabel g))).
+  { now rewrite Hglabel. }
+  rewrite Hlength.
+  apply iter_sepcon_ramif_pred_1.
+  remember (nat_inc_list (length (g_gen (glabel g)))) as generations.
+  assert (Hin: In (vgeneration v) generations).
+  { subst generations. rewrite nat_inc_list_In_iff. exact Hgen. }
+  apply In_Permutation_cons in Hin. destruct Hin as [rest Hperm].
+  exists rest. split; [exact Hperm |].
+  intros gen Hin'.
+  apply generation_rep_vertex_update_eq_in_diff_gen with (v := v); auto.
+  assert (Hnodup: NoDup generations) by
+    (subst generations; apply nat_inc_list_NoDup).
+  apply (Permutation_NoDup Hperm), NoDup_cons_2 in Hnodup.
+  intro Heq. subst gen. contradiction.
+Qed.
+
+Lemma graph_vertex_update_ramif:
+  forall g g' v,
+    glabel g' = glabel g ->
+    (forall sh v', v' <> v -> vertex_rep sh g v' = vertex_rep sh g' v') ->
+    graph_has_v g v ->
+    graph_rep g |-- vertex_rep (nth_sh g (vgeneration v)) g v *
+      (vertex_rep (nth_sh g (vgeneration v)) g' v -* graph_rep g').
+Proof.
+  intros g g' [gen index] Hglabel Hvertex [Hgen Hindex].
+  simpl in *.
+  sep_apply (graph_generation_vertex_update_ramif
+               g g' (gen, index) Hglabel Hvertex Hgen).
+  change
+    (generation_rep g gen * (generation_rep g' gen -* graph_rep g') |--
+     vertex_rep (nth_sh g gen) g (gen, index) *
+       (vertex_rep (nth_sh g gen) g' (gen, index) -* graph_rep g')).
+  sep_apply (generation_vertex_update_ramif
+               g g' gen index Hglabel Hvertex Hindex).
+  cancel. apply wand_frame_ver.
+Qed.
+
+Lemma graph_rep_vertex_field_update_ramif:
+  forall g g' v pos new,
+    glabel g' = glabel g ->
+    (forall sh v', v' <> v -> vertex_rep sh g v' = vertex_rep sh g' v') ->
+    graph_has_v g v ->
+    0 <= pos < Zlength (make_fields_vals g v) ->
+    vertex_address g' v = vertex_address g v ->
+    make_header g' v = make_header g v ->
+    make_fields_vals g' v =
+      upd_Znth pos (make_fields_vals g v) new ->
+    graph_rep g |--
+      data_at (nth_sh g (vgeneration v)) int_or_ptr_type
+        (Znth pos (make_fields_vals g v))
+        (field_address
+           (tarray int_or_ptr_type (Zlength (make_fields_vals g v)))
+           [ArraySubsc pos] (vertex_address g v)) *
+      (data_at (nth_sh g (vgeneration v)) int_or_ptr_type new
+         (field_address
+            (tarray int_or_ptr_type (Zlength (make_fields_vals g v)))
+            [ArraySubsc pos] (vertex_address g v)) -*
+       graph_rep g').
+Proof.
+  intros g g' v pos new Hglabel Hother Hv Hpos Haddr Hheader Hfields.
+  sep_apply (graph_vertex_update_ramif g g' v Hglabel Hother Hv).
+  sep_apply (vertex_rep_field_update_ramif
+               (nth_sh g (vgeneration v)) g g' v pos new
+               Hpos Haddr Hheader Hfields).
+  cancel. apply wand_frame_ver.
+Qed.
+
+Lemma mutable_graph_update_vertex_rep_other:
+  forall g src pos new g' sh v,
+    v <> src ->
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    vertex_rep sh g v = vertex_rep sh g' v.
+Proof.
+  intros g src pos new g' sh v Hneq Hloc Hupd.
+  unfold vertex_rep.
+  rewrite (mutable_graph_update_vertex_address
+             g (InteriorVertexPos src pos) new g' v Hloc Hupd).
+  rewrite (mutable_graph_update_make_header
+             g (InteriorVertexPos src pos) new g' v Hloc Hupd).
+  rewrite (mutable_graph_update_make_fields_vals_other
+             g src pos new g' v Hneq Hloc Hupd).
+  reflexivity.
+Qed.
+
+Lemma mutable_graph_update_graph_vertex_ramif:
+  forall g src pos new g',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    graph_has_v g src ->
+    graph_rep g |-- vertex_rep (nth_sh g (vgeneration src)) g src *
+      (vertex_rep (nth_sh g (vgeneration src)) g' src -* graph_rep g').
+Proof.
+  intros g src pos new g' Hloc Hupd Hsrc.
+  apply graph_vertex_update_ramif.
+  - eapply mutable_graph_update_glabel; eassumption.
+  - intros sh v Hneq.
+    exact (mutable_graph_update_vertex_rep_other
+             g src pos new g' sh v Hneq Hloc Hupd).
+  - exact Hsrc.
+Qed.
+
+Lemma graph_rep_mutable_update_ramif:
+  forall g src pos new g',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    graph_rep g |--
+      data_at (nth_sh g (vgeneration src)) int_or_ptr_type
+        (Znth pos (make_fields_vals g src))
+        (field_address
+           (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+           [ArraySubsc pos] (vertex_address g src)) *
+      (data_at (nth_sh g (vgeneration src)) int_or_ptr_type
+         (exterior2val g new)
+         (field_address
+            (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+            [ArraySubsc pos] (vertex_address g src)) -*
+       graph_rep g').
+Proof.
+  intros g src pos new g' Hloc Hupd.
+  destruct Hloc as [Hsrc [Hpos [Hmark Htag]]].
+  assert (Hloc': mutable_location_compatible
+                   g (InteriorVertexPos src pos)) by
+    (exact (conj Hsrc (conj Hpos (conj Hmark Htag)))).
+  apply graph_rep_vertex_field_update_ramif.
+  - eapply mutable_graph_update_glabel; eassumption.
+  - intros sh v Hneq.
+    exact (mutable_graph_update_vertex_rep_other
+             g src pos new g' sh v Hneq Hloc' Hupd).
+  - exact Hsrc.
+  - rewrite fields_eq_length. exact Hpos.
+  - eapply mutable_graph_update_vertex_address; eassumption.
+  - eapply mutable_graph_update_make_header; eassumption.
+  - eapply mutable_graph_update_make_fields_vals_src; eassumption.
+Qed.
+
+Lemma heap_remset_rep_mutable_graph_update:
+  forall g it new g' h rh,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    heap_remset_rep g h rh = heap_remset_rep g' h rh.
+Proof.
+  intros g it new g' h rh Hloc Hupd.
+  apply heap_remset_rep_vertex_address_eq. intros v.
+  symmetry. eapply mutable_graph_update_vertex_address; eassumption.
+Qed.
+
 Lemma heap_unused_rep_cut: forall (h: part_heap) i s (H1: 0 <= i < Zlength (spaces h))
                                 (H2: has_space (Znth i (spaces h)) s),
     space_start (Znth i (spaces h)) <> nullval ->
@@ -1818,6 +2150,18 @@ Definition space_token_rep (sp: space): mpred :=
 Definition ti_token_rep (h: part_heap) (p: val): mpred :=
   malloc_token Ews heap_type p * iter_sepcon (spaces h) space_token_rep.
 
+Lemma ti_token_rep_weak_heap_relation: forall h h' p,
+    weak_heap_relation h h' ->
+    ti_token_rep h p = ti_token_rep h' p.
+Proof.
+  intros h h' p [Hstart Htotal]. unfold ti_token_rep. f_equal.
+  apply (iter_sepcon_pointwise_eq _ _ _ _ null_space null_space).
+  - rewrite <- !ZtoNat_Zlength, !spaces_size. reflexivity.
+  - intros. fold (nth_space h i). fold (nth_space h' i).
+    unfold total_size in Htotal. unfold space_token_rep.
+    rewrite Hstart, Htotal. reflexivity.
+Qed.
+
 Lemma ti_token_rep_add: forall h p sp i (Hs: 0 <= i < MAX_SPACES),
     space_start (Znth i (spaces h)) = nullval ->
     space_start sp <> nullval ->
@@ -2328,7 +2672,7 @@ Definition heap_management_rep (sh: share) (ti: thread_info) : mpred :=
   let n_lim := offset_val (WORD_SIZE * nursery.(available_space)) p in
   let n_ttl := offset_val (WORD_SIZE * nursery.(total_space)) p in
   heap_struct_rep
-    sh ((p, (Vundef, (n_lim, n_ttl)))
+    sh ((p, (Vundef, (Vundef, n_ttl)))
           :: map space_quad (tl ti.(ti_heap).(pt_heap).(spaces))) ti.(ti_heap_p) *
     heap_unused_rep ti.(ti_heap).(pt_heap) *
     ti_token_rep (ti_heap ti).(pt_heap) (ti_heap_p ti).

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -234,6 +234,23 @@ Proof. intros. destruct ext; simpl; reflexivity. Qed.
 Definition remset_rep (sh: share) (g: LGraph) (rmst: remset) : mpred :=
   iter_sepcon rmst (remset_ext_rep sh g).
 
+Lemma remset_ext_rep_vertex_address_eq: forall sh g g' ext,
+    (forall v, vertex_address g v = vertex_address g' v) ->
+    remset_ext_rep sh g ext = remset_ext_rep sh g' ext.
+Proof.
+  intros sh g g' [p v | vertex v] Haddr; simpl; auto.
+  now rewrite Haddr.
+Qed.
+
+Lemma remset_rep_vertex_address_eq: forall sh g g' rmst,
+    (forall v, vertex_address g v = vertex_address g' v) ->
+    remset_rep sh g rmst = remset_rep sh g' rmst.
+Proof.
+  intros sh g g' rmst Haddr. unfold remset_rep.
+  apply iter_sepcon_func_strong. intros ext Hin.
+  now apply remset_ext_rep_vertex_address_eq.
+Qed.
+
 Lemma remset_rep_ramif_stable: forall sh g rmst rext,
     In rext rmst ->
     remset_rep sh g rmst |-- remset_ext_rep sh g rext *
@@ -1553,6 +1570,17 @@ Lemma heap_remset_rep_mutable_graph_update:
 Proof.
   intros g it new g' h rh Hloc Hupd.
   apply heap_remset_rep_vertex_address_eq. intros v.
+  symmetry. eapply mutable_graph_update_vertex_address; eassumption.
+Qed.
+
+Lemma remset_rep_mutable_graph_update:
+  forall sh g it new g' rmst,
+    mutable_location_compatible g it ->
+    mutable_graph_update g it new g' ->
+    remset_rep sh g rmst = remset_rep sh g' rmst.
+Proof.
+  intros sh g it new g' rmst Hloc Hupd.
+  apply remset_rep_vertex_address_eq. intros v.
   symmetry. eapply mutable_graph_update_vertex_address; eassumption.
 Qed.
 

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -12,7 +12,7 @@ Require Import CertiGraph.CertiGC.env_graph_gc.
 Require Import CertiGraph.msl_ext.iter_sepcon.
 Require Import Stdlib.Lists.List.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Definition vertex_at (sh: share) (p: val) (header: Z) (lst_fields: list val) :=
   Eval cbv delta [Archi.ptr64] match

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -2487,10 +2487,10 @@ Proof.
   cut (l1 = l3 /\ l2 = l4).
   - intros Heq. clear -Heq. destruct Heq. subst. apply wand_frame_intro.
   - pose proof spaces_size h. pose proof spaces_size (incr_remset_heap h (Z.of_nat gen)). split.
-    + subst. rewrite Znth_list_eq. split; [list_solve |].
+    + subst. apply List_ext.list_eq_Znth; [list_solve |].
       intros j Hj. rewrite !Znth_sublist; [|list_solve..].
       symmetry. apply irh_Znth_spaces_not_eq. lia.
-    + subst. rewrite Znth_list_eq. split; [list_solve |].
+    + subst. apply List_ext.list_eq_Znth; [list_solve |].
       intros j Hj. rewrite !Znth_sublist; [|list_solve..].
       symmetry. apply irh_Znth_spaces_not_eq. list_solve.
 Qed.

--- a/CertiGC/spatial_gcgraph.v
+++ b/CertiGC/spatial_gcgraph.v
@@ -2437,8 +2437,7 @@ Proof.
   intros from to sh g h g' h' rext Hghg Hcc Hrec Hfgh. Opaque forward_graph_and_heap.
   destruct rext as [out | vtx]; simpl in *; auto. unfold remset_ext2forward_t in Hfgh. simpl in Hfgh.
   f_equal. eapply fr_vertex_address; eauto.
-  - pose proof fr_forward_graph_and_heap from to O (ForwardVertex vtx) g h as Hfr.
-    rewrite <- Hfgh in Hfr. simpl in Hfr. eassumption. Transparent forward_graph_and_heap.
+  - eapply fr_forward_graph_and_heap_eq; exact Hfgh. Transparent forward_graph_and_heap.
   - symmetry in Hfgh. eapply fgh_O_closure_has_v_update_vertex; eassumption.
 Qed.
 
@@ -2462,8 +2461,7 @@ Proof.
   - clear e. subst. eapply fgh_remset_ext_rep_upd_eq; eassumption.
   - eapply fr_remset_ext_rep_eq; eauto.
     + apply Hrc. symmetry in Hperm. eapply Permutation_in; eauto. right. assumption.
-    + pose proof fr_forward_graph_and_heap from to O (remset_ext2forward_t rext) g h as Hfr.
-      rewrite <- Hfgh in Hfr. simpl in Hfr. eassumption.
+    + eapply fr_forward_graph_and_heap_eq; exact Hfgh.
 Qed.
 
 Lemma heap_rem_ramif: forall sh h p gen,
@@ -2513,12 +2511,16 @@ Proof.
   assert (Hghc': graph_heap_compatible g' h') by (eapply forward_graph_and_heap_ghc; eassumption).
   assert (Hlen': length rh = length (spaces h')) by (rewrite <- !ZtoNat_Zlength in *; lia).
   rewrite !heap_remset_rep_iter_sepcon; [|assumption..].
-  pose proof fr_forward_graph_and_heap from to depth p g h as Hfr. rewrite <- Hfgh in Hfr. simpl in Hfr.
+  pose proof (fr_forward_graph_and_heap_eq from to depth p g h g' h' Hfgh) as Hfr.
   pose proof fr_g_gen_len_presv depth from to p g g' Hghg Hfr as Hgenlen. rewrite <- Hgenlen.
   apply iter_sepcon_func_strong. intros gen Hgen. Transparent space_remset_rep. simpl.
   rewrite nat_inc_list_In_iff in Hgen. fold (graph_has_gen g gen) in Hgen.
-  pose proof heaprel_forward_graph_and_heap from to depth p g h as Hh. rewrite <- Hfgh in Hh. simpl in Hh.
-  destruct Hh as [Ha [Hs [Ht Hss]]]. unfold available_size in Ha. unfold total_size in Ht.
+  pose proof (heaprel_forward_graph_and_heap_eq from to depth p g h g' h' Hfgh) as Hh.
+  pose proof (heap_relation_available_size h h' gen Hh) as Ha.
+  pose proof (heap_relation_space_start h h' gen Hh) as Hs.
+  pose proof (heap_relation_total_size h h' gen Hh) as Ht.
+  pose proof (heap_relation_space_sh h h' gen Hh) as Hss.
+  unfold available_size in Ha. unfold total_size in Ht.
   rewrite <- Hs, <- Ha, <- Ht, <- Hss.
   cut (map (remset_item_val g) (nth_remset_space rh gen) =
          map (remset_item_val g') (nth_remset_space rh gen)).
@@ -2621,7 +2623,7 @@ Proof.
   apply iter_sepcon_func_strong. intros ext Hinx. hnf in Hrc. rewrite Forall_forall in Hrc.
   pose proof Hrc _ Hinx as Hrcext. destruct ext as [gp | gn]; simpl; auto. simpl in Hrcext. f_equal.
   apply (fr_vertex_address 0 from to item g g'); auto.
-  - pose proof fr_forward_graph_and_heap from to O item g h. rewrite <- Hfgh in H. simpl in H. assumption.
+  - eapply fr_forward_graph_and_heap_eq; exact Hfgh.
   - apply graph_has_v_in_closure. assumption.
 Qed.
 

--- a/CertiGC/verif_Is_from.v
+++ b/CertiGC/verif_Is_from.v
@@ -48,9 +48,9 @@ Definition Is_from_sem : extcall_sem :=
 Definition Is_from_sig : signature :=
   mksignature (AST.Xptr :: AST.Xptr :: AST.Xptr :: nil) AST.Xint cc_default.
 
-Ltac split3 := split; [|split ].
+#[local] Ltac split3 := split; [|split ].
 
-Lemma lt_ptr_mod: forall n1 n2,
+#[local] Lemma lt_ptr_mod: forall n1 n2,
     n1 <= n2 <= Ptrofs.max_unsigned -> n1 <= n2 < Ptrofs.modulus.
 Proof.
   intros.

--- a/CertiGC/verif_Is_from.v
+++ b/CertiGC/verif_Is_from.v
@@ -13,7 +13,7 @@ Require Import compcert.common.Values compcert.common.AST.
 Require Import compcert.lib.Integers.
 Require Import Stdlib.ZArith.BinInt Stdlib.Lists.List Stdlib.micromega.Lia.
 Import ListNotations.
-Local Open Scope Z_scope. Local Open Scope list_scope.
+#[local] Open Scope Z_scope. #[local] Open Scope list_scope.
 
 (* Verification of the function Is_from *)
 

--- a/CertiGC/verif_create_heap.v
+++ b/CertiGC/verif_create_heap.v
@@ -1,6 +1,6 @@
 From CertiGraph.CertiGC Require Import env_graph_gc gc_spec.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 
 Lemma data_at_heaptype_eq:  forall (sh: share) v h,

--- a/CertiGC/verif_create_heap.v
+++ b/CertiGC/verif_create_heap.v
@@ -3,7 +3,7 @@ From CertiGraph.CertiGC Require Import env_graph_gc gc_spec.
 #[local] Open Scope logic.
 
 
-Lemma data_at_heaptype_eq:  forall (sh: share) v h,
+#[local] Lemma data_at_heaptype_eq:  forall (sh: share) v h,
     isptr h -> 
     field_compatible heap_type [StructField _spaces] h ->
     @data_at CompSpecs sh heap_type v h = @data_at CompSpecs sh (tarray space_type MAX_SPACES) v h.
@@ -14,7 +14,7 @@ Proof.
   rewrite isptr_offset_val_zero; auto.
 Qed.
 
-Lemma split2_data_at_Tarray_space_type:
+#[local] Lemma split2_data_at_Tarray_space_type:
   forall (sh: share) (n n1: Z) (v: list (val * (val * (val*val)))) (p: val),
     0 <= n1 <= n -> n = Zlength v ->
     data_at sh (tarray space_type n) v p =
@@ -28,7 +28,7 @@ Proof.
   - rewrite sublist_same; auto.
 Qed.
 
-Lemma space_array_1_eq: forall (sh: share) (v: (val * (val * (val*val)))) (p: val),
+#[local] Lemma space_array_1_eq: forall (sh: share) (v: (val * (val * (val*val)))) (p: val),
     data_at sh (tarray space_type 1) [v] p = data_at sh space_type v p.
 Proof.
   intros. pose proof (data_at_singleton_array_eq sh space_type). apply H. reflexivity.

--- a/CertiGC/verif_create_space.v
+++ b/CertiGC/verif_create_space.v
@@ -1,6 +1,6 @@
 From CertiGraph.CertiGC Require Import env_graph_gc gc_spec.
 
-Local Open Scope Z_scope.
+#[local] Open Scope Z_scope.
 
 Lemma body_create_space: semax_body Vprog Gprog f_create_space create_space_spec.
 Proof.

--- a/CertiGC/verif_do_generation.v
+++ b/CertiGC/verif_do_generation.v
@@ -11,7 +11,7 @@ Require Import CertiGraph.msl_ext.iter_sepcon.
 Require Import CertiGraph.CertiGC.gc_spec.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Lemma fri_rootpairs_compatible:
   forall from to g h rh rmst item g' h' rh' rmst' rootpairs roots,

--- a/CertiGC/verif_do_generation.v
+++ b/CertiGC/verif_do_generation.v
@@ -148,7 +148,7 @@ Proof.
     + eapply (fri_rootpairs_compatible from to g h rh rmst a g2 h2 rh2 rmst2 rootpairs roots); eauto.
 Qed.
 
-Lemma heap_remset_zero_available_weak_valid: forall g h rh gen,
+#[local] Lemma heap_remset_zero_available_weak_valid: forall g h rh gen,
     graph_heap_compatible g h ->
     graph_has_gen g gen ->
     remset_heap_and_heap_compatible rh h ->
@@ -183,7 +183,7 @@ Proof.
     rep_lia.
 Qed.
 
-Lemma heap_unused_rep_reset_with_remset:
+#[local] Lemma heap_unused_rep_reset_with_remset:
   forall g h rg rhh rh gen,
     graph_heap_compatible g h ->
     graph_has_gen g gen ->

--- a/CertiGC/verif_do_generation.v
+++ b/CertiGC/verif_do_generation.v
@@ -85,16 +85,11 @@ Lemma forward_remset_item_fold_closure_has_v:
     closure_has_v g x ->
     closure_has_v g' x.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' x Hto Hfold Hcl; simpl in Hfold.
-  - now inversion Hfold.
-  - destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    pose proof Hfri2 as Hfri2'. unfold forward_remset_item in Hfri2'. simpl in Hfri2'.
-    rewrite Hfri2' in Hfold. symmetry in Hfri2.
-    assert (Hto2: graph_has_gen g2 to).
-    { rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri2 to). exact Hto. }
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' x Hto2 Hfold).
-    eapply (fri_closure_has_v from to g h rh rmst a g2 h2 rh2 rmst2 x); eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' x Hto Hfold Hcl.
+  eapply (forward_remset_item_fold_graph_property
+            (fun g0 => closure_has_v g0 x));
+    [| exact Hto | exact Hcl | exact Hfold].
+  intros. eapply fri_closure_has_v; eassumption.
 Qed.
 
 Lemma forward_remset_item_fold_vertex_address:
@@ -104,18 +99,16 @@ Lemma forward_remset_item_fold_vertex_address:
     closure_has_v g x ->
     vertex_address g x = vertex_address g' x.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' x Hto Hfold Hcl; simpl in Hfold.
-  - now inversion Hfold.
-  - destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    pose proof Hfri2 as Hfri2'. unfold forward_remset_item in Hfri2'. simpl in Hfri2'.
-    rewrite Hfri2' in Hfold. symmetry in Hfri2.
-    assert (Hto2: graph_has_gen g2 to).
-    { rewrite <- (forward_remset_item_ghg _ _ _ _ _ _ _ _ _ _ _ Hto Hfri2 to). exact Hto. }
-    assert (Hcl2: closure_has_v g2 x) by
-        (eapply (fri_closure_has_v from to g h rh rmst a g2 h2 rh2 rmst2 x); eauto).
-    rewrite <- (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' x Hto2 Hfold Hcl2).
-    eapply (fri_vertex_address from to g h rh rmst a g2 h2 rh2 rmst2 x); eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' x Hto Hfold Hcl.
+  eapply (forward_remset_item_fold_graph_property
+            (fun g0 => closure_has_v g0 x /\
+               vertex_address g x = vertex_address g0 x));
+    [| exact Hto | split; [exact Hcl | reflexivity] | exact Hfold].
+  intros item g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 Hto0 [Hcl0 Haddr] Hitem.
+  split.
+  - eapply fri_closure_has_v; eassumption.
+  - transitivity (vertex_address g0 x); [exact Haddr |].
+    eapply fri_vertex_address; eassumption.
 Qed.
 
 Lemma forward_remset_item_fold_rootpairs_compatible:
@@ -131,24 +124,16 @@ Lemma forward_remset_item_fold_rootpairs_compatible:
     (g', h', rh', rmst') = fold_left (forward_remset_item from to) r (g, h, rh, rmst) ->
     rootpairs_compatible g' rootpairs roots.
 Proof.
-  intros from to g h rh rmst r. revert g h rh rmst.
-  induction r; intros g h rh rmst g' h' rh' rmst' rootpairs roots Hneq Hto Hcc Hrnd Hrc Hrrsc Hrgc Hrpc Hfri;
-    simpl in Hfri.
-  - now inversion Hfri.
-  - hnf in Hrrsc. rewrite Forall_cons_iff in Hrrsc. destruct Hrrsc as [Hrica Hricr].
-    destruct (forward_remset_item from to (g, h, rh, rmst) a) as [[[g2 h2] rh2] rmst2] eqn:Hfri2.
-    pose proof Hfri2 as Hfri2'. unfold forward_remset_item in Hfri2'. simpl in Hfri2'.
-    rewrite Hfri2' in Hfri. symmetry in Hfri2.
-    eapply (IHr g2 h2 rh2 rmst2 g' h' rh' rmst' rootpairs roots); eauto.
-    + eapply forward_remset_item_ghg with (g := g); eassumption.
-    + eapply fri_copy_compatible; eauto.
-    + eapply fri_remset_nodup; eassumption.
-    + eapply fri_remset_graph_compatible; eauto.
-    + hnf. rewrite Forall_forall in Hricr |- *. intros x Hin. specialize (Hricr _ Hin).
-      eapply fri_remset_item_compatible with (rmst := rmst) (item := a); eassumption.
-    + eapply (forward_remset_item_roots_graph_compatible_pres
-                from to g h rh rmst a g2 h2 rh2 rmst2 roots); eauto.
-    + eapply (fri_rootpairs_compatible from to g h rh rmst a g2 h2 rh2 rmst2 rootpairs roots); eauto.
+  intros from to g h rh rmst r g' h' rh' rmst' rootpairs roots
+         _ Hto _ _ _ _ Hrgc Hrpc Hfold.
+  eapply (forward_remset_item_fold_graph_property
+            (fun g0 => roots_graph_compatible roots g0 /\
+               rootpairs_compatible g0 rootpairs roots));
+    [| exact Hto | split; [exact Hrgc | exact Hrpc] | exact Hfold].
+  intros item g0 h0 rh0 rmst0 g1 h1 rh1 rmst1 Hto0 [Hrgc0 Hrpc0] Hitem.
+  split.
+  - eapply forward_remset_item_roots_graph_compatible_pres; eassumption.
+  - eapply fri_rootpairs_compatible; eassumption.
 Qed.
 
 #[local] Lemma heap_remset_zero_available_weak_valid: forall g h rh gen,

--- a/CertiGC/verif_do_generation.v
+++ b/CertiGC/verif_do_generation.v
@@ -27,8 +27,9 @@ Proof.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
     simpl in Hfri. inversion Hfri; subst; clear Hfri.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh
+                  (eq_sym Hfgh)) as Hfr.
     unfold rootpairs_compatible in *. rewrite <- Hrpc. apply map_ext_in.
     intros x Hin. destruct x; simpl; auto.
     symmetry. eapply fr_vertex_address; eauto. apply graph_has_v_in_closure.
@@ -50,8 +51,9 @@ Proof.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
     simpl in Hfri. inversion Hfri; subst; clear Hfri.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh
+                  (eq_sym Hfgh)) as Hfr.
     eapply fr_closure_has_v; eauto.
   - now inversion Hfri.
 Qed.
@@ -69,8 +71,9 @@ Proof.
   - destruct (forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h)
       as [newg newh] eqn:Hfgh.
     simpl in Hfri. inversion Hfri; subst; clear Hfri.
-    pose proof fr_forward_graph_and_heap from to 0 (remset_item2forward_t item rmst g) g h as Hfr.
-    rewrite Hfgh in Hfr. simpl in Hfr.
+    pose proof (fr_forward_graph_and_heap_eq from to 0
+                  (remset_item2forward_t item rmst g) g h newg newh
+                  (eq_sym Hfgh)) as Hfr.
     eapply fr_vertex_address; eauto.
   - now inversion Hfri.
 Qed.
@@ -509,7 +512,7 @@ Proof.
       destruct (zlt 0 (available_size h1 to)) as [Hav1|Hav1].
       - cancel.
       - assert (Hzero0: available_size h0 to = 0). {
-          rewrite (proj1 H23 to).
+          rewrite (heap_relation_available_size _ _ to H23).
           pose proof available_space_range (nth_space h1 to).
           unfold available_size in *. lia.
         }
@@ -603,20 +606,21 @@ Proof.
           (eapply hr_trans; [exact H23 | exact H34]).
       assert (Hstart02: gen_start g0 from = gen_start g2 from). {
         destruct (gt_gs_compatible _ _ Hghc0 _ Hfrom_g0) as [Hs0 _].
-        destruct Hhr02 as [_ [Hss _]].
         unfold gen_start at 1. rewrite if_true by exact Hfrom_g0.
-        rewrite Hs0, Hss. exact Hstart2_from.
+        rewrite Hs0, (heap_relation_space_start _ _ from Hhr02).
+        exact Hstart2_from.
       }
       assert (Hsh02: nth_sh g0 from = nth_sh g2 from). {
         destruct (gt_gs_compatible _ _ Hghc0 _ Hfrom_g0) as [_ [Hsh0 _]].
         destruct (gt_gs_compatible _ _ Hghc2 _ Hfrom_g2) as [_ [Hsh2 _]].
-        destruct Hhr02 as [_ [_ [_ Hshh]]].
-        unfold nth_sh. rewrite Hsh0, Hshh, <- Hsh2. reflexivity.
+        unfold nth_sh.
+        rewrite Hsh0, (heap_relation_space_sh _ _ from Hhr02), <- Hsh2.
+        reflexivity.
       }
       assert (Hav02: available_size h0 from = available_size h2 from) by
-          (destruct Hhr02 as [Hav _]; apply Hav).
+          (apply (heap_relation_available_size _ _ from Hhr02)).
       assert (Htot02: total_size h0 from = total_size h2 from) by
-          (destruct Hhr02 as [_ [_ [Htot _]]]; apply Htot).
+          (apply (heap_relation_total_size _ _ from Hhr02)).
       sep_apply (heap_unused_rep_reset_with_remset
                    g2 h2 g0 h0 rh0 from Hghc2 Hfrom_g2
                    Hghc0 Hfrom_g0 Hrhhc0 Hstart02 Hsh02 Hav02 Htot02).

--- a/CertiGC/verif_do_scan.v
+++ b/CertiGC/verif_do_scan.v
@@ -11,9 +11,9 @@ Require Import CertiGraph.msl_ext.iter_sepcon.
 Require Import CertiGraph.CertiGC.gc_spec.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
 
-Local Opaque Int64.repr.
+#[local] Opaque Int64.repr.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Lemma weak_derives_elim: forall P Q : mpred,
   (weak_derives P Q && emp) * P |-- Q.

--- a/CertiGC/verif_do_scan.v
+++ b/CertiGC/verif_do_scan.v
@@ -412,18 +412,20 @@ Proof.
                      rewrite <- Hsvfl. unfold no_scan in Hxx. lia.
               ** Intros vret. destruct vret as [g4 h4]. simpl fst in *. simpl snd in *.
                  Exists i g4 h4. rename H0 into Hgh. simpl forward_p2forward_t in Hgh.
-                 pose proof fr_forward_graph_and_heap from to O
-                   (field2forward (Znth (i - 1) (make_fields g3 (to, index)))) g3 h3 as Hfr.
-                 simpl Z.to_nat in Hgh. rewrite <- Hgh in Hfr. simpl fst in Hfr.
-                 pose proof heaprel_forward_graph_and_heap from to O
-                   (field2forward (Znth (i - 1) (make_fields g3 (to, index)))) g3 h3 as Hhr4.
-                 rewrite <- Hgh in Hhr4. simpl snd in Hhr4.
+                 simpl Z.to_nat in Hgh.
+                 pose proof (fr_forward_graph_and_heap_eq from to O
+                   (field2forward (Znth (i - 1) (make_fields g3 (to, index))))
+                   g3 h3 g4 h4 Hgh) as Hfr.
+                 pose proof (heaprel_forward_graph_and_heap_eq from to O
+                   (field2forward (Znth (i - 1) (make_fields g3 (to, index))))
+                   g3 h3 g4 h4 Hgh) as Hhr4.
                  assert (Hgsf: gen_start g3 from = gen_start g4 from) by
                    (eapply fr_gen_start; eassumption).
                  assert (Hgst: gen_start g3 to = gen_start g4 to) by
                    (eapply fr_gen_start; eassumption).
                  assert (Hla: limit_address g3 h3 from = limit_address g4 h4 from). {
-                   unfold limit_address. rewrite Hgsf. do 2 f_equal. apply (proj1 Hhr4). }
+                   unfold limit_address. rewrite Hgsf. do 2 f_equal.
+                   apply (heap_relation_available_size _ _ _ Hhr4). }
                  simpl forward_p_rep. entailer !!.
                  assert (Hcpt: forward_t_compatible
                                  (field2forward
@@ -454,7 +456,9 @@ Proof.
                  --- apply hr_trans with h3; assumption.
                  --- f_equal. symmetry. eapply fr_vertex_address; eauto.
                      apply graph_has_v_in_closure; assumption.
-                 --- rewrite Hgst. rewrite <- (proj1 Hhr4 to). apply derives_refl.
+                 --- rewrite Hgst.
+                     rewrite <- (heap_relation_available_size _ _ to Hhr4).
+                     apply derives_refl.
         -- Intros i g3 h3. cbv [Archi.ptr64]. forward.
            ++ entailer !!. simpl in Hzr.
               first [rewrite !Int.signed_repr | rewrite Int64.signed_repr]; rep_lia.

--- a/CertiGC/verif_do_scan.v
+++ b/CertiGC/verif_do_scan.v
@@ -33,7 +33,7 @@ Proof.
                       apply predicates_hered.ext_refl | exact HPa].
 Qed.
 
-Lemma typed_true_tag: forall (to : nat) (g : LGraph) (index : nat),
+#[local] Lemma typed_true_tag: forall (to : nat) (g : LGraph) (index : nat),
     typed_true tint
                (force_val
                   (option_map (fun b : bool => Val.of_bool (negb b))
@@ -52,7 +52,7 @@ Proof.
   - red. rep_lia.
 Qed.
 
-Lemma typed_false_tag: forall (to : nat) (g : LGraph) (index : nat),
+#[local] Lemma typed_false_tag: forall (to : nat) (g : LGraph) (index : nat),
     typed_false tint
                (force_val
                   (option_map (fun b : bool => Val.of_bool (negb b))

--- a/CertiGC/verif_forward.v
+++ b/CertiGC/verif_forward.v
@@ -3,7 +3,7 @@ Require Import CertiGraph.msl_ext.ramification_lemmas.
 Require Import CertiGraph.CertiGC.verif_forward1.
 Require Import CertiGraph.CertiGC.verif_forward2.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Lemma body_forward: semax_body Vprog Gprog f_forward forward_spec.
 Proof.

--- a/CertiGC/verif_forward1.v
+++ b/CertiGC/verif_forward1.v
@@ -440,17 +440,16 @@ Proof.
                      simpl upd_fwd. simpl forward_p_rep.
                      remember (field2forward
                                  (Znth i (make_fields g3 (new_copied_v g to)))) as newi.
-                     pose proof fr_forward_graph_and_heap from to (Z.to_nat (depth - 1))
-                       newi g3 h3 as Hfr3. rewrite <- Hgh4 in Hfr3. simpl fst in Hfr3.
+                     pose proof (fr_forward_graph_and_heap_eq from to
+                       (Z.to_nat (depth - 1)) newi g3 h3 g4 h4 Hgh4) as Hfr3.
                      assert (Hgs: gen_start g3 from = gen_start g4 from). {
                        eapply fr_gen_start; try eassumption.
                        erewrite <- fl_graph_has_gen; eassumption. } rewrite Hgs.
-                     pose proof heaprel_forward_graph_and_heap from to
-                       (Z.to_nat (depth - 1)) newi g3 h3 as Hhr.
-                     rewrite <- Hgh4 in Hhr. simpl snd in Hhr.
+                     pose proof (heaprel_forward_graph_and_heap_eq from to
+                       (Z.to_nat (depth - 1)) newi g3 h3 g4 h4 Hgh4) as Hhr.
                      assert (Hla: limit_address g3 h3 from = limit_address g4 h4 from). {
                        unfold limit_address. f_equal. 2: assumption. f_equal.
-                       destruct Hhr as [Hgsize _]. rewrite Hgsize. reflexivity. }
+                       rewrite (heap_relation_available_size _ _ _ Hhr). reflexivity. }
                      assert (Hvd: vertex_address g3 (new_copied_v g to) =
                                     vertex_address g4 (new_copied_v g to)). {
                        eapply fr_vertex_address; try eassumption.

--- a/CertiGC/verif_forward1.v
+++ b/CertiGC/verif_forward1.v
@@ -86,8 +86,7 @@ Proof.
     replace_SEP 0 ((weak_derives P (memory_block fsh fn fp * TT) && emp) * P) by
       (entailer; assumption). Intros. simpl exterior2val in *. simpl in Hfpc.
     assert (P |-- (weak_derives P (valid_pointer (Vptr b i) * TT) && emp) * P) as Hweakp. {
-      subst. cancel. apply andp_right. 2: cancel.
-      assert (HS: emp |-- TT) by entailer; sep_apply HS; clear HS. apply derives_weak.
+      apply weak_derives_strong. subst.
       sep_apply (outlier_rep_valid_pointer _ _ Hfpc).
       simpl GC_Pointer2val. cancel. }
     replace_SEP 1 ((weak_derives P (valid_pointer (Vptr b i) * TT) && emp) * P) by

--- a/CertiGC/verif_forward1.v
+++ b/CertiGC/verif_forward1.v
@@ -12,9 +12,9 @@ Require Import CertiGraph.CertiGC.gc_spec.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
 Require Import CertiGraph.CertiGC.forward_lemmas.
 
-Local Opaque Int64.repr.
+#[local] Opaque Int64.repr.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Lemma body_forward_extr:
   forall (Espec : OracleKind)

--- a/CertiGC/verif_forward2.v
+++ b/CertiGC/verif_forward2.v
@@ -15,7 +15,7 @@ Require Import CertiGraph.CertiGC.forward_lemmas.
 #[local] Opaque Int64.repr.
 #[local] Opaque lgraph_copy_v.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Lemma body_forward_intr:
   forall (Espec : OracleKind)

--- a/CertiGC/verif_forward2.v
+++ b/CertiGC/verif_forward2.v
@@ -525,17 +525,16 @@ Proof.
                         simpl fst in *. simpl snd in *. Exists g4 h4. simpl in Hgh4.
                         simpl upd_fwd. simpl forward_p_rep.
                         remember (field2forward (Znth i (make_fields g3 ncv))) as newi.
-                        pose proof fr_forward_graph_and_heap from to (Z.to_nat (depth - 1))
-                          newi g3 h3 as Hfr3. rewrite <- Hgh4 in Hfr3. simpl fst in Hfr3.
+                        pose proof (fr_forward_graph_and_heap_eq from to
+                          (Z.to_nat (depth - 1)) newi g3 h3 g4 h4 Hgh4) as Hfr3.
                         assert (Hgs: gen_start g3 from = gen_start g4 from). {
                           eapply fr_gen_start; [| eassumption ].
                           erewrite <- fl_graph_has_gen; eauto. } rewrite Hgs.
-                        pose proof heaprel_forward_graph_and_heap from to
-                          (Z.to_nat (depth - 1)) newi g3 h3 as Hhr.
-                        rewrite <- Hgh4 in Hhr. simpl snd in Hhr.
+                        pose proof (heaprel_forward_graph_and_heap_eq from to
+                          (Z.to_nat (depth - 1)) newi g3 h3 g4 h4 Hgh4) as Hhr.
                         assert (Hla: limit_address g3 h3 from = limit_address g4 h4 from). {
                           unfold limit_address. f_equal. 2: assumption. f_equal.
-                          destruct Hhr as [Hgsize _]. rewrite Hgsize. reflexivity. }
+                          rewrite (heap_relation_available_size _ _ _ Hhr). reflexivity. }
                         rewrite Hla. entailer !!. eapply forward_gh_loop_add_tail_vpp; eauto.
                         simpl. Transparent lgraph_copy_v. rewrite lcv_vlabel_new; assumption.
                 --- Intros g3 h3. rename H0 into Hfwdlp.

--- a/CertiGC/verif_forward2.v
+++ b/CertiGC/verif_forward2.v
@@ -102,8 +102,7 @@ Proof.
       (entailer; assumption). Intros.
     assert (HGC: In (GCPtr b i) outlier) by (eapply in_gcptr_outlier; eauto).
     assert (Hweakp: P |-- (weak_derives P (valid_pointer (Vptr b i) * TT) && emp) * P). {
-      subst; cancel; apply andp_right; [|cancel].
-      assert (HS: emp |-- TT) by entailer; sep_apply HS; clear HS. apply derives_weak.
+      apply weak_derives_strong. subst.
       sep_apply (outlier_rep_valid_pointer outlier (GCPtr b i) HGC).
       simpl GC_Pointer2val. cancel. }
     replace_SEP 1 ((weak_derives P (valid_pointer (Vptr b i) * TT) && emp) * P) by

--- a/CertiGC/verif_forward_remset.v
+++ b/CertiGC/verif_forward_remset.v
@@ -19,10 +19,8 @@ Proof.
   start_function.
   rename H into Hghc. rename H0 into Hoc. rename H1 into Hfrc. rename H2 into Hrc.
   rename H3 into Hrhc. rename H4 into Hftneq. destruct Hfrc as [Hese [Hghgf [Hghgt [Hcc [Hndd Htsc]]]]].
-  assert (Hgsc: generation_space_compatible g (from, nth_gen g from, nth_space h from)) by
-    (apply gt_gs_compatible; assumption). destruct Hgsc as [Haddrf [Hshf Hsizef]].
-  assert (Hgsc: generation_space_compatible g (to, nth_gen g to, nth_space h to)) by
-    (apply gt_gs_compatible; assumption). destruct Hgsc as [Haddrt [Hsht Hsizet]].
+  destruct (gt_gs_compatible g h Hghc from Hghgf) as [Haddrf [Hshf Hsizef]].
+  destruct (gt_gs_compatible g h Hghc to Hghgt) as [Haddrt [Hsht Hsizet]].
   assert (Hptrf: isptr (space_start (nth_space h from))) by
     (rewrite <- Haddrf; apply start_isptr).
   assert (Hptrt: isptr (space_start (nth_space h to))) by
@@ -261,8 +259,7 @@ Proof.
            replace_SEP 0 ((weak_derives P (memory_block fsh fn fp * TT) && emp) * P) by
              (entailer !!; assumption). Intros.
            assert (P |-- (weak_derives P (valid_pointer v * TT) && emp) * P) as Hweakp. {
-             subst. cancel. apply andp_right. 2: cancel.
-             assert (HS: emp |-- TT) by entailer; sep_apply HS; clear HS. apply derives_weak.
+             apply weak_derives_strong. subst.
              sep_apply (remset_rep_valid_pointer sh g' rmst' v SH0 Hinv). cancel. }
            replace_SEP 1 ((weak_derives P (valid_pointer v * TT) && emp) * P) by
              (entailer !!; assumption). Intros.
@@ -323,8 +320,8 @@ Proof.
                    pose proof (fr_forward_graph_and_heap_eq from to O
                      (remset_ext2forward_t rext) g' h' g2 h2 Hfgh) as Hfr.
                    erewrite <- fr_graph_has_gen; eassumption. }
-                 assert (Hgsc: generation_space_compatible g2 (to, nth_gen g2 to, nth_space h2 to)) by
-                   (apply gt_gs_compatible; assumption). destruct Hgsc as [Haddrt2 [Hsht2 Hsizet2]].
+                 destruct (gt_gs_compatible g2 h2 Hghc2 to Hghgt2)
+                   as [Haddrt2 [Hsht2 Hsizet2]].
                  assert (Hptrt2: isptr (space_start (nth_space h2 to))) by
                    (rewrite <- Haddrt2; apply start_isptr). unfold heap_rep. Intros.
                  freeze [0; 1; 2; 3; 5; 6] FR.
@@ -404,8 +401,7 @@ Proof.
            assert (P |-- (weak_derives P (valid_pointer (offset_val (pos * WORD_SIZE)
                                                            (vertex_address g' v)) * TT) && emp) * P)
              as Hweakp. {
-             subst. cancel. apply andp_right. 2: cancel.
-             assert (HS: emp |-- TT) by entailer; sep_apply HS; clear HS. apply derives_weak.
+             apply weak_derives_strong. subst.
              sep_apply (graph_rep_interiro_vptr g' v pos). cancel. }
            replace_SEP 1 ((weak_derives P (valid_pointer (offset_val (pos * WORD_SIZE)
                                                             (vertex_address g' v)) * TT) && emp) * P) by
@@ -460,8 +456,8 @@ Proof.
                 pose proof (fr_forward_graph_and_heap_eq from to O ft
                   g' h' g2 h2 Hfgh) as Hfr.
                 erewrite <- fr_graph_has_gen; eassumption. }
-              assert (Hgsc: generation_space_compatible g2 (to, nth_gen g2 to, nth_space h2 to)) by
-                (apply gt_gs_compatible; assumption). destruct Hgsc as [Haddrt2 [Hsht2 Hsizet2]].
+              destruct (gt_gs_compatible g2 h2 Hghc2 to Hghgt2)
+                as [Haddrt2 [Hsht2 Hsizet2]].
               assert (Hptrt2: isptr (space_start (nth_space h2 to))) by
                 (rewrite <- Haddrt2; apply start_isptr). unfold heap_rep. Intros.
               freeze [0; 1; 2; 4; 5; 6] FR.

--- a/CertiGC/verif_forward_remset.v
+++ b/CertiGC/verif_forward_remset.v
@@ -9,22 +9,10 @@ Require Import CertiGraph.CertiGC.env_graph_gc.
 Require Import CertiGraph.CertiGC.spatial_gcgraph.
 Require Import CertiGraph.msl_ext.iter_sepcon.
 Require Import CertiGraph.CertiGC.gc_spec.
+Require Import CertiGraph.CertiGC.forward_lemmas.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
 
 #[local] Open Scope logic.
-
-Lemma sem_sub_pi_available_space_minus: forall s,
-    isptr (space_start s) ->
-    force_val
-       (sem_sub_pi int_or_ptr_type Signed
-          (offset_val (WORD_SIZE * available_space s) (space_start s)) (Vint (Int.repr 1))) =
-      offset_val (WORD_SIZE * (available_space s - 1)) (space_start s).
-Proof.
-  intros s Hptr. destruct (space_start s); try contradiction. simpl.
-  rewrite ptrofs_of_ints_unfold, ptrofs_mul_repr, Ptrofs.add_commut, Ptrofs.sub_add_l.
-  rewrite ptrofs_sub_repr, Int.signed_repr by rep_lia. rewrite Ptrofs.add_commut. do 3 f_equal.
-  unfold WORD_SIZE. lia.
-Qed.
 
 Lemma body_forward_remset: semax_body Vprog Gprog f_forward_remset forward_remset_spec.
 Proof.

--- a/CertiGC/verif_forward_remset.v
+++ b/CertiGC/verif_forward_remset.v
@@ -320,8 +320,9 @@ Proof.
                  assert (Hghc2: graph_heap_compatible g2 h2). {
                    eapply forward_graph_and_heap_O_ghc with (g := g'); eauto. }
                  assert (Hghgt2: graph_has_gen g2 to). {
-                   pose proof fr_forward_graph_and_heap from to O (remset_ext2forward_t rext) g' h'.
-                   rewrite <- Hfgh in H. simpl in H. erewrite <- fr_graph_has_gen; eassumption. }
+                   pose proof (fr_forward_graph_and_heap_eq from to O
+                     (remset_ext2forward_t rext) g' h' g2 h2 Hfgh) as Hfr.
+                   erewrite <- fr_graph_has_gen; eassumption. }
                  assert (Hgsc: generation_space_compatible g2 (to, nth_gen g2 to, nth_space h2 to)) by
                    (apply gt_gs_compatible; assumption). destruct Hgsc as [Haddrt2 [Hsht2 Hsizet2]].
                  assert (Hptrt2: isptr (space_start (nth_space h2 to))) by
@@ -363,8 +364,7 @@ Proof.
                  gather_SEP (data_at_ _ _ _) (heap_remset_rep _ _ _). Intros.
                  assert (Hrhhc2: remset_heap_and_heap_compatible rh' h2). {
                    apply heap_relation_rhhc with h'; auto.
-                   pose proof heaprel_forward_graph_and_heap from to O (remset_ext2forward_t rext) g' h'.
-                   rewrite <- Hfgh in H. simpl in H. assumption. }
+                   eapply heaprel_forward_graph_and_heap_eq; exact Hfgh. }
                  assert ((g2, incr_remset_heap h2 (Z.of_nat to),
                            upd_remset_heap (RemSetExterior v) rh' to,
                            upd_remset from to g' (RemSetExterior v) rmst') =
@@ -457,8 +457,9 @@ Proof.
               assert (Hghc2: graph_heap_compatible g2 h2). {
                 eapply forward_graph_and_heap_O_ghc with (g := g'); eauto. }
               assert (Hghgt2: graph_has_gen g2 to). {
-                pose proof fr_forward_graph_and_heap from to O ft g' h'.
-                rewrite <- Hfgh in H. simpl in H. erewrite <- fr_graph_has_gen; eassumption. }
+                pose proof (fr_forward_graph_and_heap_eq from to O ft
+                  g' h' g2 h2 Hfgh) as Hfr.
+                erewrite <- fr_graph_has_gen; eassumption. }
               assert (Hgsc: generation_space_compatible g2 (to, nth_gen g2 to, nth_space h2 to)) by
                 (apply gt_gs_compatible; assumption). destruct Hgsc as [Haddrt2 [Hsht2 Hsizet2]].
               assert (Hptrt2: isptr (space_start (nth_space h2 to))) by
@@ -500,8 +501,7 @@ Proof.
               gather_SEP (data_at_ _ _ _) (heap_remset_rep _ _ _). Intros.
               assert (Hrhhc2: remset_heap_and_heap_compatible rh' h2). {
                 apply heap_relation_rhhc with h'; auto.
-                pose proof heaprel_forward_graph_and_heap from to O ft g' h'.
-                rewrite <- Hfgh in H. simpl in H. assumption. }
+                eapply heaprel_forward_graph_and_heap_eq; exact Hfgh. }
               assert ((g2, incr_remset_heap h2 (Z.of_nat to),
                         upd_remset_heap (RemSetInterior (InteriorVertexPos v pos)) rh' to,
                         upd_remset from to g' (RemSetInterior (InteriorVertexPos v pos)) rmst') =
@@ -515,9 +515,10 @@ Proof.
                 (upd_remset from to g' (RemSetInterior (InteriorVertexPos v pos)) rmst').
               unfold limit_address. clear Heqfp. rewrite <- Hgens in Haddrf'.
               entailer !!. 1: rewrite Haddrf'; unfold available_size; f_equal. lia. simpl. cancel.
-              pose proof fr_forward_graph_and_heap from to 0
-                (field2forward (Znth pos (make_fields g' v))) g' h' as Hfr. rewrite <- Hfgh in Hfr.
-              simpl fst in Hfr. replace (vertex_address g' v) with (vertex_address g2 v).
+              pose proof (fr_forward_graph_and_heap_eq from to 0
+                (field2forward (Znth pos (make_fields g' v)))
+                g' h' g2 h2 Hfgh) as Hfr.
+              replace (vertex_address g' v) with (vertex_address g2 v).
               2: { symmetry. eapply fr_vertex_address; eauto. apply graph_has_v_in_closure; assumption. }
               sep_apply remset_rep_upd_int; auto.
            ++ destruct vret as [Hvin | Hvnot]. 2: contradiction. subst P. clear Pweak Hweakp H. Intros.

--- a/CertiGC/verif_forward_roots.v
+++ b/CertiGC/verif_forward_roots.v
@@ -426,14 +426,13 @@ Proof.
       remember (Znth (nr k + i) (roots'' ++ oldroots k i)) as extr.
       remember (upd_roots from to (nr k + i) g'' (roots'' ++ oldroots k i)) as roots3.
       rename Heqroots3 into H16. simpl Z.to_nat in H15.
-      pose proof fr_forward_graph_and_heap from to O (exterior2forward extr) g'' h''.
-      rewrite <- H15 in H17. simpl fst in H17.
+      pose proof (fr_forward_graph_and_heap_eq from to O (exterior2forward extr)
+                    g'' h'' g3 h3 H15) as H17.
       assert (forward_condition g3 h3 from to). {
         eapply forward_graph_and_heap_fc; [assumption | | eassumption..].
         destruct extr as [z | p | v]; simpl; auto. }
-      assert (heap_relation h'' h3). {
-        pose proof heaprel_forward_graph_and_heap from to O (exterior2forward extr) g'' h''.
-        rewrite <- H15 in H19. simpl snd in H19. apply H19. }
+      assert (H19: heap_relation h'' h3) by
+        (eapply heaprel_forward_graph_and_heap_eq; exact H15).
       Exists g3 h3 (sublist 0 (nr k + (i+1)) roots3).
       entailer !!.
       -- split; [|split; [|split; [|split]]].
@@ -506,12 +505,13 @@ Proof.
             destruct H0 as [_ [_ [? _]]].
             erewrite <- frr_graph_has_gen; eauto.
         ++ unfold limit_address.
-           destruct H19; rewrite H16.
+           pose proof (heap_relation_available_size h'' h3 from H19) as Havail.
+           rewrite Havail.
            f_equal.
            symmetry; eapply fr_gen_start with (x:=from); try eassumption.
            destruct H0 as [_ [_ [? _]]].
            eapply frr_graph_has_gen with (gen:=to) in H11; eauto.
-           rewrite <- H11; auto.
+           rewrite <- H11. exact H0.
       -- apply derives_trans with
            (Q := roots_rep sh
                    (update_rootpairs rp''

--- a/CertiGC/verif_forward_roots.v
+++ b/CertiGC/verif_forward_roots.v
@@ -12,7 +12,7 @@ Require Import CertiGraph.CertiGC.gc_spec.
 Require Import CertiGraph.msl_ext.ramification_lemmas.
 Require Import CertiGraph.CertiGC.forward_lemmas.
 
-Lemma frames_shell_rep_isolate:
+#[local] Lemma frames_shell_rep_isolate:
   forall sh frs k,
    0 <= k < Zlength frs ->
    frames_shell_rep sh frs |--
@@ -40,7 +40,7 @@ Proof.
     cancel.
 Qed.
 
-Lemma Zlength_update_frames:
+#[local] Lemma Zlength_update_frames:
  forall frs roots,
    Zlength roots = Zlength (frames2rootpairs frs) ->
    Zlength (update_frames frs roots) = Zlength frs.
@@ -49,7 +49,7 @@ Lemma Zlength_update_frames:
    autorewrite with sublist in *. simpl in *. list_solve.
 Qed.
 
-Lemma frames_p_update_frames_sublist:
+#[local] Lemma frames_p_update_frames_sublist:
  forall frs roots k,
     Zlength (frames2rootpairs frs) = Zlength roots ->
     0 <= k <= Zlength frs ->
@@ -65,7 +65,7 @@ destruct (zeq k 0).
   apply IHfrs; clear IHfrs. list_solve. lia.
 Qed.
 
-Lemma frames_p_isptr:
+#[local] Lemma frames_p_isptr:
   forall sh frs,
     frames_shell_rep sh frs |-- !! forall k, 0 <= k < Zlength frs -> isptr (frames_p (sublist k (Zlength frs) frs)).
 Proof.

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -1,7 +1,7 @@
 From CertiGraph.CertiGC Require Import env_graph_gc gc_spec.
 Require Import CertiGraph.msl_ext.iter_sepcon.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Lemma sem_sub_pp_word_offsets: forall base hi lo, isptr base ->
     Ptrofs.min_signed <= WORD_SIZE * (hi - lo) <= Ptrofs.max_signed ->
@@ -763,7 +763,7 @@ Proof.
                    g' (add_new_space (pt_heap (ti_heap t_info')) sp (i + 1) Hi1_max)
                    rh' gi (Z.to_nat i) rmst' Hrgh).
         rewrite (remset_rep_add_new_gen sh g' gi outlier rmst' Hrgo).
-        Local Opaque super_compatible. Exists g1 t_info1 rh' rmst'. entailer!!.
+        #[local] Opaque super_compatible. Exists g1 t_info1 rh' rmst'. entailer!!.
     + forward. remember (space_start (Znth (i + 1) (spaces (pt_heap (ti_heap t_info'))))).
       assert (Hisptr_next: isptr v). {
         destruct v; try contradiction.

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -454,8 +454,8 @@ Proof.
                        space_address (ti_heap_p tif) (Z.to_nat j)). {
           intros. unfold space_address. now rewrite Z2Nat.id. }
   unfold before_gc_thread_info_rep, heap_management_rep, heap_struct_rep. Intros.
-  rename H1 into Hunrec_init. rename H2 into Hsafeh.
-  rename H3 into Hremc. rename H4 into Hremgen.
+  rename H0 into Hunrec_init. rename H1 into Hremc. rename H2 into Hremgen.
+  unfold full_gc in H. destruct H as [H [H0 Hsafeh]].
   pose proof H0 as Hgcc_init.
   assert (Hsafe_graph: safe_to_copy g) by
       (eapply safe_to_copy_heap_implies_safe_to_copy;
@@ -990,9 +990,9 @@ Proof.
         assert (graph_gen_clear g2 O) by (apply Hfirst2; rewrite Hi1_nat2; lia).
         forward_call (rsh, sh, gv, ti, g2, t_info2, roots2). forward.
         Exists g2 t_info2 roots2 (reset_nth_remset_heap (Z.to_nat i) rh2) rmst2.
-        entailer!!. split3.
-        -- exists (Z.to_nat i). rewrite <- Hi1_nat2 at 1. split; assumption.
+        unfold full_gc. entailer!!. split3.
         -- eapply safe_to_copy_heap_complete; eauto.
+        -- exists (Z.to_nat i). rewrite <- Hi1_nat2 at 1. split; assumption.
         -- rewrite HN. auto.
         -- pose proof Hsc1 as Hsc1_parts.
            destruct Hsc1_parts as [Hghc1 _].

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -22,21 +22,6 @@ Proof.
   do 2 f_equal; unfold WORD_SIZE; rewrite Z.mul_comm, Z.quot_mul by lia; auto.
 Qed.
 
-Lemma sem_sub_pp_available_space: forall s,
-    isptr (space_start s) ->
-    force_val
-      (sem_sub_pp int_or_ptr_type
-                  (offset_val (WORD_SIZE * available_space s) (space_start s))
-                  (space_start s)) =
-    if Archi.ptr64 then Vlong (Int64.repr (available_space s)) else
-      Vint (Int.repr (available_space s)).
-Proof.
-  intros s Hptr; rewrite <- (isptr_offset_val_zero (space_start s)) at 2 by exact Hptr.
-  replace (offset_val 0 (space_start s)) with (offset_val (WORD_SIZE * 0) (space_start s))
-    by (f_equal; lia); rewrite (sem_sub_pp_word_offsets (space_start s) (available_space s) 0)
-    by (try exact Hptr; pose proof (available_space_signed_range s); lia); now rewrite Z.sub_0_r.
-Qed.
-
 Lemma sem_sub_pp_total_space: forall s,
     isptr (space_start s) ->
     force_val
@@ -98,18 +83,6 @@ Proof.
   unfold thread_info_rep, heap_rep, heap_struct_rep.
   do 2 unfold_data_at (data_at _ thread_info_type _ _).
   cancel.
-Qed.
-
-Lemma ti_rel_token_the_same_weak: forall (h1 h2: part_heap) p,
-    weak_heap_relation h1 h2 -> ti_token_rep h1 p = ti_token_rep h2 p.
-Proof.
-  intros h1 h2 p [Hstart Htotal]. unfold ti_token_rep. f_equal.
-  apply (iter_sepcon_pointwise_eq _ _ _ _ null_space null_space).
-  - rewrite <- !ZtoNat_Zlength, !spaces_size. reflexivity.
-  - intros. fold (nth_space h1 i). fold (nth_space h2 i).
-    unfold total_size in Htotal.
-    unfold space_token_rep.
-    rewrite Hstart, Htotal. reflexivity.
 Qed.
 
 Lemma remset_item_val_add_new_gen: forall g gi from rmst item,
@@ -857,7 +830,7 @@ Proof.
       change fr2 with (ti_frames t_info2).
       unfold heap_rep. Intros. unfold heap_struct_rep.
       replace_SEP 10 (ti_token_rep (pt_heap (ti_heap t_info2)) (ti_heap_p t_info2))
-        by (erewrite ti_rel_token_the_same_weak; eauto; entailer!!; apply derives_refl).
+        by (erewrite ti_token_rep_weak_heap_relation; eauto; entailer!!; apply derives_refl).
       sep_apply gather_thread_info_rep.
       unfold thread_info_rep, heap_rep, heap_struct_rep.
       Intros. assert (Hhas_i1_g2: graph_has_gen g2 (Z.to_nat (i + 1))) by

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -303,6 +303,25 @@ Proof.
   rewrite Hsh, Hav, Htotal. reflexivity.
 Qed.
 
+#[local] Lemma space_remset_rep_do_generation_heap_eq:
+  forall from to h h_rem h' g rh gen,
+    gen <> from ->
+    do_generation_heap_relation from to h h_rem h' ->
+    space_remset_rep g (nth_space h_rem gen, nth_remset_space rh gen) =
+    space_remset_rep g (nth_space h' gen, nth_remset_space rh gen).
+Proof.
+  intros from to h h_rem h' g rh gen Hnfrom [_ [h_scan [Hhr Hreset]]].
+  subst h'. apply space_remset_rep_heap_eq.
+  - rewrite reset_nth_heap_nth_space_diff by lia.
+    now apply heap_relation_space_start.
+  - rewrite reset_nth_heap_available_size_diff by exact Hnfrom.
+    now apply heap_relation_available_size.
+  - rewrite reset_nth_heap_total_size.
+    now apply heap_relation_total_size.
+  - rewrite reset_nth_heap_nth_space_diff by lia.
+    now apply heap_relation_space_sh.
+Qed.
+
 #[local] Lemma heap_remset_rep_except_eq:
   forall g1 g2 h1 h2 rh gen,
     length rh = length (spaces h1) ->
@@ -1078,25 +1097,7 @@ Proof.
                   (nth_space h_rem n, nth_remset_space rh2 n)).
              - eapply space_remset_rep_do_generation_eq; eauto.
                eapply remset_and_remset_heap_compatible_nth; eauto.
-             - apply space_remset_rep_heap_eq.
-               + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-                 destruct Hhr as [_ [Hstart_hr [_ _]]]. subst h2.
-                 unfold nth_space, reset_nth_heap; simpl.
-                 rewrite reset_nth_space_diff by exact Hnfrom.
-                 apply Hstart_hr.
-               + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-                 destruct Hhr as [Hav_hr _]. subst h2.
-                 rewrite reset_nth_heap_available_size_diff by exact Hnfrom.
-                 apply Hav_hr.
-               + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-                 destruct Hhr as [_ [_ [Htotal_hr _]]]. subst h2.
-                 rewrite reset_nth_heap_total_size.
-                 apply Htotal_hr.
-               + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-                 destruct Hhr as [_ [_ [_ Hsh_hr]]]. subst h2.
-                 unfold nth_space, reset_nth_heap; simpl.
-                 rewrite reset_nth_space_diff by exact Hnfrom.
-                 apply Hsh_hr.
+             - eapply space_remset_rep_do_generation_heap_eq; eauto.
            }
            rewrite <- Hexcept_eq. cancel.
       * forward. Intros.
@@ -1279,25 +1280,7 @@ Proof.
                (nth_space h_rem n, nth_remset_space rh2 n)).
           - eapply space_remset_rep_do_generation_eq; eauto.
             eapply remset_and_remset_heap_compatible_nth; eauto.
-          - apply space_remset_rep_heap_eq.
-            + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-              destruct Hhr as [_ [Hstart_hr [_ _]]]. subst h2.
-              unfold nth_space, reset_nth_heap; simpl.
-              rewrite reset_nth_space_diff by exact Hnfrom.
-              apply Hstart_hr.
-            + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-              destruct Hhr as [Hav_hr _]. subst h2.
-              rewrite reset_nth_heap_available_size_diff by exact Hnfrom.
-              apply Hav_hr.
-            + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-              destruct Hhr as [_ [_ [Htotal_hr _]]]. subst h2.
-              rewrite reset_nth_heap_total_size.
-              apply Htotal_hr.
-            + destruct Hdg_heap as [_ [h_scan [Hhr Hreset]]].
-              destruct Hhr as [_ [_ [_ Hsh_hr]]]. subst h2.
-              unfold nth_space, reset_nth_heap; simpl.
-              rewrite reset_nth_space_diff by exact Hnfrom.
-              apply Hsh_hr.
+          - eapply space_remset_rep_do_generation_heap_eq; eauto.
         }
         rewrite <- Hexcept_eq. cancel.
   - Intros g2 roots2 t_info2 rh2 rmst2. unfold all_string_constants. Intros.

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -463,8 +463,8 @@ Proof.
   forward.
   pose proof H as Hsc_init.
   destruct Hsc_init as [Hghc_init _].
-  pose proof (gt_gs_compatible _ _ Hghc_init _ (graph_has_gen_O _)) as Hgen0.
-  destruct Hgen0 as [Hstart0 [? ?]].
+  destruct (gt_gs_compatible _ _ Hghc_init _ (graph_has_gen_O _))
+    as [Hstart0 [? ?]].
   replace (heap_head (pt_heap (ti_heap t_info))) with
     (nth_space (pt_heap (ti_heap t_info)) 0) by
     (symmetry; apply heap_head_nth_space_O).
@@ -828,12 +828,8 @@ Proof.
       Intros vret. destruct vret as [[gpack h2] roots2].
       destruct gpack as [[[[g_rem h_rem] rh2] rmst2] g2].
       simpl fst in *. simpl snd in *.
+      pose proof H11 as Hrel_full.
       destruct H11 as [H11 Hdg_heap].
-      assert (Hrel_full:
-                do_generation_relation (Z.to_nat i) (Z.to_nat (i + 1))
-                  roots' roots2 g1 (pt_heap (ti_heap t_info1)) rh1 rmst1
-                  g_rem h_rem rh2 rmst2 g2 h2) by
-          (split; [exact H11 | exact Hdg_heap]).
       set (fr2 := update_frames _ _) in *.
       thaw FR1.
       pose (t_info2 := {| ti_heap_p := ti_heap_p t_info1;

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -446,9 +446,9 @@ Proof.
   destruct Hsc_init as [Hghc_init _].
   pose proof (gt_gs_compatible _ _ Hghc_init _ (graph_has_gen_O _)) as Hgen0.
   destruct Hgen0 as [Hstart0 [? ?]].
-  replace (heap_head (pt_heap (ti_heap t_info))) with (nth_space (pt_heap (ti_heap t_info)) 0) by
-      (destruct (heap_head_cons (pt_heap (ti_heap t_info))) as [hs [hl [Hspaces_head Hhead_eq]]];
-       unfold nth_space; rewrite Hspaces_head, Hhead_eq; simpl; reflexivity).
+  replace (heap_head (pt_heap (ti_heap t_info))) with
+    (nth_space (pt_heap (ti_heap t_info)) 0) by
+    (symmetry; apply heap_head_nth_space_O).
   assert (isptr (space_start (nth_space (pt_heap (ti_heap t_info)) 0))) by
     (rewrite <- Hstart0; apply start_isptr). do 2 forward. deadvars!.
   simpl fst in *. simpl snd in *. rewrite upd_Znth0_old.
@@ -1035,8 +1035,7 @@ Proof.
              rewrite <- ZtoNat_Zlength. apply Z2Nat.inj_lt; lia.
            }
            assert (Hlen_h2: length rh2 = length (spaces h2)). {
-             rewrite Hlen_rem.
-             rewrite <- !ZtoNat_Zlength, !spaces_size. reflexivity.
+             rewrite Hlen_rem. apply part_heap_spaces_length_eq.
            }
            assert (Hfrom_hrem: (Z.to_nat i < length (spaces h_rem))%nat). {
              rewrite <- Hlen_rem. rewrite Hlen_h2. exact Hfrom_h2.
@@ -1235,8 +1234,7 @@ Proof.
           rewrite <- ZtoNat_Zlength. apply Z2Nat.inj_lt; lia.
         }
         assert (Hlen_h2: length rh2 = length (spaces h2)). {
-          rewrite Hlen_rem.
-          rewrite <- !ZtoNat_Zlength, !spaces_size. reflexivity.
+          rewrite Hlen_rem. apply part_heap_spaces_length_eq.
         }
         assert (Hfrom_hrem: (Z.to_nat i < length (spaces h_rem))%nat). {
           rewrite <- Hlen_rem. rewrite Hlen_h2. exact Hfrom_h2.

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -22,7 +22,7 @@ Proof.
   do 2 f_equal; unfold WORD_SIZE; rewrite Z.mul_comm, Z.quot_mul by lia; auto.
 Qed.
 
-Lemma sem_sub_pp_total_space: forall s,
+#[local] Lemma sem_sub_pp_total_space: forall s,
     isptr (space_start s) ->
     force_val
       (sem_sub_pp int_or_ptr_type
@@ -37,7 +37,7 @@ Proof.
     by (try exact Hptr; pose proof (total_space_signed_range s); lia); now rewrite Z.sub_0_r.
 Qed.
 
-Lemma sem_sub_pp_rest_space: forall s,
+#[local] Lemma sem_sub_pp_rest_space: forall s,
     isptr (space_start s) ->
     force_val
       (sem_sub_pp int_or_ptr_type
@@ -52,7 +52,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma t_info_space_address: forall t_info i,
+#[local] Lemma t_info_space_address: forall t_info i,
     0 <= i -> isptr (ti_heap_p t_info) ->
     (if Archi.ptr64 then
       force_val (sem_add_ptr_long space_type (offset_val 0 (ti_heap_p t_info))
@@ -66,11 +66,11 @@ Proof.
   unfold space_address. rewrite Z2Nat.id by lia. simpl. f_equal.
 Qed.
 
-Ltac tc_val_Znth := entailer!!; rewrite Znth_map by assumption;
+#[local] Ltac tc_val_Znth := entailer!!; rewrite Znth_map by assumption;
                     unfold space_quad; apply isptr_is_pointer_or_null;
                     try assumption.
 
-Lemma gather_thread_info_rep:
+#[local] Lemma gather_thread_info_rep:
   forall (v1 v2: val) sh t_info ti ,
    data_at sh thread_info_type (v1,(v2, (ti_heap_p t_info, (ti_args t_info, (ti_fp t_info, (Vptrofs(ti_nalloc t_info),nullval)))))) ti
    * frames_rep sh (ti_frames t_info)
@@ -85,7 +85,7 @@ Proof.
   cancel.
 Qed.
 
-Lemma remset_item_val_add_new_gen: forall g gi from rmst item,
+#[local] Lemma remset_item_val_add_new_gen: forall g gi from rmst item,
     remset_item_compatible g from rmst item ->
     remset_item_val (lgraph_add_new_gen g gi) item = remset_item_val g item.
 Proof.
@@ -93,7 +93,7 @@ Proof.
   destruct H as [Hv _]. rewrite ang_vertex_address_old by exact Hv. reflexivity.
 Qed.
 
-Lemma space_remset_rep_add_new_gen: forall g gi from rmst sp rs,
+#[local] Lemma space_remset_rep_add_new_gen: forall g gi from rmst sp rs,
     remset_and_remset_space_compatible g from rmst rs ->
     space_remset_rep g (sp, rs) =
     space_remset_rep (lgraph_add_new_gen g gi) (sp, rs).
@@ -105,7 +105,7 @@ Proof.
   apply H. exact Hin.
 Qed.
 
-Lemma heap_remset_rep_add_new_gen: forall g h rh gi from rmst,
+#[local] Lemma heap_remset_rep_add_new_gen: forall g h rh gi from rmst,
     remset_and_remset_heap_compatible g from rmst rh ->
     heap_remset_rep g h rh =
     heap_remset_rep (lgraph_add_new_gen g gi) h rh.
@@ -116,7 +116,7 @@ Proof.
   eapply in_combine_r. exact Hin.
 Qed.
 
-Lemma remset_rep_add_new_gen: forall sh g gi outlier rmst,
+#[local] Lemma remset_rep_add_new_gen: forall sh g gi outlier rmst,
     remset_graph_outlier_compatible g outlier rmst ->
     remset_rep sh g rmst =
     remset_rep sh (lgraph_add_new_gen g gi) rmst.
@@ -129,7 +129,7 @@ Proof.
   specialize (H _ Hin). simpl in H. exact H.
 Qed.
 
-Lemma remset_ext_compatible_add_new_gen: forall g gi outlier rext,
+#[local] Lemma remset_ext_compatible_add_new_gen: forall g gi outlier rext,
     remset_ext_compatible g outlier rext ->
     remset_ext_compatible (lgraph_add_new_gen g gi) outlier rext.
 Proof.
@@ -137,7 +137,7 @@ Proof.
   apply ang_graph_has_v. assumption.
 Qed.
 
-Lemma remset_item_compatible_add_new_gen: forall g gi from rmst item,
+#[local] Lemma remset_item_compatible_add_new_gen: forall g gi from rmst item,
     remset_item_compatible g from rmst item ->
     remset_item_compatible (lgraph_add_new_gen g gi) from rmst item.
 Proof.
@@ -147,7 +147,7 @@ Proof.
   - split; assumption.
 Qed.
 
-Lemma remset_compatible_add_new_empty: forall g h rh rmst outlier from gi sp i
+#[local] Lemma remset_compatible_add_new_empty: forall g h rh rmst outlier from gi sp i
     (Hs: 0 <= i < MAX_SPACES),
     remset_compatible g outlier from rmst rh h ->
     space_start (Znth i (spaces h)) = nullval ->
@@ -190,7 +190,7 @@ Proof.
            apply Hrhh. exact Hj.
 Qed.
 
-Lemma heap_remset_rep_add_empty_space: forall g h rh sp i (Hs: 0 <= i < MAX_SPACES),
+#[local] Lemma heap_remset_rep_add_empty_space: forall g h rh sp i (Hs: 0 <= i < MAX_SPACES),
     remset_heap_and_heap_compatible rh h ->
     space_start (Znth i (spaces h)) = nullval ->
     available_space sp = total_space sp ->
@@ -239,7 +239,7 @@ Proof.
       [entailer! | reflexivity | apply isptr_offset_val'; exact Hptr | reflexivity].
 Qed.
 
-Lemma remset_rep_do_generation_eq:
+#[local] Lemma remset_rep_do_generation_eq:
   forall sh from to roots roots' g h rh rmst g_rem h_rem rh' rmst' g' h',
     graph_has_gen g_rem to ->
     remset_graph_compatible g_rem rmst' ->
@@ -257,7 +257,7 @@ Proof.
   apply graph_has_v_in_closure. exact Hrgc.
 Qed.
 
-Lemma space_remset_rep_do_generation_eq:
+#[local] Lemma space_remset_rep_do_generation_eq:
   forall from to roots roots' g h rh rmst g_rem h_rem rh' rmst' g' h' sp rs,
     graph_has_gen g_rem to ->
     remset_and_remset_space_compatible g_rem from rmst' rs ->
@@ -275,7 +275,7 @@ Proof.
   apply graph_has_v_in_closure. tauto.
 Qed.
 
-Lemma remset_and_remset_heap_compatible_nth:
+#[local] Lemma remset_and_remset_heap_compatible_nth:
   forall g from rmst rh gen,
     (gen < length rh)%nat ->
     remset_and_remset_heap_compatible g from rmst rh ->
@@ -287,7 +287,7 @@ Proof.
   apply Hrrhc. apply nth_In. exact Hgen.
 Qed.
 
-Lemma space_remset_rep_heap_eq:
+#[local] Lemma space_remset_rep_heap_eq:
   forall g h1 h2 rh gen,
     space_start (nth_space h1 gen) = space_start (nth_space h2 gen) ->
     available_size h1 gen = available_size h2 gen ->
@@ -303,7 +303,7 @@ Proof.
   rewrite Hsh, Hav, Htotal. reflexivity.
 Qed.
 
-Lemma heap_remset_rep_except_eq:
+#[local] Lemma heap_remset_rep_except_eq:
   forall g1 g2 h1 h2 rh gen,
     length rh = length (spaces h1) ->
     length rh = length (spaces h2) ->
@@ -350,7 +350,7 @@ Proof.
       apply Hspace; lia.
 Qed.
 
-Lemma heap_remset_rep_except_reset_rh:
+#[local] Lemma heap_remset_rep_except_reset_rh:
   forall g h rh gen,
     length rh = length (spaces h) ->
     (gen < length (spaces h))%nat ->
@@ -399,7 +399,7 @@ Proof.
       rewrite reset_nth_remset_heap_diff by lia. reflexivity.
 Qed.
 
-Lemma heap_remset_rep_reset_nth_remset:
+#[local] Lemma heap_remset_rep_reset_nth_remset:
   forall g h rh gen,
     length rh = length (spaces h) ->
     (gen < length (spaces h))%nat ->

--- a/CertiGC/verif_garbage_collect.v
+++ b/CertiGC/verif_garbage_collect.v
@@ -453,8 +453,9 @@ Proof.
              0 <= j -> offset_val (sizeof (Tstruct _space noattr) * j) (ti_heap_p tif)=
                        space_address (ti_heap_p tif) (Z.to_nat j)). {
           intros. unfold space_address. now rewrite Z2Nat.id. }
-  unfold before_gc_thread_info_rep, heap_management_rep, heap_struct_rep. Intros.
-  rename H0 into Hunrec_init. rename H1 into Hremc. rename H2 into Hremgen.
+  unfold gc_sep, before_gc_thread_info_rep, heap_management_rep, heap_struct_rep. Intros.
+  unfold remembered_set_ok in H0.
+  destruct H0 as [Hunrec_init [Hremc Hremgen]].
   unfold full_gc in H. destruct H as [H [H0 Hsafeh]].
   pose proof H0 as Hgcc_init.
   assert (Hsafe_graph: safe_to_copy g) by
@@ -990,7 +991,7 @@ Proof.
         assert (graph_gen_clear g2 O) by (apply Hfirst2; rewrite Hi1_nat2; lia).
         forward_call (rsh, sh, gv, ti, g2, t_info2, roots2). forward.
         Exists g2 t_info2 roots2 (reset_nth_remset_heap (Z.to_nat i) rh2) rmst2.
-        unfold full_gc. entailer!!. split3.
+        unfold full_gc, gc_sep. entailer!!. split3.
         -- eapply safe_to_copy_heap_complete; eauto.
         -- exists (Z.to_nat i). rewrite <- Hi1_nat2 at 1. split; assumption.
         -- rewrite HN. auto.

--- a/CertiGC/verif_is_ptr.v
+++ b/CertiGC/verif_is_ptr.v
@@ -1,6 +1,6 @@
 From CertiGraph.CertiGC Require Import env_graph_gc gc_spec.
 
-Ltac hif_tac H :=
+#[local] Ltac hif_tac H :=
   match type of H with context [if ?a then _ else _] => destruct a eqn: ?H end.
 
 Lemma body_is_ptr: semax_body Vprog Gprog f_is_ptr is_ptr_spec.

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -135,21 +135,6 @@ Proof.
       generation_share_writable.
 Qed.
 
-Lemma sem_sub_pi_available_space_minus: forall s,
-    isptr (space_start s) ->
-    force_val
-      (sem_sub_pi int_or_ptr_type Signed
-        (offset_val (WORD_SIZE * available_space s) (space_start s))
-        (Vint (Int.repr 1))) =
-    offset_val (WORD_SIZE * (available_space s - 1)) (space_start s).
-Proof.
-  intros s Hptr. destruct (space_start s); try contradiction. simpl.
-  rewrite ptrofs_of_ints_unfold, ptrofs_mul_repr, Ptrofs.add_commut,
-    Ptrofs.sub_add_l.
-  rewrite ptrofs_sub_repr, Int.signed_repr by rep_lia.
-  rewrite Ptrofs.add_commut. do 3 f_equal. unfold WORD_SIZE. lia.
-Qed.
-
 Lemma align_compatible_int_or_ptr_tptr: forall z,
     align_compatible_rec cenv_cs int_or_ptr_type z <->
     align_compatible_rec cenv_cs (tptr int_or_ptr_type) z.

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -4,7 +4,7 @@ Require Import CertiGraph.graph.graph_model.
 
 #[local] Open Scope logic.
 
-Lemma graph_rep_interior_field_address: forall g src pos,
+#[local] Lemma graph_rep_interior_field_address: forall g src pos,
     graph_has_v g src ->
     0 <= pos < Zlength (raw_fields (vlabel g src)) ->
     graph_rep g |--
@@ -28,7 +28,7 @@ Proof.
     end.
 Qed.
 
-Lemma heap_head_nth_space_O: forall h,
+#[local] Lemma heap_head_nth_space_O: forall h,
     heap_head h = nth_space h O.
 Proof.
   intros h.
@@ -97,7 +97,7 @@ Proof.
   exact Hclosed.
 Qed.
 
-Lemma generation_data_at__test_order: forall g h gen i j,
+#[local] Lemma generation_data_at__test_order: forall g h gen i j,
     graph_has_gen g gen ->
     0 <= i <= available_size h gen ->
     0 <= j <= available_size h gen ->
@@ -135,7 +135,7 @@ Proof.
       generation_share_writable.
 Qed.
 
-Lemma align_compatible_int_or_ptr_tptr: forall z,
+#[local] Lemma align_compatible_int_or_ptr_tptr: forall z,
     align_compatible_rec cenv_cs int_or_ptr_type z <->
     align_compatible_rec cenv_cs (tptr int_or_ptr_type) z.
 Proof.
@@ -148,7 +148,7 @@ Proof.
       [reflexivity|exact H].
 Qed.
 
-Lemma data_at__int_or_ptr_tptr: forall sh p,
+#[local] Lemma data_at__int_or_ptr_tptr: forall sh p,
     data_at_ sh int_or_ptr_type p = data_at_ sh (tptr int_or_ptr_type) p.
 Proof.
   intros. unfold data_at_, field_at_, data_at, field_at.
@@ -157,7 +157,7 @@ Proof.
   rewrite align_compatible_int_or_ptr_tptr. reflexivity.
 Qed.
 
-Lemma data_at_int_or_ptr_tptr: forall sh p v,
+#[local] Lemma data_at_int_or_ptr_tptr: forall sh p v,
     isptr v ->
     data_at sh int_or_ptr_type v p =
     data_at sh (tptr int_or_ptr_type) v p.

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -2,7 +2,7 @@ From CertiGraph.CertiGC Require Import
   env_graph_gc gc_spec forward_lemmas gc_correct.
 Require Import CertiGraph.graph.graph_model.
 
-Local Open Scope logic.
+#[local] Open Scope logic.
 
 Lemma graph_rep_interior_field_address: forall g src pos,
     graph_has_v g src ->

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -61,7 +61,7 @@ Proof.
          Hloc Hext Hupd Hrecordable Htinfo Hrh
          Hsuper Hgcc Hunrecorded Hsafe Hremset Hremgen.
   subst t_info' rh'.
-  unfold info_recordable in Hrecordable.
+  rewrite info_recordable_iff_used_lt_available in Hrecordable.
   rewrite heap_head_nth_space_O in Hrecordable.
   pose proof
     (mutable_update_garbage_collect_model_preconditions
@@ -194,7 +194,8 @@ Proof.
     space_start (heap_head (pt_heap (ti_heap t_info)))).
   { unfold gen_start. rewrite if_true by apply graph_has_gen_O.
     rewrite heap_head_nth_space_O. exact Hstart. }
-  unfold info_recordable in Hrecordable.
+  change (info_recordable t_info) in Hrecordable.
+  rewrite info_recordable_iff_used_lt_available in Hrecordable.
   unfold before_gc_thread_info_rep, heap_management_rep. Intros.
   assert_PROP
     (field_compatible

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -173,10 +173,8 @@ Proof.
   rename H2 into Hloc.
   rename H3 into Hext.
   destruct it as [src pos].
-  destruct Hloc as [Hsrc [Hpos [Hmark Htag]]].
-  assert (Hloc: mutable_location_compatible
-                  g (InteriorVertexPos src pos)) by
-    (exact (conj Hsrc (conj Hpos (conj Hmark Htag)))).
+  pose proof Hloc as Hloc_parts.
+  destruct Hloc_parts as [Hsrc [Hpos [Hmark Htag]]].
   destruct (mutable_graph_update_exists
               g (InteriorVertexPos src pos) v Hloc) as [g' Hupd].
   assert_PROP (valid_int_or_ptr (exterior2val g v)) as Hvalid.
@@ -188,10 +186,9 @@ Proof.
        [ArraySubsc pos] (vertex_address g src)) as Hcell.
   { sep_apply (graph_rep_interior_field_address g src pos Hsrc Hpos).
     entailer!. }
-  pose proof
+  destruct
     (gt_gs_compatible g (pt_heap (ti_heap t_info)) Hghc O
-       (graph_has_gen_O g)) as Hgsc.
-  destruct Hgsc as [Hstart [Hspace_sh Hused]].
+       (graph_has_gen_O g)) as [Hstart [Hspace_sh Hused]].
   assert (Hgenstart:
     gen_start g O =
     space_start (heap_head (pt_heap (ti_heap t_info)))).

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -1,5 +1,5 @@
 From CertiGraph.CertiGC Require Import
-  env_graph_gc gc_spec forward_lemmas gc_correct.
+  env_graph_gc gc_spec forward_lemmas.
 Require Import CertiGraph.graph.graph_model.
 
 #[local] Open Scope logic.
@@ -26,67 +26,6 @@ Proof.
         rewrite <- fields_eq_length in Hpos;
         unfold field_compatible in *; simpl in *; tauto
     end.
-Qed.
-
-Theorem int_mutable_update_restores_garbage_collect_model_preconditions:
-  forall g src pos new g' t_info t_info' roots outlier rmst rh rh',
-    mutable_location_compatible g (InteriorVertexPos src pos) ->
-    exterior_compatible g outlier new ->
-    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
-    info_recordable t_info ->
-    t_info' = decr_info_nursery t_info (exterior2val g new) ->
-    rh' = mtb_upd_remset_heap
-            (exterior2val g new)
-            (RemSetInterior (InteriorVertexPos src pos)) rh ->
-    super_compatible
-      g (pt_heap (ti_heap t_info))
-      (frames2rootpairs (ti_frames t_info)) roots outlier ->
-    garbage_collect_condition g (pt_heap (ti_heap t_info)) ->
-    no_unrecorded_backward_edge g rh ->
-    safe_to_copy_heap g (pt_heap (ti_heap t_info)) ->
-    remset_compatible
-      g outlier O rmst rh (pt_heap (ti_heap t_info)) ->
-    remset_generation_compatible O rmst rh ->
-    super_compatible
-      g' (pt_heap (ti_heap t_info'))
-      (frames2rootpairs (ti_frames t_info')) roots outlier /\
-    garbage_collect_condition g' (pt_heap (ti_heap t_info')) /\
-    no_unrecorded_backward_edge g' rh' /\
-    safe_to_copy_heap g' (pt_heap (ti_heap t_info')) /\
-    remset_compatible
-      g' outlier O rmst rh' (pt_heap (ti_heap t_info')) /\
-    remset_generation_compatible O rmst rh'.
-Proof.
-  intros g src pos new g' t_info t_info' roots outlier rmst rh rh'
-         Hloc Hext Hupd Hrecordable Htinfo Hrh
-         Hsuper Hgcc Hunrecorded Hsafe Hremset Hremgen.
-  subst t_info' rh'.
-  rewrite info_recordable_iff_used_lt_available in Hrecordable.
-  rewrite heap_head_nth_space_O in Hrecordable.
-  pose proof
-    (mutable_update_garbage_collect_model_preconditions
-       g src pos new g' (pt_heap (ti_heap t_info))
-       (frames2rootpairs (ti_frames t_info)) roots outlier rmst rh
-       Hloc Hext Hupd Hrecordable Hsuper Hgcc Hunrecorded Hsafe
-       Hremset Hremgen) as Hclosed.
-  assert (Hheap:
-    pt_heap
-      (ti_heap
-        (decr_info_nursery t_info (exterior2val g new))) =
-    if isptr_dec (exterior2val g new)
-    then incr_remset_heap (pt_heap (ti_heap t_info)) 0
-    else pt_heap (ti_heap t_info)).
-  { unfold decr_info_nursery.
-    destruct (isptr_dec (exterior2val g new)); reflexivity. }
-  assert (Hframes:
-    ti_frames
-      (decr_info_nursery t_info (exterior2val g new)) =
-    ti_frames t_info).
-  { unfold decr_info_nursery.
-    destruct (isptr_dec (exterior2val g new)); reflexivity. }
-  rewrite Hheap, Hframes.
-  unfold mtb_upd_remset_heap.
-  exact Hclosed.
 Qed.
 
 #[local] Lemma generation_data_at__test_order: forall g h gen i j,

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -28,14 +28,6 @@ Proof.
     end.
 Qed.
 
-#[local] Lemma heap_head_nth_space_O: forall h,
-    heap_head h = nth_space h O.
-Proof.
-  intros h.
-  destruct (heap_head_cons h) as [sp [rest [Hspaces Hhead]]].
-  unfold nth_space. rewrite Hspaces, Hhead. reflexivity.
-Qed.
-
 Theorem int_mutable_update_restores_garbage_collect_model_preconditions:
   forall g src pos new g' t_info t_info' roots outlier rmst rh rh',
     mutable_location_compatible g (InteriorVertexPos src pos) ->

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -1,0 +1,407 @@
+From CertiGraph.CertiGC Require Import
+  env_graph_gc gc_spec forward_lemmas.
+Require Import CertiGraph.graph.graph_model.
+
+Local Open Scope logic.
+
+Lemma graph_rep_interior_field_address: forall g src pos,
+    graph_has_v g src ->
+    0 <= pos < Zlength (raw_fields (vlabel g src)) ->
+    graph_rep g |--
+      !! (interior_address (InteriorVertexPos src pos) g =
+          field_address
+            (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+            [ArraySubsc pos] (vertex_address g src)).
+Proof.
+  intros g src pos Hsrc Hpos.
+  sep_apply (graph_rep_vertex_rep g src Hsrc). Intros sh.
+  unfold vertex_rep, vertex_at. Intros.
+  entailer !.
+  unfold interior_address, field_address.
+  rewrite if_true.
+  - reflexivity.
+  - match goal with
+    | Hfc : field_compatible _ [] _ |- _ =>
+        clear -Hfc Hpos;
+        rewrite <- fields_eq_length in Hpos;
+        unfold field_compatible in *; simpl in *; tauto
+    end.
+Qed.
+
+Lemma heap_head_nth_space_O: forall h,
+    heap_head h = nth_space h O.
+Proof.
+  intros h.
+  destruct (heap_head_cons h) as [sp [rest [Hspaces Hhead]]].
+  unfold nth_space. rewrite Hspaces, Hhead. reflexivity.
+Qed.
+
+Lemma generation_data_at__test_order: forall g h gen i j,
+    graph_has_gen g gen ->
+    0 <= i <= available_size h gen ->
+    0 <= j <= available_size h gen ->
+    0 < available_size h gen ->
+    generation_data_at_ g h gen |--
+      denote_tc_test_order
+        (offset_val (WORD_SIZE * i) (gen_start g gen))
+        (offset_val (WORD_SIZE * j) (gen_start g gen)).
+Proof.
+  intros g h gen i j Hgen Hi Hj Hav.
+  unfold generation_data_at_. rewrite data_at__memory_block. Intros.
+  rewrite sizeof_tarray_int_or_ptr by
+    (unfold available_size; apply available_space_range).
+  rewrite isptr_denote_tc_test_order by
+    (apply isptr_offset_val'; apply graph_has_gen_start_isptr; exact Hgen).
+  unfold test_order_ptrs.
+  rewrite sameblock_offset_val by
+    (apply graph_has_gen_start_isptr; exact Hgen).
+  apply andp_right.
+  - eapply derives_trans with
+      (Q := memory_block (nth_sh g gen)
+              (WORD_SIZE * available_size h gen) (gen_start g gen));
+      [cancel|].
+    apply memory_block_weak_valid_pointer;
+      [unfold WORD_SIZE; lia|unfold WORD_SIZE; lia|].
+    unfold nth_sh. apply readable_nonidentity, writable_readable,
+      generation_share_writable.
+  - eapply derives_trans with
+      (Q := memory_block (nth_sh g gen)
+              (WORD_SIZE * available_size h gen) (gen_start g gen));
+      [cancel|].
+    apply memory_block_weak_valid_pointer;
+      [unfold WORD_SIZE; lia|unfold WORD_SIZE; lia|].
+    unfold nth_sh. apply readable_nonidentity, writable_readable,
+      generation_share_writable.
+Qed.
+
+Lemma sem_sub_pi_available_space_minus: forall s,
+    isptr (space_start s) ->
+    force_val
+      (sem_sub_pi int_or_ptr_type Signed
+        (offset_val (WORD_SIZE * available_space s) (space_start s))
+        (Vint (Int.repr 1))) =
+    offset_val (WORD_SIZE * (available_space s - 1)) (space_start s).
+Proof.
+  intros s Hptr. destruct (space_start s); try contradiction. simpl.
+  rewrite ptrofs_of_ints_unfold, ptrofs_mul_repr, Ptrofs.add_commut,
+    Ptrofs.sub_add_l.
+  rewrite ptrofs_sub_repr, Int.signed_repr by rep_lia.
+  rewrite Ptrofs.add_commut. do 3 f_equal. unfold WORD_SIZE. lia.
+Qed.
+
+Lemma align_compatible_int_or_ptr_tptr: forall z,
+    align_compatible_rec cenv_cs int_or_ptr_type z <->
+    align_compatible_rec cenv_cs (tptr int_or_ptr_type) z.
+Proof.
+  intro z; split; intro H.
+  - eapply align_compatible_rec_by_value_inv in H; [|reflexivity].
+    apply align_compatible_rec_by_value with (ch := Mptr);
+      [reflexivity|exact H].
+  - eapply align_compatible_rec_by_value_inv in H; [|reflexivity].
+    apply align_compatible_rec_by_value with (ch := Mptr);
+      [reflexivity|exact H].
+Qed.
+
+Lemma data_at__int_or_ptr_tptr: forall sh p,
+    data_at_ sh int_or_ptr_type p = data_at_ sh (tptr int_or_ptr_type) p.
+Proof.
+  intros. unfold data_at_, field_at_, data_at, field_at.
+  simpl nested_field_type. simpl nested_field_offset. f_equal; f_equal.
+  apply prop_ext. unfold field_compatible. destruct p; simpl; try tauto.
+  rewrite align_compatible_int_or_ptr_tptr. reflexivity.
+Qed.
+
+Lemma data_at_int_or_ptr_tptr: forall sh p v,
+    isptr v ->
+    data_at sh int_or_ptr_type v p =
+    data_at sh (tptr int_or_ptr_type) v p.
+Proof.
+  intros sh p v Hv. unfold data_at, field_at.
+  simpl nested_field_type. simpl nested_field_offset.
+  destruct v; try contradiction.
+  unfold int_or_ptr_type. cbv [Archi.ptr64 log2_sizeof_pointer].
+  f_equal; f_equal. apply prop_ext. unfold field_compatible.
+  destruct p; simpl; try tauto.
+  rewrite align_compatible_int_or_ptr_tptr. reflexivity.
+Qed.
+
+Lemma body_mutable_update:
+  semax_body Vprog Gprog f_mutable_update int_mutable_update_spec.
+Proof.
+  start_function.
+  rename H into Hrecordable.
+  rename H0 into Hghc.
+  rename H1 into Hrhhc.
+  rename H2 into Hloc.
+  rename H3 into Hext.
+  destruct it as [src pos].
+  destruct Hloc as [Hsrc [Hpos [Hmark Htag]]].
+  assert (Hloc: mutable_location_compatible
+                  g (InteriorVertexPos src pos)) by
+    (exact (conj Hsrc (conj Hpos (conj Hmark Htag)))).
+  destruct (mutable_graph_update_exists
+              g (InteriorVertexPos src pos) v Hloc) as [g' Hupd].
+  assert_PROP (valid_int_or_ptr (exterior2val g v)) as Hvalid.
+  { sep_apply (extr_valid_int_or_ptr g v outlier Hext). entailer!. }
+  assert_PROP
+    (interior_address (InteriorVertexPos src pos) g =
+     field_address
+       (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+       [ArraySubsc pos] (vertex_address g src)) as Hcell.
+  { sep_apply (graph_rep_interior_field_address g src pos Hsrc Hpos).
+    entailer!. }
+  pose proof
+    (gt_gs_compatible g (pt_heap (ti_heap t_info)) Hghc O
+       (graph_has_gen_O g)) as Hgsc.
+  destruct Hgsc as [Hstart [Hspace_sh Hused]].
+  assert (Hgenstart:
+    gen_start g O =
+    space_start (heap_head (pt_heap (ti_heap t_info)))).
+  { unfold gen_start. rewrite if_true by apply graph_has_gen_O.
+    rewrite heap_head_nth_space_O. exact Hstart. }
+  unfold info_recordable in Hrecordable.
+  unfold before_gc_thread_info_rep, heap_management_rep. Intros.
+  assert_PROP
+    (field_compatible
+       (tarray int_or_ptr_type (available_size (pt_heap (ti_heap t_info)) O))
+       [] (gen_start g O)) as Harray.
+  { gather_SEP (graph_rep g) (heap_unused_rep (pt_heap (ti_heap t_info))).
+    sep_apply
+      (graph_and_heap_rest_data_at_
+         g (pt_heap (ti_heap t_info)) O (graph_has_gen_O g) Hghc).
+    unfold generation_data_at_. entailer!.
+  }
+  assert (Hused_range:
+    0 <= used_space (heap_head (pt_heap (ti_heap t_info))) <=
+    available_space (heap_head (pt_heap (ti_heap t_info)))).
+  { apply used_leq_available. }
+  assert (Halloc_address:
+    field_address0
+      (tarray int_or_ptr_type (available_size (pt_heap (ti_heap t_info)) O))
+      [ArraySubsc (used_space (heap_head (pt_heap (ti_heap t_info))))]
+      (gen_start g O) =
+    offset_val
+      (WORD_SIZE * used_space (heap_head (pt_heap (ti_heap t_info))))
+      (space_start (heap_head (pt_heap (ti_heap t_info))))).
+  { rewrite arr_field_address0.
+    - rewrite Hgenstart. reflexivity.
+    - exact Harray.
+    - unfold available_size. rewrite <- heap_head_nth_space_O. exact Hused_range. }
+  assert (Hlimit_address:
+    field_address0
+      (tarray int_or_ptr_type (available_size (pt_heap (ti_heap t_info)) O))
+      [ArraySubsc (available_space (heap_head (pt_heap (ti_heap t_info))))]
+      (gen_start g O) =
+    offset_val
+      (WORD_SIZE * available_space (heap_head (pt_heap (ti_heap t_info))))
+      (space_start (heap_head (pt_heap (ti_heap t_info))))).
+  { rewrite arr_field_address0.
+    - rewrite Hgenstart. reflexivity.
+    - exact Harray.
+    - unfold available_size. rewrite <- heap_head_nth_space_O. lia. }
+  assert (Hcmp:
+    typed_true tint
+      (force_val
+        (sem_cmp_pp Clt
+          (offset_val
+            (WORD_SIZE * used_space (heap_head (pt_heap (ti_heap t_info))))
+            (space_start (heap_head (pt_heap (ti_heap t_info)))))
+          (offset_val
+            (WORD_SIZE * available_space (heap_head (pt_heap (ti_heap t_info))))
+            (space_start (heap_head (pt_heap (ti_heap t_info)))))))).
+  { rewrite <- Halloc_address, <- Hlimit_address.
+    rewrite ptr_comparison_lt_iff.
+    - exact Hrecordable.
+    - exact Harray.
+    - unfold available_size. rewrite <- heap_head_nth_space_O. exact Hused_range.
+    - unfold available_size. rewrite <- heap_head_nth_space_O. lia.
+    - change (0 < WORD_SIZE). unfold WORD_SIZE. lia.
+    - apply graph_has_gen_start_isptr, graph_has_gen_O.
+  }
+  assert_PROP (isptr ti) as Hti by entailer!.
+  forward.
+  - entailer !. apply isptr_is_pointer_or_null. apply isptr_offset_val'.
+    rewrite <- Hgenstart. apply graph_has_gen_start_isptr, graph_has_gen_O.
+  - forward.
+    + entailer !. apply isptr_is_pointer_or_null. apply isptr_offset_val'.
+      rewrite <- Hgenstart. apply graph_has_gen_start_isptr, graph_has_gen_O.
+    + forward_if True.
+      * sep_apply
+          (graph_and_heap_rest_data_at_
+             g (pt_heap (ti_heap t_info)) O (graph_has_gen_O g) Hghc).
+        sep_apply
+          (generation_data_at__test_order
+             g (pt_heap (ti_heap t_info)) O
+             (used_space (heap_head (pt_heap (ti_heap t_info))))
+             (available_space (heap_head (pt_heap (ti_heap t_info))))).
+        { apply graph_has_gen_O. }
+        { unfold available_size. rewrite <- heap_head_nth_space_O.
+          exact Hused_range. }
+        { unfold available_size. rewrite <- heap_head_nth_space_O. lia. }
+        { unfold available_size. rewrite <- heap_head_nth_space_O. lia. }
+        { rewrite Hgenstart.
+          rewrite !isptr_denote_tc_test_order by
+            (apply isptr_offset_val'; rewrite <- Hgenstart;
+             apply graph_has_gen_start_isptr, graph_has_gen_O).
+          unfold test_order_ptrs.
+          rewrite !sameblock_offset_val by
+            (rewrite <- Hgenstart;
+             apply graph_has_gen_start_isptr, graph_has_gen_O).
+          apply andp_right.
+          - apply sepcon_weak_valid_pointer1.
+            apply andp_left1. apply derives_refl.
+          - apply sepcon_weak_valid_pointer1.
+            apply andp_left2. apply derives_refl. }
+      * forward. entailer!.
+      * exfalso. unfold force_val in Hcmp.
+        unfold typed_true, typed_false in *. congruence.
+      * assert (Hsrc_share:
+          writable_share (nth_sh g (vgeneration src))).
+        { unfold nth_sh. apply generation_share_writable. }
+        sep_apply
+          (graph_rep_mutable_update_ramif
+             g src pos v g' Hloc Hupd).
+        Intros.
+        rewrite Hcell.
+        let p := constr:(field_address
+          (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+          [ArraySubsc pos] (vertex_address g src)) in
+        assert_PROP (field_compatible int_or_ptr_type [] p) as Hfield.
+        { entailer!. }
+        assert (Hfield_address:
+          field_address
+            (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+            [ArraySubsc pos] (vertex_address g src) =
+          field_address int_or_ptr_type []
+            (field_address
+              (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+              [ArraySubsc pos] (vertex_address g src))).
+        { unfold field_address at 2. rewrite if_true by exact Hfield. simpl.
+          symmetry. apply isptr_offset_val_zero. destruct Hfield; assumption. }
+        forward.
+        gather_SEP
+          (field_at (nth_sh g (vgeneration src)) int_or_ptr_type []
+             (exterior2val g v)
+             (field_address
+                (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+                [ArraySubsc pos] (vertex_address g src)))
+          (data_at (nth_sh g (vgeneration src)) int_or_ptr_type
+             (exterior2val g v)
+             (field_address
+                (tarray int_or_ptr_type (Zlength (make_fields_vals g src)))
+                [ArraySubsc pos] (vertex_address g src)) -* graph_rep g').
+        replace_SEP 0 (graph_rep g').
+        { entailer !!. apply wand_frame_elim. }
+        forward_call (exterior2val g v).
+        rewrite
+          (heap_remset_rep_mutable_graph_update
+             g (InteriorVertexPos src pos) v g'
+             (pt_heap (ti_heap t_info)) rh Hloc Hupd).
+        assert (Hghc':
+          graph_heap_compatible g' (pt_heap (ti_heap t_info))).
+        { eapply mutable_graph_update_graph_heap_compatible; eassumption. }
+        remember (exterior2val g v) as x eqn:Hx.
+        destruct x; simpl in Hvalid; try contradiction.
+        { forward_if.
+          - contradiction.
+          - forward.
+            assert (Hnptr: ~ isptr (exterior2val g v)).
+            { intro Hp. rewrite <- Hx in Hp. contradiction. }
+            Exists g' t_info rh.
+            unfold decr_info_nursery, mtb_upd_remset_heap.
+            destruct (isptr_dec (exterior2val g v)); [contradiction|].
+            entailer!.
+            unfold before_gc_thread_info_rep, heap_management_rep.
+            cancel. }
+        { forward_if.
+          - assert (Hnursery_ptr:
+              isptr (space_start (heap_head (pt_heap (ti_heap t_info))))).
+            { rewrite <- Hgenstart.
+              apply graph_has_gen_start_isptr, graph_has_gen_O. }
+            forward.
+            forward.
+            simpl force_val.
+            rewrite sem_sub_pi_available_space_minus by exact Hnursery_ptr.
+            forward.
+            assert (Hrecordable0:
+              used_space (nth_space (pt_heap (ti_heap t_info)) O) <
+              available_space (nth_space (pt_heap (ti_heap t_info)) O)).
+            { rewrite <- heap_head_nth_space_O. exact Hrecordable. }
+            sep_apply
+              (heap_unused_rep_incr
+                 g' (pt_heap (ti_heap t_info)) O Hghc'
+                 (graph_has_gen_O g') Hrecordable0).
+            Intros.
+            rewrite data_at__int_or_ptr_tptr.
+            assert (Hspacew:
+              writable_share
+                (space_sh (nth_space (pt_heap (ti_heap t_info)) O))).
+            { rewrite <- Hspace_sh. apply generation_share_writable. }
+            rewrite heap_head_nth_space_O.
+            forward.
+            assert (Hpcell_ptr:
+              isptr
+                (field_address
+                   (tarray int_or_ptr_type
+                     (Zlength (make_fields_vals g src)))
+                   [ArraySubsc pos] (vertex_address g src))).
+            { destruct Hfield. assumption. }
+            rewrite <- data_at_int_or_ptr_tptr by exact Hpcell_ptr.
+            rewrite <- Hcell. unfold interior_address.
+            assert (Haddr:
+              vertex_address g' src = vertex_address g src).
+            { eapply mutable_graph_update_vertex_address; eassumption. }
+            rewrite <- Haddr.
+            sep_apply
+              (remset_rep_upd_int
+                 g' (pt_heap (ti_heap t_info)) O rh src pos Hghc'
+                 (graph_has_gen_O g') Hrhhc Hrecordable0).
+            set (h := pt_heap (ti_heap t_info)) in *.
+            set (hp := ti_heap_p t_info) in *.
+            assert (Hrange0: 0 <= Z.of_nat O < Zlength (spaces h)).
+            { pose proof (spaces_size h) as Hlen.
+              rewrite MAX_SPACES_eq in Hlen. lia. }
+            assert (Htails:
+              tl (spaces (incr_remset_heap h (Z.of_nat O))) =
+              tl (spaces h)).
+            { rewrite spaces_incr_remset_heap_split by exact Hrange0.
+              simpl. destruct (spaces h); reflexivity. }
+            assert (Htoken:
+              ti_token_rep h hp =
+              ti_token_rep (incr_remset_heap h (Z.of_nat O)) hp).
+            { apply ti_token_rep_weak_heap_relation.
+              apply incr_remset_heap_whr. }
+            Exists g'
+              (Build_thread_info
+                 hp
+                 (build_compatible_heap
+                    (incr_remset_heap h (Z.of_nat O)))
+                 (ti_args t_info) (arg_size t_info)
+                 (ti_frames t_info) (ti_nalloc t_info))
+              (upd_remset_heap
+                 (RemSetInterior (InteriorVertexPos src pos)) rh O).
+            unfold decr_info_nursery, mtb_upd_remset_heap.
+            destruct (isptr_dec (Vptr b i)) as [Hptr | Hnptr].
+            2: { exfalso. apply Hnptr. exact I. }
+            entailer!.
+            unfold before_gc_thread_info_rep, heap_management_rep.
+            simpl pt_heap. rewrite heap_head_nth_space_O.
+            rewrite irh_used_space, irh_space_start, irh_total_space.
+            pose proof
+              (irh_available_space_same h O Hrange0 Hrecordable0)
+              as Havail.
+            pose proof Htails as Htails'.
+            pose proof Htoken as Htoken'.
+            cbn in Havail, Htails', Htoken'.
+            rewrite Htoken'.
+            rewrite Havail, Htails'.
+            unfold ti_fp. simpl ti_frames. cancel.
+            cbv [Vptrofs Archi.ptr64].
+            unfold data_at, field_at.
+            simpl nested_field_type. simpl nested_field_offset.
+            simpl ti_heap_p. cancel. apply derives_refl.
+          - match goal with
+            | Hfalse : Int.repr 1 = Int.zero |- _ =>
+                apply Int.one_not_zero in Hfalse; contradiction
+            end. }
+Qed.

--- a/CertiGC/verif_mutable_update.v
+++ b/CertiGC/verif_mutable_update.v
@@ -1,5 +1,5 @@
 From CertiGraph.CertiGC Require Import
-  env_graph_gc gc_spec forward_lemmas.
+  env_graph_gc gc_spec forward_lemmas gc_correct.
 Require Import CertiGraph.graph.graph_model.
 
 Local Open Scope logic.
@@ -34,6 +34,67 @@ Proof.
   intros h.
   destruct (heap_head_cons h) as [sp [rest [Hspaces Hhead]]].
   unfold nth_space. rewrite Hspaces, Hhead. reflexivity.
+Qed.
+
+Theorem int_mutable_update_restores_garbage_collect_model_preconditions:
+  forall g src pos new g' t_info t_info' roots outlier rmst rh rh',
+    mutable_location_compatible g (InteriorVertexPos src pos) ->
+    exterior_compatible g outlier new ->
+    mutable_graph_update g (InteriorVertexPos src pos) new g' ->
+    info_recordable t_info ->
+    t_info' = decr_info_nursery t_info (exterior2val g new) ->
+    rh' = mtb_upd_remset_heap
+            (exterior2val g new)
+            (RemSetInterior (InteriorVertexPos src pos)) rh ->
+    super_compatible
+      g (pt_heap (ti_heap t_info))
+      (frames2rootpairs (ti_frames t_info)) roots outlier ->
+    garbage_collect_condition g (pt_heap (ti_heap t_info)) ->
+    no_unrecorded_backward_edge g rh ->
+    safe_to_copy_heap g (pt_heap (ti_heap t_info)) ->
+    remset_compatible
+      g outlier O rmst rh (pt_heap (ti_heap t_info)) ->
+    remset_generation_compatible O rmst rh ->
+    super_compatible
+      g' (pt_heap (ti_heap t_info'))
+      (frames2rootpairs (ti_frames t_info')) roots outlier /\
+    garbage_collect_condition g' (pt_heap (ti_heap t_info')) /\
+    no_unrecorded_backward_edge g' rh' /\
+    safe_to_copy_heap g' (pt_heap (ti_heap t_info')) /\
+    remset_compatible
+      g' outlier O rmst rh' (pt_heap (ti_heap t_info')) /\
+    remset_generation_compatible O rmst rh'.
+Proof.
+  intros g src pos new g' t_info t_info' roots outlier rmst rh rh'
+         Hloc Hext Hupd Hrecordable Htinfo Hrh
+         Hsuper Hgcc Hunrecorded Hsafe Hremset Hremgen.
+  subst t_info' rh'.
+  unfold info_recordable in Hrecordable.
+  rewrite heap_head_nth_space_O in Hrecordable.
+  pose proof
+    (mutable_update_garbage_collect_model_preconditions
+       g src pos new g' (pt_heap (ti_heap t_info))
+       (frames2rootpairs (ti_frames t_info)) roots outlier rmst rh
+       Hloc Hext Hupd Hrecordable Hsuper Hgcc Hunrecorded Hsafe
+       Hremset Hremgen) as Hclosed.
+  assert (Hheap:
+    pt_heap
+      (ti_heap
+        (decr_info_nursery t_info (exterior2val g new))) =
+    if isptr_dec (exterior2val g new)
+    then incr_remset_heap (pt_heap (ti_heap t_info)) 0
+    else pt_heap (ti_heap t_info)).
+  { unfold decr_info_nursery.
+    destruct (isptr_dec (exterior2val g new)); reflexivity. }
+  assert (Hframes:
+    ti_frames
+      (decr_info_nursery t_info (exterior2val g new)) =
+    ti_frames t_info).
+  { unfold decr_info_nursery.
+    destruct (isptr_dec (exterior2val g new)); reflexivity. }
+  rewrite Hheap, Hframes.
+  unfold mtb_upd_remset_heap.
+  exact Hclosed.
 Qed.
 
 Lemma generation_data_at__test_order: forall g h gen i j,

--- a/CertiGC/verif_resume.v
+++ b/CertiGC/verif_resume.v
@@ -103,8 +103,8 @@ Proof.
       simpl fold_left.
       replace (WORD_SIZE * 0)%Z with 0 by lia.
       rewrite !isptr_offset_val_zero by assumption.
+      unfold headroom.
       rewrite H1. simpl tl.
-      rewrite Z.sub_0_r.
       entailer_for_return.
       assert (MAX_SPACES = Zlength (map space_quad hl) + 1). {
         pose proof (spaces_size (ti_heap t_info).(pt_heap)).

--- a/CertiGC/verif_resume.v
+++ b/CertiGC/verif_resume.v
@@ -1,6 +1,6 @@
 From CertiGraph.CertiGC Require Import env_graph_gc gc_spec.
 
-Lemma int64_ltu_ptrofs_to_int_64:
+#[local] Lemma int64_ltu_ptrofs_to_int_64:
   forall x y, Archi.ptr64 = true ->
     Int64.ltu (Ptrofs.to_int64 x) (Ptrofs.to_int64 y) =  Ptrofs.ltu x y.
 Proof.
@@ -20,7 +20,7 @@ Proof.
   auto.
 Qed.
 
-Lemma int_ltu_ptrofs_to_int:
+#[local] Lemma int_ltu_ptrofs_to_int:
   forall x y, Archi.ptr64 = false ->
     Int.ltu (Ptrofs.to_int x) (Ptrofs.to_int y) =  Ptrofs.ltu x y.
 Proof.

--- a/CoqMakefile.local
+++ b/CoqMakefile.local
@@ -11,7 +11,7 @@ certigraph:  graph/spanning_tree.vo graph/dag.vo graph/marked_graph.vo graph/loc
              graph/SpaceUAdjMatGraph1.vo graph/SpaceUAdjMatGraph2.vo graph/SpaceUAdjMatGraph3.vo graph/SpaceEdgeLabelGraph.vo
 
 certigc: CertiGC/gc_correct.vo CertiGC/verif_conversion.vo CertiGC/verif_Is_from.vo CertiGC/gc_spec.vo CertiGC/verif_create_space.vo \
-         CertiGC/verif_create_heap.vo CertiGC/verif_make_tinfo.vo CertiGC/env_graph_gc.vo CertiGC/verif_is_ptr.vo CertiGC/verif_garbage_collect.vo \
+         CertiGC/verif_create_heap.vo CertiGC/verif_make_tinfo.vo CertiGC/env_graph_gc.vo CertiGC/verif_is_ptr.vo CertiGC/verif_mutable_update.vo CertiGC/verif_garbage_collect.vo \
          CertiGC/verif_resume.vo CertiGC/GCGraph.vo CertiGC/verif_forward.vo CertiGC/verif_do_scan.vo CertiGC/verif_forward_roots.vo \
          CertiGC/verif_do_generation.vo CertiGC/verif_forward_remset.vo
 

--- a/CoqMakefile.local
+++ b/CoqMakefile.local
@@ -15,6 +15,9 @@ certigc: CertiGC/gc_correct.vo CertiGC/verif_conversion.vo CertiGC/verif_Is_from
          CertiGC/verif_resume.vo CertiGC/GCGraph.vo CertiGC/verif_forward.vo CertiGC/verif_do_scan.vo CertiGC/verif_forward_roots.vo \
          CertiGC/verif_do_generation.vo CertiGC/verif_forward_remset.vo
 
+.PHONY: certigc-audit
+certigc-audit: certigc CertiGC/assumptions.vo
+
 applications: binheap/verif_binary_heap.vo binheap/verif_binary_heap_pro.vo mark/verif_mark_bin.vo mark/verif_mark_bin_dag.vo \
             summatrix/verif_summatrix.vo copy/verif_copy_bin.vo dispose/verif_dispose_bin.vo \
 	    unionfind/verif_unionfind.vo unionfind/verif_unionfind_slim.vo unionfind/verif_unionfind_rank.vo \

--- a/_CoqProject
+++ b/_CoqProject
@@ -133,6 +133,7 @@ CertiGC/verif_create_heap.v
 CertiGC/verif_make_tinfo.v
 CertiGC/env_graph_gc.v
 CertiGC/verif_is_ptr.v
+CertiGC/verif_mutable_update.v
 CertiGC/verif_garbage_collect.v
 CertiGC/verif_resume.v
 CertiGC/GCGraph.v

--- a/lib/List_ext.v
+++ b/lib/List_ext.v
@@ -1205,6 +1205,16 @@ Proof.
     rewrite !fold_left_app. simpl. rewrite H. f_equal. apply H0.
 Qed.
 
+Lemma fold_left_suffix_invariant:
+  forall {A B} (f: A -> B -> A) (Inv: list B -> A -> Prop),
+    (forall x xs s, Inv (x :: xs) s -> Inv xs (f s x)) ->
+    forall xs s, Inv xs s -> Inv nil (fold_left f xs s).
+Proof.
+  intros A B f Inv Hstep xs. induction xs as [|x xs IH]; intros s HInv.
+  - exact HInv.
+  - simpl. apply IH. apply Hstep. exact HInv.
+Qed.
+
 Local Open Scope Z_scope.
 
 Lemma exists_element_list:


### PR DESCRIPTION
## Summary

- verify the internal `mutable_update` write barrier with VST
- model graph-field updates and prove the preservation properties needed at the collector boundary
- keep the VST body proof independent from downstream GC-correctness theorems
- simplify and audit the CertiGC proof library by localizing internal helpers and consolidating repeated remset and heap-projection proofs
- package the collector's model, remembered-set, and spatial boundary conditions as `full_gc`, `remembered_set_ok`, and `gc_sep`
- align the public C header declaration with the verified `mutable_update` implementation

## Design notes

The mutable-update funspec remains deliberately weak and covers writes to fields inside `graph_rep`. Global collector invariants are established separately by model-level preservation theorems. The model closure remains in `gc_correct.v`, while `verif_mutable_update.v` contains only VST-related proof material.

See `CertiGC/mutable_update_design.md` for the settled specification and layering decisions.

## Validation

- `direnv exec . make -j4`
- `direnv exec . make -j4 certigc-audit`
- native compilation of `CertiGC/GC_Source/gc_stack.c`
